### PR TITLE
Fall back to hole range when refine input has no range

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -260,7 +260,11 @@ refine force ii e = do
   -- so that the new questionmarks appended to @e@
   -- can receive a 'Range' relatively correct to the ranges
   -- of the questionmarks withing @e@.
-  let range = getRange e
+  -- If @e@ has no range information, fall back to the current interaction
+  -- point range so appended metas still get a real file range.
+  holeRange <- getInteractionRange ii
+  let exprRange = getRange e
+      range     = if null exprRange then holeRange else exprRange
   scope <- getInteractionScope ii
   -- We try to append up to 10 meta variables
   tryRefine 10 range scope e

--- a/test/interaction/Issue5808.agda
+++ b/test/interaction/Issue5808.agda
@@ -1,0 +1,16 @@
+module Issue5808 where
+
+id1
+  : {A : Set}
+  → A
+  → A
+id1 x
+  = x
+
+id2
+  : {A : Set}
+  → A
+  → A
+
+id2 x
+  = ?

--- a/test/interaction/Issue5808.out
+++ b/test/interaction/Issue5808.out
@@ -1,0 +1,11 @@
+JSON> {"kind":"Status","status":{"checked":false,"showImplicitArguments":false,"showIrrelevantArguments":false}}
+{"kind":"ClearRunningInfo"}
+{"kind":"ClearHighlighting","tokenBased":"NotOnlyTokenBased"}
+{"kind":"Status","status":{"checked":false,"showImplicitArguments":false,"showIrrelevantArguments":false}}
+{"info":{"errors":[],"invisibleGoals":[],"kind":"AllGoalsWarnings","visibleGoals":[{"constraintObj":{"id":0,"range":[{"end":{"col":6,"line":16,"pos":110},"start":{"col":5,"line":16,"pos":109}}]},"kind":"OfType","type":"A"}],"warnings":[]},"kind":"DisplayInfo"}
+{"interactionPoints":[{"id":0,"range":[{"end":{"col":6,"line":16,"pos":110},"start":{"col":5,"line":16,"pos":109}}]}],"kind":"InteractionPoints"}
+JSON> {"giveResult":{"str":"id1 ?"},"interactionPoint":{"id":0,"range":[{"end":{"col":6,"line":16,"pos":110},"start":{"col":5,"line":16,"pos":109}}]},"kind":"GiveAction"}
+{"kind":"Status","status":{"checked":false,"showImplicitArguments":false,"showIrrelevantArguments":false}}
+{"info":{"errors":[],"invisibleGoals":[],"kind":"AllGoalsWarnings","visibleGoals":[{"constraintObj":{"id":1,"range":[{"end":{"col":8,"line":16,"pos":112},"start":{"col":8,"line":16,"pos":112}}]},"kind":"OfType","type":"A"}],"warnings":[]},"kind":"DisplayInfo"}
+{"interactionPoints":[{"id":1,"range":[{"end":{"col":8,"line":16,"pos":112},"start":{"col":8,"line":16,"pos":112}}]}],"kind":"InteractionPoints"}
+JSON> 

--- a/test/interaction/Issue5808.sh
+++ b/test/interaction/Issue5808.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+AGDA=$1
+file="Issue5808.agda"
+
+$AGDA -v0 --interaction-json --color=never <<EOF
+IOTCM "$file" None Indirect (Cmd_load "$file" [])
+IOTCM "$file" None Indirect (Cmd_refine 0 noRange "id1")
+EOF


### PR DESCRIPTION
Fixes #5808
Fixes #5836

 Falls back to the current interaction point range when the refined expression has no range information

Problem was that, refining the hole with `id1` in `--interaction-json` created a new interaction point with an empty range.

**Example**:

Initial hole after load:
```
{"interactionPoints":[{"id":0,"range":[{"end":{"col":9,"line":16,"pos":108},"start":{"col":5,"line":16,"pos":104}}]}],"kind":"InteractionPoints"}`
```

after refining hole with `id1`:

```IOTCM "Test.agda" None Indirect (Cmd_refine 0 noRange "id1")```

Agda reported:
  
  ```{"giveResult":{"str":"id1 ?"},...,"kind":"GiveAction"}```

and:

```{"interactionPoints":[{"id":1,"range":[]}],"kind":"InteractionPoints"}```

So the fresh interaction point introduced by `refine` had no source range.