### PR TITLE
[refactor] get rid of RecordWildCards where meaningful

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -388,6 +388,7 @@ common language
       DeriveTraversable
       DerivingStrategies
       DerivingVia
+      DisambiguateRecordFields
       ExistentialQuantification
       FlexibleContexts
       FlexibleInstances
@@ -402,7 +403,6 @@ common language
       OverloadedStrings
       PatternSynonyms
       RankNTypes
-      RecordWildCards
       ScopedTypeVariables
       StandaloneDeriving
       TupleSections
@@ -428,6 +428,7 @@ common language
       PatternGuards
       PolyKinds
       RebindableSyntax
+      RecordWildCards
       TemplateHaskell
       UnboxedTuples
       UndecidableInstances

--- a/src/full/Agda/Compiler/Treeless/Builtin.hs
+++ b/src/full/Agda/Compiler/Treeless/Builtin.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards #-}
+
 {-# OPTIONS_GHC -Wunused-imports #-}
 
 -- | Translates the Agda builtin nat datatype to arbitrary-precision integers.

--- a/src/full/Agda/Compiler/Treeless/Simplify.hs
+++ b/src/full/Agda/Compiler/Treeless/Simplify.hs
@@ -74,7 +74,7 @@ simplifyTTerm t = do
   return $ runS $ simplify kit t
 
 simplify :: FunctionKit -> TTerm -> S TTerm
-simplify FunctionKit{..} = simpl
+simplify FunctionKit{ divAux, modAux, natMinus, true, false } = simpl
   where
     simpl = rewrite' >=> unchainCase >=> \case
 

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -402,7 +402,7 @@ initialiseCommandQueue next = do
 
   _ <- forkIO (readCommands 0)
 
-  return (CommandQueue { .. })
+  return (CommandQueue { commands, abort })
 
 ---------------------------------------------------------
 

--- a/src/full/Agda/Interaction/Library/Parse.hs
+++ b/src/full/Agda/Interaction/Library/Parse.hs
@@ -178,7 +178,7 @@ fromGeneric' file fields fs = do
     upd l (GenericEntry h cs) = do
       mf <- findField h fields
       case mf of
-        Just Field{..} -> do
+        Just Field{ fParse, fSet } -> do
           x <- fParse r cs
           return $ fSet x l
         Nothing -> return l

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -372,7 +372,7 @@ genRecCalls thisFn = do
       return []
     recCandTerms -> do
       reportSDoc "mimer.components" 45 $ "  recCandTerms = " <+> pretty (map fst recCandTerms)
-      Costs{..} <- asks searchCosts
+      Costs{ costLocal, costNewMeta, costNewHiddenMeta } <- asks searchCosts
       n <- localVarCount
       localVars <- lift $ getLocalVars n costLocal
       let recCands = [ (t, i) | t@(compTerm -> v@Var{}) <- localVars, NoSubst i <- maybeToList $ lookup v recCandTerms ]

--- a/src/full/Agda/Mimer/Monad.hs
+++ b/src/full/Agda/Mimer/Monad.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 
 module Agda.Mimer.Monad where
 

--- a/src/full/Agda/Mimer/Types.hs
+++ b/src/full/Agda/Mimer/Types.hs
@@ -370,7 +370,8 @@ instance Pretty Costs where
         ]
 
 instance PrettyTCM Component where
-  prettyTCM Component{..} = parens (prettyTCM compId) <+> sep
+  prettyTCM Component{ compId, compTerm, compType, compCost, compMetas } =
+    parens (prettyTCM compId) <+> sep
     [ sep [ prettyTCM compTerm
           , ":" <+> prettyTCM compType ]
     , parens $ fsep $ punctuate ","

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -3441,8 +3441,8 @@ instance Pretty MetaId where
     text $ "_" ++ show n ++ "@" ++ show (moduleNameHash m)
 
 instance Enum MetaId where
-  succ MetaId{..} = MetaId { metaId = succ metaId, .. }
-  pred MetaId{..} = MetaId { metaId = pred metaId, .. }
+  succ m@MetaId{ metaId } = m { metaId = succ metaId }
+  pred m@MetaId{ metaId } = m { metaId = pred metaId }
 
   -- The following functions should not be used.
   toEnum   = __IMPOSSIBLE__

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1551,7 +1551,7 @@ instance Reify Sort where
 
     reify s = do
       s <- instantiateFull s
-      SortKit{..} <- infallibleSortKit
+      SortKit{ nameOfUniv } <- infallibleSortKit
       case s of
         I.Univ u (I.ClosedLevel 0) -> return $! A.Def' (nameOfUniv USmall u) A.NoSuffix
         I.Univ u (I.ClosedLevel n) -> return $! A.Def' (nameOfUniv USmall u) (A.Suffix n)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4,6 +4,7 @@
 -- with GHC 9.14
 {-# LANGUAGE NoDeepSubsumption #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UnboxedTuples #-}
 
 module Agda.TypeChecking.Monad.Base

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -224,7 +224,7 @@ quotingKit = do
 
       quoteTelEntry :: Dom (ArgName, Type) -> ReduceM Term
       quoteTelEntry dom@(unDom -> (x , t)) = do
-        SigmaKit{..} <- fromMaybe __IMPOSSIBLE__ <$> getSigmaKit
+        SigmaKit{ sigmaCon } <- fromMaybe __IMPOSSIBLE__ <$> getSigmaKit
         Con sigmaCon ConOSystem [] !@! quoteString x @@ quoteDom quoteType (fmap snd dom)
 
       list :: [ReduceM Term] -> ReduceM Term

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -257,7 +257,7 @@ inferApplication exh hd args e | not (defOrVar hd) = do
   v <- checkExpr' CmpEq e t
   return (v, t)
 inferApplication exh hd args e = postponeInstanceConstraints $ do
-  SortKit{..} <- sortKit
+  SortKit{ isNameOfUniv } <- sortKit
   case unScope hd of
     A.Proj o p | isAmbiguous p -> inferProjApp e o p hd args
     A.Def' x s | Just (sz, u) <- isNameOfUniv x -> inferUniv sz u e x s args
@@ -414,7 +414,7 @@ inferDef mkTerm x =
 -- not be any need to insert hidden lambdas.
 checkHeadApplication :: Comparison -> A.Expr -> Type -> A.Expr -> [NamedArg A.Expr] -> TCM Term
 checkHeadApplication cmp e t hd args = do
-  SortKit{..} <- sortKit
+  SortKit{ isNameOfUniv } <- sortKit
   sharp <- fmap nameOfSharp <$> coinductionKit
   pOr    <- getNameOfConstrained builtinPOr
   pComp  <- getNameOfConstrained builtinComp
@@ -567,7 +567,7 @@ checkArgumentsE'
   -> CheckArgumentsE'
 
 -- Case: no arguments, do not insert trailing hidden arguments: We are done.
-checkArgumentsE' S{ sArgs = [], .. }
+checkArgumentsE' S{ sArgs = [], sFun, sFunType, sChecked, sExpand }
   | isDontExpandLast sExpand =
     return $ ACState
       { acCheckedArgs = []
@@ -577,7 +577,7 @@ checkArgumentsE' S{ sArgs = [], .. }
       }
 
 -- Case: no arguments, but need to insert trailing hiddens.
-checkArgumentsE' S{ sArgs = [], .. } =
+checkArgumentsE' S{ sArgs = [], sFun, sFunType, sChecked, sResultType } =
   traceCallE (CheckArguments sFun [] sFunType sResultType) $ lift $ do
     sResultType <- traverse (unEl <.> reduce) sResultType
     (ncargs, t) <- implicitCheckedArgs (-1) (\ h _x -> expand sResultType h) sFunType
@@ -596,7 +596,7 @@ checkArgumentsE' S{ sArgs = [], .. } =
 
 -- Case: argument given.
 checkArgumentsE'
-  s@S{ sArgs = sArgs@((arg@(Arg info e), sArgsVisible) : args), .. } =
+  s@S{ sArgs = sArgs@((arg@(Arg info e), sArgsVisible) : args), sArgsLen, sChecked, sComp, sFun, sFunType, sPathView, sResultType, sSkipCheck, sSizeLtChecked } =
 
     traceCallE (CheckArguments sFun (map' fst sArgs) sFunType sResultType) $ do
       lift $ reportSDoc "tc.term.args" 30 $ sep

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
 
 {-# LANGUAGE NondecreasingIndentation #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Agda.TypeChecking.Rules.Decl where
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -117,7 +117,7 @@ isType_ e = traceCall (IsType_ e) $ do
     , nest 2 $ "returns" <?> prettyTCM a
     ]) $ do
   let fallback = isType' CmpEq e =<< do workOnTypes $ newSortMeta
-  SortKit{..} <- sortKit
+  SortKit{ isNameOfUniv } <- sortKit
   case unScope e of
     A.Fun i (Arg info t) b -> do
       a <- uncurry (defaultArgDomRew info) <$>

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -373,7 +373,7 @@ instance Unquote a => Unquote [a] where
 instance (Unquote a, Unquote b) => Unquote (a, b) where
   unquote t = do
     t <- reduceQuotedTerm t
-    SigmaKit{..} <- fromMaybe __IMPOSSIBLE__ <$> getSigmaKit
+    SigmaKit{ sigmaCon } <- fromMaybe __IMPOSSIBLE__ <$> getSigmaKit
     case t of
       Con c _ es | Just [x,y] <- allApplyElims es ->
         choice

--- a/src/full/Agda/Utils/CallStack/Pretty.hs
+++ b/src/full/Agda/Utils/CallStack/Pretty.hs
@@ -18,7 +18,8 @@ import Agda.Syntax.Common.Pretty
   )
 
 instance Pretty SrcLoc where
-  pretty SrcLoc {..} = hsep [physicalLoc, "in", logicalLoc]
+  pretty SrcLoc{ srcLocPackage, srcLocModule, srcLocFile, srcLocStartLine,
+        srcLocStartCol } = hsep [physicalLoc, "in", logicalLoc]
       where
         physicalLoc = hcat [text srcLocFile, colon, pshow srcLocStartLine, colon, pshow srcLocStartCol]
         logicalLoc = hcat [text srcLocPackage, colon, text srcLocModule]

--- a/src/full/Agda/Utils/DocTree.hs
+++ b/src/full/Agda/Utils/DocTree.hs
@@ -32,7 +32,7 @@ import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Builder qualified as Builder
 #endif
 
-import GHC.Generics
+import GHC.Generics (Generic)
 
 import Text.PrettyPrint.Annotated.HughesPJ (Doc)
 import Text.PrettyPrint.Annotated.HughesPJ qualified as Ppr

--- a/src/full/Agda/Utils/HashTable.hs
+++ b/src/full/Agda/Utils/HashTable.hs
@@ -90,7 +90,7 @@ toList (HashTable h) = Data.Vector.Hashtables.toList h
 forAssocs :: (MVector ks k, MVector vs v)
           => HashTable ks k vs v -> (k -> v -> IO ()) -> IO ()
 forAssocs (HashTable h) f = do
-  Dictionary{..} <- readMutVar (getDRef h)
+  Dictionary{ hashCode, key, refs, value } <- readMutVar (getDRef h)
   count <- refs ! getCount
   let go :: Int -> IO ()
       go i | i < 0 = pure ()
@@ -122,8 +122,8 @@ insertingIfAbsent :: forall ks k vs v a.
        -> IO v
        -> (v -> IO a)
        -> IO a
-insertingIfAbsent (HashTable DRef{..}) key' found getValue' notfound = do
-    d@Dictionary{..} <- readMutVar getDRef
+insertingIfAbsent (HashTable DRef{ getDRef }) key' found getValue' notfound = do
+    d@Dictionary{ buckets, hashCode, key, next, refs, remSize, value } <- readMutVar getDRef
     let
         hashCode' = hash key' .&. mask
         !targetBucket = hashCode' `fastRem` remSize

--- a/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -36,7 +36,7 @@ import Agda.Utils.Impossible
 import Internal.Helpers
 import Internal.TypeChecking.Positivity.Occurrence ()
 
-import Test.QuickCheck as QuickCheck
+import qualified Test.QuickCheck as QuickCheck
 
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
`RecordWildCards` make code less readable/searchable, so let's not have them on by default.

I left some record wild cards in the code where removing them would be cumbersome.