### PR TITLE
Highlighting and go-to-definition in the debug buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -395,7 +395,7 @@ Interaction and emacs mode
 --------------------------
 
 * Syntax highlighting and go-to-definition now also works in the Agda
-  information buffer in Emacs where goals etc. are displayed.
+  information and debug buffers in Emacs where goals etc. are displayed.
   This fixes long-standing [Issue #706](https://github.com/agda/agda/issues/706).
 
 * By temporarily turning on printing of hidden arguments

--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -1059,7 +1059,7 @@ major mode)."
   (setq agda2-buffer-external-status status)
   (force-mode-line-update))
 
-(defmacro agda2-information-buffer (buffer kind title)
+(defmacro agda2-information-buffer (buffer kind name-of-mode title)
   "Used to define functions like `agda2-info-buffer'."
   `(defun ,buffer nil
      ,(concat "Creates the Agda " kind
@@ -1070,7 +1070,7 @@ The buffer is returned.")
           (generate-new-buffer ,title))
 
     (with-current-buffer ,buffer
-      (compilation-mode "AgdaInfo")
+      (compilation-mode ,name-of-mode)
       ;; Support for jumping to positions mentioned in the text.
       (set (make-local-variable 'compilation-error-regexp-alist)
            '(("\\([\\\\/][^[:space:]]*\\):\\([0-9]+\\)\\.\\([0-9]+\\)\\(-\\(\\([0-9]+\\)\\.\\)?\\([0-9]+\\)\\)?"
@@ -1123,7 +1123,7 @@ The buffer is returned.")
 
   ,buffer))
 
-(agda2-information-buffer agda2-info-buffer "info" "*Agda information*")
+(agda2-information-buffer agda2-info-buffer "info" "AgdaInfo" "*Agda information*")
 
 (defun agda2-display-information-buffer ()
   "Make sure the Agda information buffer is displayed in the current window.
@@ -1978,18 +1978,24 @@ To do: dealing with semicolon separated decls."
 (defvar agda2-debug-buffer-name "*Agda debug*"
   "The name of the buffer used for Agda debug messages.")
 
-(defun agda2-verbose (msg)
+(defvar agda2-debug-buffer nil
+  "Agda debug buffer.")
+
+(agda2-information-buffer agda2-debug-buffer "debug" "AgdaDebug" agda2-debug-buffer-name)
+
+(defun agda2-verbose (msg &rest annotations)
   "Appends the string MSG plus a final newline
 to the `agda2-debug-buffer-name' buffer.
 Note that this buffer's contents is not erased automatically when
 a file is loaded."
- (declare (agda2-command (string)))
- (unless (string-empty-p msg)
-  (with-current-buffer (get-buffer-create agda2-debug-buffer-name)
-    (save-excursion
-      (goto-char (point-max))
-      (insert msg)
-      (newline)))))
+  (declare (agda2-command (string &repeat t)))
+  (unless (string-empty-p msg)
+    (with-current-buffer (agda2-debug-buffer)
+      (save-excursion
+        (goto-char (point-max))
+        (apply 'annotation-load "Click to jump to definition" nil msg annotations)
+        (insert msg)
+        (newline)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Comments and paragraphs
@@ -2404,9 +2410,8 @@ An attempt is made to preserve the default value of `agda2-mode-hook'."
     ;; Kill some buffers related to Agda.
     (when (buffer-live-p agda2-info-buffer)
       (kill-buffer agda2-info-buffer))
-    (when (and agda2-debug-buffer-name
-               (get-buffer agda2-debug-buffer-name))
-      (kill-buffer agda2-debug-buffer-name))
+    (when (buffer-live-p agda2-debug-buffer)
+      (kill-buffer agda2-debug-buffer))
 
     ;; Remove the Agda mode directory from the load path.
     (setq load-path (delete agda2-directory load-path))

--- a/src/full/Agda/Interaction/EmacsCommand.hs
+++ b/src/full/Agda/Interaction/EmacsCommand.hs
@@ -7,6 +7,7 @@ module Agda.Interaction.EmacsCommand
   ( displayInfo
   , clearRunningInfo
   , displayRunningInfo
+  , displayVerboseInfo
   ) where
 
 import Prelude hiding (null)
@@ -42,9 +43,7 @@ displayInfo header content append m = L $ concat
   , map Q ann
   ]
   where
-    (t, ann) = case m of
-      Nothing  -> (, [])                                $ treeToTextNoAnn   content
-      Just m2s -> second (lispifyHighlightingInfo_ m2s) $ treeToTextWithAnn content
+    (t, ann) = processAnnotations content m
 
 ------------------------------------------------------------------------
 -- Running info
@@ -63,3 +62,16 @@ clearRunningInfo = displayInfo runningInfoHeader empty False Nothing
 
 displayRunningInfo :: DocTree -> Maybe ModuleToSource -> Lisp String
 displayRunningInfo t = displayInfo runningInfoHeader t True
+
+displayVerboseInfo :: DocTree -> Maybe ModuleToSource -> Lisp String
+displayVerboseInfo t m = L $ concat
+  [ [ A "agda2-verbose"
+    , A (quote $ Text.unpack tx)]
+  , map Q anns]
+  where
+    (tx, anns) = processAnnotations t m
+
+processAnnotations :: DocTree -> Maybe ModuleToSource -> (Text.Text, [Lisp String])
+processAnnotations t = \case
+  Nothing  -> (, [])                                $ treeToTextNoAnn t
+  Just m2s -> second (lispifyHighlightingInfo_ m2s) $ treeToTextWithAnn t

--- a/src/full/Agda/Interaction/EmacsTop.hs
+++ b/src/full/Agda/Interaction/EmacsTop.hs
@@ -19,7 +19,6 @@ import Control.Monad.State    ( evalStateT )
 import Control.Monad.Trans    ( lift )
 
 import Data.List qualified as List
-import Data.Text qualified as Text
 
 import Agda.Syntax.Common
 import Agda.Syntax.Common.Pretty as P
@@ -37,13 +36,13 @@ import Agda.Interaction.Base
 import Agda.Interaction.BasicOps as B
 import Agda.Interaction.Response as R
 import Agda.Interaction.Emacs.Lisp
-import Agda.Interaction.EmacsCommand ( displayInfo, clearRunningInfo, displayRunningInfo)
+import Agda.Interaction.EmacsCommand ( displayInfo, clearRunningInfo, displayRunningInfo, displayVerboseInfo)
 import Agda.Interaction.Highlighting.Emacs
 import Agda.Interaction.Highlighting.Precise (TokenBased(..))
 import Agda.Interaction.Command (localStateCommandM)
 import Agda.Interaction.Options ( DiagnosticsColours(..), optDiagnosticsColour )
 
-import Agda.Utils.DocTree  ( treeToTextNoAnn, renderToTree )
+import Agda.Utils.DocTree  ( renderToTree )
 import Agda.Utils.Function ( applyWhen )
 import Agda.Utils.Functor  ( (<.>) )
 import Agda.Utils.Null
@@ -92,9 +91,7 @@ lispifyResponse = \case
 
   Resp_RunningInfo n docTree
     | n <= 1 -> displayRunningInfo docTree <$> wantBufferHighlighting
-    | otherwise ->
-        return $ L [ A "agda2-verbose", A (quote $ Text.unpack $ treeToTextNoAnn docTree) ]
-        -- TODO: do we want colored debug-printout?
+    | otherwise -> displayVerboseInfo docTree <$> wantBufferHighlighting
 
   Resp_Status s ->
     return $ L


### PR DESCRIPTION
Extends #8047 and #8071 to the debug buffer (output produced by enabling the `-v` flags). 

One thing I hadn't considered before opening this PR is that the debug buffer is never automatically cleared, so definition locations from earlier parts of the buffer may be outdated if one changes the code and then tries to revisit older logs, but that would be expected I guess? Even in the current state it helped me quite a lot when working on the "Print assumptions" command.

Example of the new output:
<img width="956" height="1030" alt="image" src="https://github.com/user-attachments/assets/94a08eab-f8e6-489c-a560-340ef1c96548" />
