### PR TITLE
[ fix #7964 ] Properly handle projection-likeness in Mimer

### DIFF
--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -47,6 +47,7 @@ import Agda.Syntax.Internal
 import Agda.Syntax.Position (Range, noRange)
 import Agda.Syntax.Translation.InternalToAbstract (reify, blankNotInScope)
 
+import Agda.TypeChecking.CheckInternal ( checkInternal )
 import Agda.TypeChecking.Empty (isEmptyType)
 import Agda.TypeChecking.Level (levelType)
 import Agda.TypeChecking.MetaVars (newValueMeta)
@@ -56,9 +57,11 @@ import Agda.TypeChecking.Reduce (reduce, instantiateFull, instantiate)
 import Agda.TypeChecking.Rules.Term  (makeAbsurdLambda)
 import Agda.TypeChecking.Substitute (apply)
 
+import Agda.Interaction.Options ( optDoubleCheck )
+
 import Agda.Utils.Impossible (__IMPOSSIBLE__)
 import Agda.Utils.Maybe (catMaybes)
-import Agda.Utils.Monad (concatMapM, ifM)
+import Agda.Utils.Monad (concatMapM, ifM, whenM)
 import Agda.Utils.Null
 import Agda.Utils.Tuple (first, second)
 import Agda.Utils.Time (measureTime, getCPUTime, fromMilliseconds)
@@ -284,6 +287,8 @@ prepareComponents goal branch = withBranchAndGoal branch goal $ do
       -- Generate components for this context
       comps <- genComponents
       reportSDoc "mimer.components" 20 $ "Generated" <+> pretty (sum $ map (length . snd) comps) <+> "components"
+      whenM (optDoubleCheck <$> pragmaOptions) $
+        mapM_ checkInternalComponent $ concatMap (\(x,xs) -> x:xs) comps
       return comps
     -- Yes, just update the missing generated components
     Just cache -> mapM prepare (Map.toAscList cache)
@@ -298,6 +303,11 @@ prepareComponents goal branch = withBranchAndGoal branch goal $ do
   prepare (sourceComp, Nothing) = do
     updateStat incCompRegen
     (sourceComp,) <$> genComponentsFrom True sourceComp
+
+checkInternalComponent :: Component -> SM ()
+checkInternalComponent comp = do
+  reportSDoc "mimer.components" 40 $ "double-checking component" <+> prettyTCM comp
+  checkInternal (compTerm comp) CmpLeq (compType comp)
 
 genComponents :: SM [(Component, [Component])]
 genComponents = do

--- a/src/full/Agda/Mimer/Monad.hs
+++ b/src/full/Agda/Mimer/Monad.hs
@@ -365,6 +365,13 @@ qnameToComponent cost qname = do
         c@Constructor{}    -> (Con (conSrcCon c) ConOCon [], conPars c - length mParams)
         Axiom{}            -> def
         GeneralizableVar{} -> def
+        f@Function{}
+          | Right proj <- funProjection f
+          , projIndex proj > 0 ->
+            let totalToDrop = projIndex proj - 1
+                term        = Def qname $ map Apply $ drop totalToDrop mParams
+                stillToDrop = max 0 $ totalToDrop - length mParams
+            in  (term , stillToDrop)
         Function{}         -> def
         Datatype{}         -> def
         Record{}           -> def

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -465,15 +465,19 @@ cover infermissing f cs sc@(SClause tel ps _ _ target) = updateRelevance $ do
 
         mtv <- (traverse . traverse) (telViewUpToPath n_extra) $ clauseType cl
         let ty = (fmap . fmap) ((parallelS (reverse $ map namedArg extra) `composeS` liftS n_extra s `applyPatSubst`) . theCore) mtv
+        let body = (`applyE` patternsToElims extra) . (s `applyPatSubst`) <$> clauseBody cl
+        let pats = (s `applySubst` ps) ++ extra
 
         reportSDoc "tc.cover.applyCl" 40 $ "new ty =" <+> pretty ty
+        reportSDoc "tc.cover.applyCl" 40 $ "new pats =" <+> pretty pats
+        reportSDoc "tc.cover.applyCl" 40 $ "new body =" <+> pretty body
 
         return $
              Clause { clauseLHSRange  = clauseLHSRange cl
                     , clauseFullRange = clauseFullRange cl
                     , clauseTel       = tel
-                    , namedClausePats = (s `applySubst` ps) ++ extra
-                    , clauseBody      = (`applyE` patternsToElims extra) . (s `applyPatSubst`) <$> clauseBody cl
+                    , namedClausePats = pats
+                    , clauseBody      = body
                     , clauseType      = ty
                     , clauseCatchall    = clauseCatchall cl
                     , clauseRecursive   = clauseRecursive cl
@@ -549,7 +553,7 @@ cover infermissing f cs sc@(SClause tel ps _ _ target) = updateRelevance $ do
             , nest 2 $ vcat
               [ "n   = " <+> text (show n)
               , "scs = " <+> prettyTCM scs
-              , "ps  = " <+> prettyTCMPatternList (fromSplitPatterns ps)
+              , "ps  = " <+> inTopContext (addContext tel $ prettyTCMPatternList $ fromSplitPatterns ps)
               ]
             ]
           let trees' = zipWith (second . etaRecordSplits (unArg n) ps) trees scs

--- a/test/interaction/Issue7964.agda
+++ b/test/interaction/Issue7964.agda
@@ -1,0 +1,6 @@
+open import Agda.Builtin.FromString
+
+data Obj : Set where obj : Obj
+
+ex : Obj
+ex = {! -u !}

--- a/test/interaction/Issue7964.in
+++ b/test/interaction/Issue7964.in
@@ -1,0 +1,2 @@
+top_command (cmd_load currentFile [])
+goal_command 0 (cmd_autoOne AsIs) "-u"

--- a/test/interaction/Issue7964.out
+++ b/test/interaction/Issue7964.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals*" "?0 : Obj" nil)
+((last . 1) . (agda2-goals-action '(0)))
+(agda2-give-action 0 "obj")
+((last . 1) . (agda2-goals-action '()))


### PR DESCRIPTION
As it says, this contains the fix for #7964. It also adds double-checking of intermediate results in Mimer when `--double-check` is enabled, and it fixes an unrelated error in coverage debug printing that I encountered while investigating this issue (which came up because I was debugging with `-vtc:60`, don't ask me why).