### PR TITLE
Add C main to configure RTS.

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -93,6 +93,10 @@ extra-source-files:
     stack-9.6.7.yaml
     stack-9.4.8.yaml
     stack-9.2.8.yaml
+    src/main/main.c
+    src/main/agda/cpu_info.c
+    src/main/agda/cpu_info.h
+    src/main/agda/hidden.h
     -- Agda's data files, embedded by module Agda.Setup.
     -- Keep in sync with the list in Agda.Setup.DataFiles and below.
     src/data/emacs-mode/agda-input.el
@@ -983,13 +987,19 @@ executable agda
       -- except for the Prelude.
     , base
   default-language: Haskell2010
-  -- If someone installs Agda with the setuid bit set, then the
-  -- presence of +RTS may be a security problem (see GHC bug #3910).
-  -- However, we sometimes recommend people to use +RTS to control
-  -- Agda's memory usage, so we want this functionality enabled by
-  -- default.
+
+  -- This instructs GHC not to generate a C main function, but rather
+  -- rely on the hand-written C main in the file: src/main/main.c
+  --
+  -- One consequence of having a hand-written C main function is that
+  -- the GHC RTS cannot be configured via Cabal, but must be configured
+  -- directly from the C main.
   ghc-options:
-    -rtsopts
+    -no-hs-main
+
+  c-sources:
+    src/main/agda/cpu_info.c
+    src/main/main.c
 
   -- The threaded RTS by default starts a major GC after a program has
   -- been idle for 0.3 s. This feature turned out to be annoying, so
@@ -997,9 +1007,6 @@ executable agda
   if !arch(wasm32)
     ghc-options:
       -threaded
-      "-with-rtsopts=-I0 -N1"
-  else
-    ghc-options: -with-rtsopts=-I0
 
 -- agda-mode executable
 ---------------------------------------------------------------------------

--- a/src/main/agda/cpu_info.c
+++ b/src/main/agda/cpu_info.c
@@ -1,0 +1,275 @@
+#include "./cpu_info.h"
+#include "./hidden.h"
+#include <stdint.h>
+
+#if defined(_WIN32)
+#include <assert.h>
+#include <malloc.h>
+#include <windows.h>
+#elif defined(__APPLE__)
+#include <sys/sysctl.h>
+#elif defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__NetBSD__) ||   \
+    defined(__DragonFly__)
+#include <sys/sysctl.h>
+#elif __linux
+#if __has_include(<unistd.h>)
+#include <unistd.h>
+#endif
+#endif
+
+/******************************************************************************
+ * Windows
+ *****************************************************************************/
+#if defined(_WIN32)
+
+typedef BOOL(WINAPI *LPFN_GLPI)(PSYSTEM_LOGICAL_PROCESSOR_INFORMATION, PDWORD);
+
+HIDDEN bool agda_cpu_info(AgdaCpuInfo *cpu_info_out) {
+  if (cpu_info_out == NULL) {
+    return false;
+  }
+
+  // Load the symbol for GetLogicalProcessorInformation.
+  const LPFN_GLPI glpi = (LPFN_GLPI)GetProcAddress(
+      GetModuleHandle(TEXT("kernel32")), "GetLogicalProcessorInformation");
+
+  // If GetLogicalProcessorInformation is not available, fall back to
+  // GetSystemInfo.
+  if (glpi == NULL) {
+    SYSTEM_INFO system_info = {0};
+    GetSystemInfo(&system_info);
+
+    // Write out the number of CPU cores:
+    cpu_info_out->cpu_count = system_info.dwNumberOfProcessors;
+
+    // GetSystemInfo does not provide the CPU cache sizes:
+    cpu_info_out->cpu_cache_size = 0;
+
+    return true;
+  }
+  assert(glpi != NULL);
+
+  // Get the buffer length required to get all logical processor information.
+  DWORD return_length = 0;
+  {
+    const BOOL status = glpi(NULL, &return_length);
+    assert(status == FALSE);
+    (void)status;
+    assert(GetLastError() == ERROR_INSUFFICIENT_BUFFER);
+    assert(return_length > 0);
+  }
+  // Allocate a buffer of the required length.
+  PSYSTEM_LOGICAL_PROCESSOR_INFORMATION buffer = malloc(return_length);
+  if (buffer == NULL) {
+    return 0;
+  }
+  // Get all logical processor information.
+  {
+    const BOOL status = glpi(buffer, &return_length);
+    assert(status == TRUE);
+    (void)status;
+  }
+  // Count the number of logical processors that correspond to a physical CPU
+  // core.
+  DWORD byte_offset = 0;
+  PSYSTEM_LOGICAL_PROCESSOR_INFORMATION buffer_ptr = buffer;
+  uint32_t cpu_count = 0;
+  DWORD cpu_l1_cache_size = 0;
+  DWORD cpu_l2_cache_size = 0;
+  DWORD cpu_l3_cache_size = 0;
+  while (byte_offset + sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION) <=
+         return_length) {
+    switch (buffer_ptr->Relationship) {
+    case RelationProcessorCore:
+      ++cpu_count;
+      break;
+    case RelationCache:
+      if (buffer_ptr->Cache.Type == CacheData ||
+          buffer_ptr->Cache.Type == CacheUnified) {
+        if (buffer_ptr->Cache.Level == 1 &&
+            buffer_ptr->Cache.Size > cpu_l1_cache_size) {
+          cpu_l1_cache_size = buffer_ptr->Cache.Size;
+        }
+        if (buffer_ptr->Cache.Level == 2 &&
+            buffer_ptr->Cache.Size > cpu_l2_cache_size) {
+          cpu_l2_cache_size = buffer_ptr->Cache.Size;
+        }
+        if (buffer_ptr->Cache.Level == 3 &&
+            buffer_ptr->Cache.Size > cpu_l3_cache_size) {
+          cpu_l3_cache_size = buffer_ptr->Cache.Size;
+        }
+      }
+      break;
+    default:
+      break;
+    }
+    byte_offset += sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION);
+    ++buffer_ptr;
+  }
+  // Free the buffer.
+  free(buffer);
+  // Write out the number of CPU cores:
+  cpu_info_out->cpu_count = cpu_count;
+  // Write out the size of the largest CPU cache:
+  {
+    uint32_t cpu_cache_size = 0;
+    if (cpu_l1_cache_size > cpu_cache_size) {
+      cpu_cache_size = cpu_l1_cache_size;
+    }
+    if (cpu_l2_cache_size > cpu_cache_size) {
+      cpu_cache_size = cpu_l2_cache_size;
+    }
+    if (cpu_l3_cache_size > cpu_cache_size) {
+      cpu_cache_size = cpu_l3_cache_size;
+    }
+    cpu_info_out->cpu_cache_size = cpu_cache_size;
+  }
+  return true;
+}
+
+/******************************************************************************
+ * macOS
+ *****************************************************************************/
+#elif defined(__APPLE__)
+
+#define TRY_SYSCTL(query, query_out)                                           \
+  (sysctlbyname((query), &(query_out), &(size_t){sizeof((query_out))}, NULL,   \
+                0) == 0)
+
+HIDDEN bool agda_cpu_info(AgdaCpuInfo *cpu_info_out) {
+  if (cpu_info_out == NULL) {
+    return false;
+  }
+
+  // Determine the number of CPU cores:
+  {
+    int cpu_count = 0;
+    // Try the number of physical Apple Silicon performance cores.
+    if (!TRY_SYSCTL("hw.perflevel0.physicalcpu", cpu_count)) {
+      // Try the number of physical CPU cores.
+      if (!TRY_SYSCTL("hw.physicalcpu", cpu_count)) {
+        // Try the number of logical Apple Silicon performance cores.
+        if (!TRY_SYSCTL("hw.perflevel0.logicalcpu", cpu_count)) {
+          // Try the number of logical CPU cores.
+          if (!TRY_SYSCTL("hw.logicalcpu", cpu_count)) {
+            // Give up.
+          }
+        }
+      }
+    }
+    cpu_info_out->cpu_count = cpu_count > 0 ? cpu_count : 0;
+  }
+
+  // Determine the size of the largest CPU cache:
+  {
+    int cpu_cache_size = 0;
+    // Try the L3 cache for the Apple Silicon performance cores.
+    if (!TRY_SYSCTL("hw.perflevel0.l3cachesize", cpu_cache_size)) {
+      // Try the L3 cache.
+      if (!TRY_SYSCTL("hw.l3cachesize", cpu_cache_size)) {
+        // Try the L2 cache for the Apple Silicon performance cores.
+        if (!TRY_SYSCTL("hw.perflevel0.l2cachesize", cpu_cache_size)) {
+          // Try the L2 cache.
+          if (!TRY_SYSCTL("hw.l2cachesize", cpu_cache_size)) {
+            // Try the L1 data cache for the Apple Silicon performance cores.
+            if (!TRY_SYSCTL("hw.perflevel0.l1dcachesize", cpu_cache_size)) {
+              // Try the L1 data cache.
+              if (!TRY_SYSCTL("hw.l1dcachesize", cpu_cache_size)) {
+                // Give up.
+              }
+            }
+          }
+        }
+      }
+    }
+    cpu_info_out->cpu_cache_size = cpu_cache_size > 0 ? cpu_cache_size : 0;
+  }
+  return true;
+}
+
+/******************************************************************************
+ * BSD
+ *****************************************************************************/
+#elif defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__NetBSD__) ||   \
+    defined(__DragonFly__)
+
+#define TRY_SYSCTL(query, query_out)                                           \
+  (sysctlbyname((query), &(query_out), &(size_t){sizeof((query_out))}, NULL,   \
+                0) == 0)
+
+HIDDEN bool agda_cpu_info(AgdaCpuInfo *cpu_info_out) {
+  if (cpu_info_out == NULL) {
+    return false;
+  }
+
+  // Determine the number of CPU cores:
+  {
+    int cpu_count = 0;
+    // Try the number of CPU cores currently online.
+    if (!TRY_SYSCTL("hw.ncpuonline", cpu_count)) {
+      // Try the number of CPU cores configured.
+      if (!TRY_SYSCTL("hw.ncpu", cpu_count)) {
+        // Give up.
+      }
+    }
+    cpu_info_out->cpu_count = cpu_count > 0 ? cpu_count : 0;
+  }
+
+  // Determine the size of the largest CPU cache:
+  {
+    // TODO:
+    // There doesn't appear to be an easy way to do this on FreeBSD,
+    // and I have not looked into OpenBSD, NetBSD, or DragonflyBSD.
+    cpu_info_out->cpu_cache_size = 0;
+  }
+  return true;
+}
+
+/******************************************************************************
+ * POSIX
+ *****************************************************************************/
+#elif __linux
+
+HIDDEN bool agda_cpu_info(AgdaCpuInfo *cpu_info_out) {
+  if (cpu_info_out == NULL) {
+    return false;
+  }
+
+  // Determine the number of CPU cores:
+  {
+    long cpu_count = 0;
+    // Try number of CPU cores currently online.
+#if __has_include(<unistd.h>) && defined(_SC_NPROCESSORS_ONLN)
+    if (cpu_count <= 0) {
+      cpu_count = sysconf(_SC_NPROCESSORS_ONLN);
+    }
+#endif
+    // Try number of CPU cores configured.
+#if __has_include(<unistd.h>) && defined(_SC_NPROCESSORS_CONF)
+    if (cpu_count <= 0) {
+      cpu_count = sysconf(_SC_NPROCESSORS_CONF);
+    }
+#endif
+    cpu_info_out->cpu_count = cpu_count > 0 ? cpu_count : 0;
+  }
+
+  // Determine the size of the largest CPU cache:
+  {
+    // TODO:
+    // It appears this requires reading the files that match:
+    //
+    //   /sys/devices/system/cpu/cpu*/cache/index*/size
+    //
+    cpu_info_out->cpu_cache_size = 0;
+  }
+  return true;
+}
+
+/******************************************************************************
+ * Default
+ *****************************************************************************/
+#else
+
+HIDDEN bool agda_cpu_info(AgdaCpuInfo *cpu_info_out) { return false; }
+
+#endif /* __APPLE__ */

--- a/src/main/agda/cpu_info.h
+++ b/src/main/agda/cpu_info.h
@@ -1,0 +1,18 @@
+#ifndef AGDA_CPU_COUNT_H
+#define AGDA_CPU_COUNT_H
+
+#include "./hidden.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+  // The number of CPU cores.
+  uint32_t cpu_count;
+  // The size of the largest CPU cache.
+  uint32_t cpu_cache_size;
+} AgdaCpuInfo;
+
+/// Get the CPU info.
+HIDDEN bool agda_cpu_info(AgdaCpuInfo *cpu_info_out);
+
+#endif /* AGDA_CPU_COUNT_H */

--- a/src/main/agda/hidden.h
+++ b/src/main/agda/hidden.h
@@ -1,0 +1,18 @@
+#ifndef AGDA_HIDDEN_H
+#define AGDA_HIDDEN_H
+
+#include <stdlib.h>
+
+// Portable macro for marking definitions as hidden.
+#ifndef HIDDEN
+#ifdef __has_attribute
+#if __has_attribute(visibility)
+#define HIDDEN __attribute__((visibility("hidden")))
+#endif
+#endif
+#ifndef HIDDEN
+#define HIDDEN ((void)0)
+#endif
+#endif
+
+#endif /* AGDA_HIDDEN_H */

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1,0 +1,56 @@
+#include <Rts.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "agda/cpu_info.h"
+
+/// The main closure from Main.hs.
+extern StgClosure ZCMain_main_closure;
+
+/// Set the default RtsFlags.
+static void agda_set_default_rts_flags(void) {
+  // The threaded RTS by default starts a major GC after a program has been idle
+  // for 0.3 s. This feature turned out to be annoying, so the idle GC is now by
+  // default turned off (-I0).
+  RtsFlags.GcFlags.idleGCDelayTime = 0;
+
+  // Get the CPU info:
+  AgdaCpuInfo cpu_info = {0};
+  if (agda_cpu_info(&cpu_info)) {
+    // Set the number of capabilities to equal the number of physical CPU cores:
+    if (cpu_info.cpu_count > 0) {
+      const uint32_t n = cpu_info.cpu_count;
+      fprintf(stderr, "RtsFlags.ParFlags.nCapabilities = %u\n", n);
+      RtsFlags.ParFlags.nCapabilities = n;
+
+      // Set the minimum allocation area size:
+      if (cpu_info.cpu_cache_size > 0) {
+        const uint32_t a =
+            (cpu_info.cpu_cache_size / cpu_info.cpu_count) / BLOCK_SIZE;
+        fprintf(stderr, "RtsFlags.GcFlags.minAllocAreaSize = %u\n", a);
+        RtsFlags.GcFlags.minAllocAreaSize = a;
+      }
+    }
+  }
+}
+
+/// The main function for Agda.
+int main(int argc, char *argv[]) {
+
+  // Create RTS configuration:
+  RtsConfig rts_config = {0};
+  memcpy(&rts_config, &defaultRtsConfig, sizeof(RtsConfig));
+
+  // If someone installs Agda with the setuid bit set, then the presence of +RTS
+  // may be a security problem (see GHC bug #3910). However, we sometimes
+  // recommend people to use +RTS to control Agda's memory usage, so we want
+  // this functionality enabled by default.
+  rts_config.rts_opts_enabled = RtsOptsAll;
+
+  // Agda tries to optimise the default RTS configuration.
+  rts_config.defaultsHook = agda_set_default_rts_flags;
+
+  // Initialise the GHC RTS and evaluate the Haskell main closure:
+  return hs_main(argc, argv, &ZCMain_main_closure, rts_config);
+}


### PR DESCRIPTION
This PR adds a C main that configures the RTS, as discussed with @AndrasKovacs in #8473:

- Add `src/main/main.c` and configure Cabal to use the main function from this file, rather than from `src/main/Main.hs`.
- Add minimal implementation of `agda_get_physical_cpu_count` for Windows, macOS, and Linux.
- Migrate RTS configuration from `Agda.cabal` to `main.c`.
- Set `RtsFlags.ParFlags.nCapabilities` based on the result of `agda_get_physical_cpu_count`.

Tested on macOS 15 and in an Ubuntu docker container. We'll see what my Windows code does.