### PR TITLE
Bump GHC 9.12.2 to 9.12.4

### DIFF
--- a/.github/workflows/cabal-install.yml
+++ b/.github/workflows/cabal-install.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         cabal-update: true
         cabal-version: latest
-        ghc-version: 9.12.2
+        ghc-version: 9.12.4
     - name: Configure the build plan
       run: |
         # shellcheck disable=SC2086

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       FLAGS: -O0 ${{ matrix.cabal-flags || '--enable-tests --flags=enable-cluster-counting'
         }}
-      GHC_VER: ${{ matrix.ghc-ver || '9.12.2' }}
+      GHC_VER: ${{ matrix.ghc-ver || '9.12.4' }}
     name: Cabal ${{ matrix.description }}, ${{ matrix.ghc-ver }}
     needs: auto-cancel
     runs-on: ${{ matrix.os }}
@@ -127,7 +127,7 @@ jobs:
         doctest:
         - false
         ghc-ver:
-        - 9.12.2
+        - 9.12.4
         - 9.10.3
         - 9.8.4
         - 9.6.7
@@ -142,22 +142,22 @@ jobs:
         - cabal-flags: --disable-tests
           description: Linux doctest
           doctest: true
-          ghc-ver: 9.12.2
+          ghc-ver: 9.12.4
           os: ubuntu-24.04
         - cabal-flags: --enable-tests --flags=debug
           description: Linux debug
-          ghc-ver: 9.12.2
+          ghc-ver: 9.12.4
           os: ubuntu-24.04
         - cabal-flags: --enable-tests --flags=use-xdg-data-home --flags=enable-cluster-counting
             --flags=debug --flags=debug-serialisation --flags=debug-parsing
           description: Linux debug all
-          ghc-ver: 9.12.2
+          ghc-ver: 9.12.4
           os: ubuntu-24.04
         - description: macOS
-          ghc-ver: 9.12.2
+          ghc-ver: 9.12.4
           os: macos-15
         - description: Windows
-          ghc-ver: 9.12.2
+          ghc-ver: 9.12.4
           os: windows-2025
         os:
         - ubuntu-24.04

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,7 +164,7 @@ jobs:
         cabal-ver:
         - latest
         ghc-ver:
-        - 9.12.2
+        - 9.12.4
         os:
         - windows-latest
         - macos-latest

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         ghc-ver:
-        - 9.12.2
+        - 9.12.4
         os:
         - ubuntu-24.04
 name: Haddock

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -127,16 +127,16 @@ jobs:
       fail-fast: false
       matrix:
         ghc-ver:
-        - 9.12.2
+        - 9.12.4
         - 9.10.3
         - 9.8.4
         - 9.6.7
         - 9.4.8
         - 9.2.8
         include:
-        - ghc-ver: 9.12.2
+        - ghc-ver: 9.12.4
           os: macos-15
-        - ghc-ver: 9.12.2
+        - ghc-ver: 9.12.4
           os: windows-2025
         os:
         - ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@
 ######################################################
 env:
   AGDA_TESTS_OPTIONS: -j${PARALLEL_TESTS} --hide-successes
-  GHC_VER: 9.12.2
+  GHC_VER: 9.12.4
   PARALLEL_TESTS: 2
   STACK: stack --system-ghc
   TASTY_ANSI_TRICKS: 'false'

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -30,7 +30,7 @@ description:
     Emacs mode.
 
 tested-with:
-    GHC == 9.12.2
+    GHC == 9.12.4
     GHC == 9.10.3
     GHC == 9.8.4
     GHC == 9.6.7
@@ -87,7 +87,7 @@ extra-doc-files:
     doc/release-notes/2.2.0.md
 
 extra-source-files:
-    stack-9.12.2.yaml
+    stack-9.12.4.yaml
     stack-9.10.3.yaml
     stack-9.8.4.yaml
     stack-9.6.7.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Installation
 
 * Dropped support for GHC 8.8, 8.10, and 9.0.
 
-* Agda supports GHC versions 9.2.8 to 9.12.2.
+* Agda supports GHC versions 9.2.8 to 9.12.4.
 
 Pragmas and options
 -------------------

--- a/src/github/workflows/cabal-install.yml
+++ b/src/github/workflows/cabal-install.yml
@@ -61,7 +61,7 @@ jobs:
     - uses: haskell-actions/setup@v2
       id: setup-haskell
       with:
-        ghc-version:   '9.12.2'
+        ghc-version:   '9.12.4'
         cabal-version: latest
         cabal-update:  true
 

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         description: [Linux]      ## This just for pretty-printing the job name.
-        ghc-ver: [9.12.2, 9.10.3, 9.8.4, 9.6.7, 9.4.8, 9.2.8]
+        ghc-ver: [9.12.4, 9.10.3, 9.8.4, 9.6.7, 9.4.8, 9.2.8]
         cabal-flags: ['--enable-tests --flags=enable-cluster-counting']
         doctest: [false]
         include:
@@ -65,7 +65,7 @@ jobs:
           # Linux, without tests but with doctest
           - os: ubuntu-24.04
             description: Linux doctest
-            ghc-ver: '9.12.2'
+            ghc-ver: '9.12.4'
             # Can't leave cabal-flags empty here lest it becomes the default value.
             cabal-flags: '--disable-tests'
             doctest: true
@@ -73,13 +73,13 @@ jobs:
           # Linux, without -f enable-cluster-counting but with -f debug
           - os: ubuntu-24.04
             description: Linux debug
-            ghc-ver: '9.12.2'
+            ghc-ver: '9.12.4'
             cabal-flags: '--enable-tests --flags=debug'
 
           # Linux, with all debug options
           - os: ubuntu-24.04
             description: Linux debug all
-            ghc-ver: '9.12.2'
+            ghc-ver: '9.12.4'
             ## Andreas, 2024-08-16: Keeping the following outdated note for future reference:
             ## Note: -c 'containers >= 0.7' with single quotes does not get communicated properly.
             ## (The single quotes stay, and "-c 'containers" is an option parse error for cabal.)
@@ -94,16 +94,16 @@ jobs:
           # macOS with default flags
           - os: macos-15
             description: macOS
-            ghc-ver: '9.12.2'
+            ghc-ver: '9.12.4'
 
           # Windows with default flags
           - os: windows-2025
             description: Windows
-            ghc-ver: '9.12.2'
+            ghc-ver: '9.12.4'
 
     # Default values
     env:
-      GHC_VER:   ${{ matrix.ghc-ver || '9.12.2' }}
+      GHC_VER:   ${{ matrix.ghc-ver || '9.12.4' }}
       FLAGS: >-
         -O0
         ${{ matrix.cabal-flags || '--enable-tests --flags=enable-cluster-counting' }}

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
           - macos-latest
           - macos-15-intel
           - ubuntu-latest
-        ghc-ver: ['9.12.2']
+        ghc-ver: ['9.12.4']
         cabal-ver: [latest]
 
     env:

--- a/src/github/workflows/haddock.yml
+++ b/src/github/workflows/haddock.yml
@@ -25,7 +25,7 @@ jobs:
         # not for the virtual environments, and also haskell/action/setup
         # is usually not up-to-date.
         os: [ubuntu-24.04]
-        ghc-ver: ['9.12.2']
+        ghc-ver: ['9.12.4']
           # Use the versions that come with the virtual environment, if possible.
 
     if: |

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        ghc-ver: [9.12.2, 9.10.3, 9.8.4, 9.6.7, 9.4.8, 9.2.8]
+        ghc-ver: [9.12.4, 9.10.3, 9.8.4, 9.6.7, 9.4.8, 9.2.8]
           # Andreas, 2022-03-26:
           # Note: ghc-ver needs to be spelled out with minor version, i.e., x.y.z
           # rather than x.y (which haskell-setup would resolve to a suitable .z)
@@ -59,9 +59,9 @@ jobs:
           # adding the respective stack-x.y.z.yaml file.
         include:
         - os: macos-15
-          ghc-ver: 9.12.2
+          ghc-ver: 9.12.4
         - os: windows-2025
-          ghc-ver: 9.12.2
+          ghc-ver: 9.12.4
 
     # # Try "allowed-failure" for Windows with GHC 9.2
     # continue-on-error: ${{ startsWith(matrix.os, 'windows') && startsWith(matrix.ghc-ver,'9.2') }}

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -59,7 +59,7 @@ env:
   # Andreas, 2022-03-26, 2022-11-28:
   # GHC_VER should be given as x.y.z (as opposed to x.y only)
   # because it is used verbatim when referring to stack-x.y.z.yaml.
-  GHC_VER: "9.12.2"
+  GHC_VER: "9.12.4"
 
   # Part 2: Variables that should not have to be changed
   ###########################################################################

--- a/stack-9.10.3.yaml
+++ b/stack-9.10.3.yaml
@@ -1,4 +1,4 @@
-resolver: lts-24.29
+resolver: lts-24.37
 compiler: ghc-9.10.3
 compiler-check: match-exact
 

--- a/stack-9.12.4.yaml
+++ b/stack-9.12.4.yaml
@@ -1,5 +1,5 @@
-resolver: nightly-2025-08-02
-compiler: ghc-9.12.2
+resolver: nightly-2026-04-15
+compiler: ghc-9.12.4
 compiler-check: match-exact
 
 # Local packages specified by relative directory name.


### PR DESCRIPTION
Remark: Tried to pass `--no-install-ghc` to Stack but this would also prevent it from installing MSYS under Windows.
One could try `--no-install-ghc --install-msys` instead by I don't want to crack up CI yet another time.