### PR TITLE
Disambiguate `module` & other names in JS output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -458,6 +458,10 @@ Interaction and emacs mode
 Backends
 --------
 
+* (**BREAKING**): the JavaScript backend now generates different names for local Agda
+  modules, to avoid collisions with similarly-named `postulate`s or functions:
+  (see [#8483]((https://github.com/agda/agda/issues/)))
+
 * `agda --html --html-highlight=code example.lagda.tree` now produces `html/example.tree`, which Forester can consume directly - no external tools needed.
 
 * New option `--ghc-trace` for GHC Backend to instrument code

--- a/src/data/lib/prim/Agda/Builtin/Float.agda
+++ b/src/data/lib/prim/Agda/Builtin/Float.agda
@@ -62,10 +62,10 @@ primitive
     primFloatRound = function(x) {
         x = agdaRTS._primFloatRound(x);
         if (x === null) {
-            return z_jAgda_Agda_Builtin_Maybe["Maybe"]["nothing"];
+            return z_jAgda_Agda_Builtin_Maybe["module Maybe"]["nothing"];
         }
         else {
-            return z_jAgda_Agda_Builtin_Maybe["Maybe"]["just"](x);
+            return z_jAgda_Agda_Builtin_Maybe["module Maybe"]["just"](x);
         }
     };
 #-}
@@ -73,10 +73,10 @@ primitive
     primFloatFloor = function(x) {
         x = agdaRTS._primFloatFloor(x);
         if (x === null) {
-            return z_jAgda_Agda_Builtin_Maybe["Maybe"]["nothing"];
+            return z_jAgda_Agda_Builtin_Maybe["module Maybe"]["nothing"];
         }
         else {
-            return z_jAgda_Agda_Builtin_Maybe["Maybe"]["just"](x);
+            return z_jAgda_Agda_Builtin_Maybe["module Maybe"]["just"](x);
         }
     };
 #-}
@@ -84,10 +84,10 @@ primitive
     primFloatCeiling = function(x) {
         x = agdaRTS._primFloatCeiling(x);
         if (x === null) {
-            return z_jAgda_Agda_Builtin_Maybe["Maybe"]["nothing"];
+            return z_jAgda_Agda_Builtin_Maybe["module Maybe"]["nothing"];
         }
         else {
-            return z_jAgda_Agda_Builtin_Maybe["Maybe"]["just"](x);
+            return z_jAgda_Agda_Builtin_Maybe["module Maybe"]["just"](x);
         }
     };
 #-}
@@ -101,10 +101,10 @@ primitive
     primFloatDecode = function(x) {
         x = agdaRTS._primFloatDecode(x);
         if (x === null) {
-            return z_jAgda_Agda_Builtin_Maybe["Maybe"]["nothing"];
+            return z_jAgda_Agda_Builtin_Maybe["module Maybe"]["nothing"];
         }
         else {
-            return z_jAgda_Agda_Builtin_Maybe["Maybe"]["just"](
+            return z_jAgda_Agda_Builtin_Maybe["module Maybe"]["just"](
                 z_jAgda_Agda_Builtin_Sigma["_,_"](x.mantissa)(x.exponent));
         }
     };
@@ -114,10 +114,10 @@ primitive
         return function (y) {
             x = agdaRTS.uprimFloatEncode(x, y);
             if (x === null) {
-                return z_jAgda_Agda_Builtin_Maybe["Maybe"]["nothing"];
+                return z_jAgda_Agda_Builtin_Maybe["module Maybe"]["nothing"];
             }
             else {
-                return z_jAgda_Agda_Builtin_Maybe["Maybe"]["just"](x);
+                return z_jAgda_Agda_Builtin_Maybe["module Maybe"]["just"](x);
             }
         }
     };

--- a/src/data/lib/prim/Agda/Builtin/String.agda
+++ b/src/data/lib/prim/Agda/Builtin/String.agda
@@ -23,8 +23,8 @@ primitive
   primShowNat        : Nat → String
 
 {-# COMPILE JS primStringUncons = function(x) {
-   if (x === "") { return z_jAgda_Agda_Builtin_Maybe["Maybe"]["nothing"]; };
-   return z_jAgda_Agda_Builtin_Maybe["Maybe"]["just"](z_jAgda_Agda_Builtin_Sigma["_,_"](x.charAt(0))(x.slice(1)));
+   if (x === "") { return z_jAgda_Agda_Builtin_Maybe["module Maybe"]["nothing"]; };
+   return z_jAgda_Agda_Builtin_Maybe["module Maybe"]["just"](z_jAgda_Agda_Builtin_Sigma["_,_"](x.charAt(0))(x.slice(1)));
    }
  #-}
 {-# COMPILE JS primStringToList = function(x) { return x.split(""); } #-}

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -297,13 +297,17 @@ jsFileName :: JSModuleStyle -> GlobalId -> String
 jsFileName JSES6 (GlobalId ms) = intercalate "." ms ++ ".mjs" -- Hint that file is ES6, not old js
 jsFileName _     (GlobalId ms) = intercalate "." ms ++  ".js"
 
-jsMember :: Name -> MemberId
-jsMember n
+-- Convert an internal name (fragment) to a (MemberID-wrapped) string
+-- Bool parameter should be True for module names, and False otherwise
+jsMember :: Bool -> Name -> MemberId
+jsMember isModuleName n
   -- Anonymous fields are used for where clauses,
   -- and they're all given the concrete name "_",
   -- so we disambiguate them using their name id.
-  | isNoName n = MemberId ("_" ++ show (nameId n))
-  | otherwise  = MemberId $ prettyShow n
+  | isNoName n   = MemberId ("_" ++ show (nameId n))
+  -- Module names are disambiguated to avoid #8483
+  | isModuleName = MemberId $ "module " <> prettyShow n
+  | otherwise    = MemberId $ prettyShow n
 
 global' :: QName -> TCM (Exp, JSQName)
 global' q = do
@@ -314,7 +318,7 @@ global' q = do
     qms = mnameToList $ qnameModule q
     -- File-local module prefix
     localms = drop (size top) qms
-    nm = fmap jsMember $ List1.snoc localms $ qnameName q
+    nm = List1.snoc (map (jsMember True) localms) $ jsMember False (qnameName q)
   if top == i
     then return (Self, nm)
     else return (Global (jsMod top), nm)
@@ -528,7 +532,7 @@ definition' kit q d t ls =
 --
 --    compiles to
 --
---        exports["Foo"]["c2"] = x => y => k => k["c2"](x,y)
+--        exports["module Foo"]["c2"] = x => y => k => k["c2"](x,y)
 --
 --  * A constructor application, e.g.
 --
@@ -536,7 +540,7 @@ definition' kit q d t ls =
 --
 --    compiles to
 --
---        exports["Foo"]["c2"](x)(y)
+--        exports["module Foo"]["c2"](x)(y)
 --
 --  * A case split, e.g.
 --

--- a/test/Compiler/simple/Issue8483.agda
+++ b/test/Compiler/simple/Issue8483.agda
@@ -1,0 +1,20 @@
+
+module Issue8483 where
+
+open import Agda.Builtin.String
+
+postulate
+  HTMLInputElement : Set
+  HTMLTextAreaElement : Set
+  IO : Set → Set
+
+-- local modules to avoid name clashes on 'get-value':
+
+module HTMLInputElement where
+  postulate get-value : HTMLInputElement → IO String
+  {-# COMPILE JS get-value = e => ks => ks(e.value) #-}
+
+module HTMLTextAreaElement where
+  postulate get-value : HTMLTextAreaElement → IO String
+  {-# COMPILE JS get-value = e => ks => ks(e.value) #-}
+

--- a/test/Compiler/simple/Issue8483.options
+++ b/test/Compiler/simple/Issue8483.options
@@ -1,0 +1,7 @@
+TestOptions
+  { forCompilers =
+      [ (JS ES6 NonOptimized, CompilerOptions {extraAgdaArgs = []})
+      ]
+  , runtimeOptions = []
+  , executeProg = True
+  }

--- a/test/Compiler/simple/Issue8483.out
+++ b/test/Compiler/simple/Issue8483.out
@@ -1,0 +1,3 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess


### PR DESCRIPTION
This PR fixes #8483 by prefixing module names, e.g.

```js
import agdaRTS from "./agda-rts.mjs";

import z_jAgda_Agda_Builtin_String  from "./jAgda.Agda.Builtin.String.mjs";
import z_jAgda_Agda_Primitive  from "./jAgda.Agda.Primitive.mjs";

const exports = {};

exports["HTMLInputElement"] = undefined;
exports["HTMLTextAreaElement"] = undefined;
exports["IO"] = undefined;
exports["module HTMLInputElement"] = {};
exports["module HTMLInputElement"]["get-value"] = e => ks => ks(e.value);
exports["module HTMLTextAreaElement"] = {};
exports["module HTMLTextAreaElement"]["get-value"] = e => ks => ks(e.value);

;export default exports;
```

which does not crash at JS load time.

This is a breaking change: downstream JS code that calls Agda-generated JS code may need updating.

I tested this PR by running `nix build .#compiler-test` locally, which gave no errors.
