### PR TITLE
Add lines-per-second information to --profile=modules

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Benchmark.hs
+++ b/src/full/Agda/TypeChecking/Monad/Benchmark.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# LANGUAGE NumDecimals #-}
 
 -- | Measure CPU time for individual phases of the Agda pipeline.
 
@@ -14,22 +15,22 @@ module Agda.TypeChecking.Monad.Benchmark
   ) where
 
 import Prelude hiding (print)
-import Control.Monad.IO.Class (liftIO)
-import Agda.Utils.FileName (filePath)
 
+import Data.Foldable (foldMap')
 import Data.Function (on)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Monoid (Sum(..), getSum)
+import qualified Data.Text.Lazy as TL
 
 import Agda.Benchmarking
 
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Debug
-import Agda.TypeChecking.Monad.State (topLevelModuleNameWithSourceFileCompleter)
+import Agda.TypeChecking.Monad.Imports (getVisitedModule)
 
 import qualified Agda.Utils.Benchmark as B
-import qualified Agda.Utils.IO.UTF8 as UTF8
 import qualified Agda.Utils.Trie as Trie
+import Agda.Utils.Impossible (__IMPOSSIBLE__)
 import Agda.Utils.Monad
 import Agda.Utils.Time (CPUTime(..), fromMilliseconds)
 import Agda.Syntax.Common.Pretty
@@ -84,14 +85,13 @@ instance Pretty ModuleThroughput where
     text (prettyShow $ mtModuleName mt) <+>
     parens
       (hsep
-        [ text (show (mtLineCount mt) ++ " lines") <> comma
-        , text (show (linesPerSecond mt) ++ " lines/s")
+        [ (text (show (mtLineCount mt)) <+> "lines") <> comma
+        , text (show (linesPerSecond mt)) <+> "lines/s"
         ])
 
 moduleThroughputDoc :: Benchmark -> TCM Doc
 moduleThroughputDoc b = do
-  moduleCompleter <- topLevelModuleNameWithSourceFileCompleter
-  stats           <- mapM (loadModuleThroughput moduleCompleter) (moduleRows b)
+  stats <- mapM loadModuleThroughput (moduleRows b)
   pure $ renderModuleThroughput stats
 
 renderModuleThroughput :: [ModuleThroughput] -> Doc
@@ -116,7 +116,7 @@ moduleRows =
         _             -> Nothing
 
 -- | Flatten benchmark timings into entries ordered by aggregate time,
---   skip entries with time below 10 ms.
+--   skipping entries with aggregate time below 10 ms.
 --   Each entry stores:
 --   * the account path
 --   * time stored at this node
@@ -134,18 +134,19 @@ orderedBenchmarkEntries =
 aggregateNode :: Ord a => Trie.Trie a CPUTime -> (CPUTime, CPUTime)
 aggregateNode t =
   ( fromMaybe 0 $ Trie.lookup [] t
-  , getSum $ foldMap Sum t
+  , getSum $ foldMap' Sum t
   )
 
 loadModuleThroughput
-  :: (TopLevelModuleName -> TopLevelModuleNameWithSourceFile)
-  -> (TopLevelModuleName, CPUTime)
+  :: (TopLevelModuleName, CPUTime)
   -> TCM ModuleThroughput
-loadModuleThroughput complete (mName, totalTime) = do
-  let given = complete mName
-  path <- srcFilePath (fileModuleSourceFile given)
-  contents <- liftIO $ UTF8.readFile (filePath path)
-  let lineCount = length (lines contents)
+loadModuleThroughput (mName, totalTime) = do
+  mi <- getVisitedModule mName >>= \case
+    Just mi -> pure mi
+    -- Module throughput is rendered only for modules already present in the benchmark output,
+    -- so the corresponding module info should already be in the visited-module cache.
+    Nothing -> __IMPOSSIBLE__
+  let lineCount = length (lines (TL.unpack (iSource (miInterface mi))))
   pure ModuleThroughput
     { mtModuleName = mName
     , mtTime = totalTime
@@ -153,7 +154,7 @@ loadModuleThroughput complete (mName, totalTime) = do
     }
 
 picosecondsPerSecond :: Integer
-picosecondsPerSecond = 1000000000000
+picosecondsPerSecond = 1e12
 
 linesPerSecond :: ModuleThroughput -> Integer
 linesPerSecond ModuleThroughput{ mtLineCount, mtTime = CPUTime ps }

--- a/src/full/Agda/TypeChecking/Monad/Benchmark.hs
+++ b/src/full/Agda/TypeChecking/Monad/Benchmark.hs
@@ -14,16 +14,28 @@ module Agda.TypeChecking.Monad.Benchmark
   ) where
 
 import Prelude hiding (print)
+import Control.Monad.IO.Class (liftIO)
+import Agda.Utils.FileName (filePath)
+
+import Data.Function (on)
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Monoid (Sum(..), getSum)
 
 import Agda.Benchmarking
 
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Debug
+import Agda.TypeChecking.Monad.State (topLevelModuleNameWithSourceFileCompleter)
 
 import qualified Agda.Utils.Benchmark as B
-
+import qualified Agda.Utils.IO.UTF8 as UTF8
+import qualified Agda.Utils.Trie as Trie
 import Agda.Utils.Monad
-import Agda.Syntax.Common.Pretty (pretty)
+import Agda.Utils.Time (CPUTime(..), fromMilliseconds)
+import Agda.Syntax.Common.Pretty
+  ( Doc, Pretty, comma, hsep, nest, parens, pretty, prettyShow
+  , text, vcat, (<+>), ($+$)
+  )
 import qualified Agda.Interaction.Options.ProfileOptions as Profile
 
 -- | When profile options are set or changed, we need to turn benchmarking on or off.
@@ -47,6 +59,9 @@ benchmarking = liftTCM $
 print :: MonadTCM tcm => tcm ()
 print = liftTCM $ whenM (B.isBenchmarkOn [] <$> benchmarking) $ do
   b <- B.getBenchmark
+  extra <- ifM (hasProfileOption Profile.Modules)
+    (moduleThroughputDoc b)
+    (pure mempty)
   -- Andreas, 2017-07-29, issue #2602:
   -- The following line messes up the AgdaInfo buffer,
   -- thus, as Fredrik Forsberg suggest, I restore the original
@@ -56,7 +71,99 @@ print = liftTCM $ whenM (B.isBenchmarkOn [] <$> benchmarking) $ do
   -- is turned on, effectively making module/definition benchmarking impossible (since internal
   -- takes precedence). It needs to be > 1 to avoid triggering #2602 though. Also use
   -- displayDebugMessage instead of reportSLn to avoid requiring -v profile:2.
-  displayDebugMessage "profile" 2 $ pretty b
+  displayDebugMessage "profile" 2 $ pretty b $+$ extra
+
+data ModuleThroughput = ModuleThroughput
+  { mtModuleName :: TopLevelModuleName
+  , mtLineCount  :: Int
+  , mtTime       :: CPUTime
+  }
+
+instance Pretty ModuleThroughput where
+  pretty mt =
+    text (prettyShow $ mtModuleName mt) <+>
+    parens
+      (hsep
+        [ text (show (mtLineCount mt) ++ " lines") <> comma
+        , text (show (linesPerSecond mt) ++ " lines/s")
+        ])
+
+moduleThroughputDoc :: Benchmark -> TCM Doc
+moduleThroughputDoc b = do
+  moduleCompleter <- topLevelModuleNameWithSourceFileCompleter
+  stats           <- mapM (loadModuleThroughput moduleCompleter) (moduleRows b)
+  pure $ renderModuleThroughput stats
+
+renderModuleThroughput :: [ModuleThroughput] -> Doc
+renderModuleThroughput [] = mempty
+renderModuleThroughput stats =
+  vcat
+    [ mempty
+    , mempty
+    , text "Module throughput:"
+    , vcat $ map (nest 2 . pretty) stats
+    ]
+
+-- | Keep only benchmark entries corresponding to top-level modules,
+--   using the aggregate module time.
+moduleRows :: Benchmark -> [(TopLevelModuleName, CPUTime)]
+moduleRows =
+  mapMaybe moduleRow . orderedBenchmarkEntries
+  where
+    moduleRow (acc, (_selfTime, totalTime)) =
+      case acc of
+        [TopModule m] -> Just (m, totalTime)
+        _             -> Nothing
+
+-- | Flatten benchmark timings into entries ordered by aggregate time,
+--   skip entries with time below 10 ms.
+--   Each entry stores:
+--   * the account path
+--   * time stored at this node
+--   * the aggregate time of the whole subtree
+orderedBenchmarkEntries :: Benchmark -> [(Account, (CPUTime, CPUTime))]
+orderedBenchmarkEntries =
+  Trie.toListOrderedBy (flip compare `on` snd)
+  . Trie.filter ((> fromMilliseconds 10) . snd)
+  . Trie.mapSubTries (Just . aggregateNode)
+  . B.timings
+
+-- | For a benchmark trie node, return:
+--   * time stored at this node
+--   * the aggregate time of the whole subtree
+aggregateNode :: Ord a => Trie.Trie a CPUTime -> (CPUTime, CPUTime)
+aggregateNode t =
+  ( fromMaybe 0 $ Trie.lookup [] t
+  , getSum $ foldMap Sum t
+  )
+
+loadModuleThroughput
+  :: (TopLevelModuleName -> TopLevelModuleNameWithSourceFile)
+  -> (TopLevelModuleName, CPUTime)
+  -> TCM ModuleThroughput
+loadModuleThroughput complete (mName, totalTime) = do
+  let given = complete mName
+  path <- srcFilePath (fileModuleSourceFile given)
+  contents <- liftIO $ UTF8.readFile (filePath path)
+  let lineCount = length (lines contents)
+  pure ModuleThroughput
+    { mtModuleName = mName
+    , mtTime = totalTime
+    , mtLineCount = lineCount
+    }
+
+picosecondsPerSecond :: Integer
+picosecondsPerSecond = 1000000000000
+
+linesPerSecond :: ModuleThroughput -> Integer
+linesPerSecond ModuleThroughput{ mtLineCount, mtTime = CPUTime ps }
+  | ps == 0   = 0
+  | otherwise = round throughput
+  where
+    elapsedSeconds =
+      fromInteger ps / fromInteger picosecondsPerSecond
+    throughput =
+      fromIntegral mtLineCount / elapsedSeconds
 
 -- -- | Bill a computation to a specific account.
 -- {-# SPECIALIZE billTo :: Account -> TCM a -> TCM a #-}

--- a/src/full/Agda/TypeChecking/Monad/Benchmark.hs
+++ b/src/full/Agda/TypeChecking/Monad/Benchmark.hs
@@ -23,6 +23,7 @@ import Data.Monoid (Sum(..), getSum)
 import qualified Data.Text.Lazy as TL
 
 import Agda.Benchmarking
+import Agda.Interaction.Options.Types( optParallelChecking, Parallelism(..) )
 
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Debug
@@ -60,7 +61,7 @@ benchmarking = liftTCM $
 print :: MonadTCM tcm => tcm ()
 print = liftTCM $ whenM (B.isBenchmarkOn [] <$> benchmarking) $ do
   b <- B.getBenchmark
-  extra <- ifM (hasProfileOption Profile.Modules)
+  extra <- ifM moduleThroughputEnabled
     (moduleThroughputDoc b)
     (pure mempty)
   -- Andreas, 2017-07-29, issue #2602:
@@ -73,6 +74,19 @@ print = liftTCM $ whenM (B.isBenchmarkOn [] <$> benchmarking) $ do
   -- takes precedence). It needs to be > 1 to avoid triggering #2602 though. Also use
   -- displayDebugMessage instead of reportSLn to avoid requiring -v profile:2.
   displayDebugMessage "profile" 2 $ pretty b $+$ extra
+
+moduleThroughputEnabled :: TCM Bool
+moduleThroughputEnabled = do
+  modulesProfiling <- hasProfileOption Profile.Modules
+  sequential       <- sequentialTypeChecking
+  pure $ modulesProfiling && sequential
+
+sequentialTypeChecking :: TCM Bool
+sequentialTypeChecking = do
+  opts <- commandLineOptions
+  pure $ case optParallelChecking opts of
+    Sequential -> True
+    Parallel{} -> False
 
 data ModuleThroughput = ModuleThroughput
   { mtModuleName :: TopLevelModuleName


### PR DESCRIPTION
Fix #8478 

Extends `--profile=modules` output with a `Module throughput` section with:
- source line count
- computed lines/s based on aggregate module time

Example output:
```text
Checking Agda.Builtin.Reflection (/home/piter/agda/src/data/lib/prim/Agda/Builtin/Reflection.agda).
 Checking Agda.Builtin.Unit (/home/piter/agda/src/data/lib/prim/Agda/Builtin/Unit.agda).
 Checking Agda.Builtin.Bool (/home/piter/agda/src/data/lib/prim/Agda/Builtin/Bool.agda).
 Checking Agda.Builtin.Nat (/home/piter/agda/src/data/lib/prim/Agda/Builtin/Nat.agda).
 Checking Agda.Builtin.Word (/home/piter/agda/src/data/lib/prim/Agda/Builtin/Word.agda).
 Checking Agda.Builtin.List (/home/piter/agda/src/data/lib/prim/Agda/Builtin/List.agda).
 Checking Agda.Builtin.String (/home/piter/agda/src/data/lib/prim/Agda/Builtin/String.agda).
  Checking Agda.Builtin.Char (/home/piter/agda/src/data/lib/prim/Agda/Builtin/Char.agda).
  Checking Agda.Builtin.Maybe (/home/piter/agda/src/data/lib/prim/Agda/Builtin/Maybe.agda).
  Checking Agda.Builtin.Sigma (/home/piter/agda/src/data/lib/prim/Agda/Builtin/Sigma.agda).
 Checking Agda.Builtin.Float (/home/piter/agda/src/data/lib/prim/Agda/Builtin/Float.agda).
  Checking Agda.Builtin.Int (/home/piter/agda/src/data/lib/prim/Agda/Builtin/Int.agda).
Total                   239ms 
Miscellaneous            62ms 
Agda.Builtin.Reflection  85ms 
Agda.Builtin.Float       36ms 
Agda.Builtin.Nat         29ms 
Agda.Primitive.Cubical   25ms 

Module throughput:
  Agda.Builtin.Reflection (486 lines, 5670 lines/s)
  Agda.Builtin.Float (209 lines, 5718 lines/s)
  Agda.Builtin.Nat (173 lines, 5929 lines/s)
  Agda.Primitive.Cubical (78 lines, 3072 lines/s)
```
from running:
```shell
Agda_datadir=src/data \
"$AGDA" --ignore-interfaces --no-default-libraries -i src/data/lib/prim \
  --profile=modules -v profile:2 src/data/lib/prim/Agda/Builtin/Reflection.agda
```  