### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,3 +33,7 @@ generally do not encourage LLM-assisted contributions.
 In particular, due to the limited time of the core team for reviewing issue
 reports and pull requests, we do not accept any contributions by external
 contributors that are created by or with the assistance of LLMs.
+
+Members of the Agda organization using LLMs for creating a contribution are
+expected to take full responsibility for both the quality and the legality of
+the code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing to Agda
+
+Thank you for your interest to contribute to Agda. Agda is developed by a small
+core group of volunteers and a larger group of occasional contributors, whose
+names can be found in our [LICENSE](https://github.com/agda/agda/blob/master/LICENSE).
+
+We are very grateful for contributions in different forms including but not
+limited to issue reports, feature requests, bug fixes, and improvements to the
+documentation and test suite. For new features, the desirability and design
+should be discussed in advance via a feature request before creating a pull
+request.
+
+## Coding guidelines
+
+All contributions are expected to be of high quality and not violate the
+copyright of any other projects. See
+[HACKING](https://github.com/agda/agda/blob/master/HACKING.md) for detailed
+guidelines on how to work with the Agda codebase.
+
+## AI Contribution Policy
+
+As a community, we are concerned about the negative effects of large language
+models (LLMs) on many individuals, our society, and our planet. Consequently we
+generally do not encourage LLM-assisted contributions.
+
+In particular, due to the limited time of the core team for reviewing issue
+reports and pull requests, we do not accept any contributions by external
+contributors that are created by or with the assistance of LLMs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,13 @@ documentation and test suite. For new features, the desirability and design
 should be discussed in advance via a feature request before creating a pull
 request.
 
+New contributors who are interested to contribute to Agda more structurally are
+encouraged to get in contact with the core developers via the #developers
+channel on the Agda Zulip
+(https://agda.zulipchat.com/#narrow/channel/259645-developers) or in person at
+one of the biannual Agda Meetings
+(https://wiki.portal.chalmers.se/agda/Main/AgdaMeetings).
+
 ## Coding guidelines
 
 All contributions are expected to be of high quality and not violate the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,12 @@ names can be found in our [LICENSE](https://github.com/agda/agda/blob/master/LIC
 
 We are very grateful for contributions in different forms including but not
 limited to issue reports, feature requests, bug fixes, and improvements to the
-documentation and test suite. For new features, the desirability and design
-should be discussed in advance via a feature request before creating a pull
-request.
+documentation and test suite.
+
+For adding new features to Agda, the desirability and design should be discussed
+in advance via a feature request before creating a pull request. We also expect
+contributors of new features to commit to maintaining that feature and be
+available to fix issues related to it as they come up.
 
 New contributors who are interested to contribute to Agda more structurally are
 encouraged to get in contact with the core developers via the #developers
@@ -23,17 +26,3 @@ All contributions are expected to be of high quality and not violate the
 copyright of any other projects. See
 [HACKING](https://github.com/agda/agda/blob/master/HACKING.md) for detailed
 guidelines on how to work with the Agda codebase.
-
-## AI Contribution Policy
-
-As a community, we are concerned about the negative effects of large language
-models (LLMs) on many individuals, our society, and our planet. Consequently we
-generally do not encourage LLM-assisted contributions.
-
-In particular, due to the limited time of the core team for reviewing issue
-reports and pull requests, we do not accept any contributions by external
-contributors that are created by or with the assistance of LLMs.
-
-Members of the Agda organization using LLMs for creating a contribution are
-expected to take full responsibility for both the quality and the legality of
-the code.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Getting Started
 Contributing to Agda
 --------------------
 
-* Contribution how-to: [`HACKING`](https://github.com/agda/agda/blob/master/HACKING.md)
+* [Contributing to Agda](https://github.com/agda/agda/blob/master/CONTRIBUTING.md)
 * [Haskell style-guide](https://github.com/andreasabel/haskell-style-guide/blob/master/haskell-style.md)
 
 [agdawiki]: http://wiki.portal.chalmers.se/agda/pmwiki.php


### PR DESCRIPTION
So... prepare to be disappointed. There has been a lot of discussion on the topic of LLMs in Agda, both in https://github.com/agda/agda/pull/8456 and during the Agda meeting this week. The main five issues that were discussed are the following:

1. **Workload caused by LLM-assisted issues and PRs**: This is addressed directly in this PR by banning all external contributions created by or with the use of LLMs. In the face of the inherent asymmetry between the time invested by the submitter and the reviewer created by LLMs, this seems appropriate and necessary.
2. **Quality of LLM-generated code**: The Agda project will continue to have the same standards for code quality as before, no matter in what way the code is produced.
3. **Negative effects on developers**: While these effects are definitely concerning, it is the responsibility of each individual to make their own decision in this matter. I neither can nor want to start policing what people do on their own computers.
4. **Legal concerns**: The legal status of LLM-generated code is currently unclear. However, this is mostly a problem for larger pieces of reusable code, and not so much for small changes or changes that are very specific to Agda. No matter in what way submitted code is produced, it remains the responsibility of the person submitting it to ensure that it does not violate any copyright.
5. **Ethical concerns** (including but not limited to surveillance, censorship, discrimination, labor violations, climate and ecological impact, impact on the hardware market, and centralization of power by Big Tech): This was by far the biggest and most controversial topic in the discussion, and we unfortunately did not reach a consensus. For me, it seems that this disagreement points to a deeper divide and lack of trust between some of the developers that can anyway not be resolved with a mere new policy. Hence this PR contains a clear statement that we are concerned by these developments, but currently does not include any concrete actions (other than the ban for external contributions mentioned above).

It is clear that some people wanted a much stronger policy than the one I am proposing here, and have expressed their clear intent to leave the project if they do not get their way. To those people: I am sad to see you go, but I have a great deal of respect for your steadfastness in your moral beliefs. To the rest of us who remain: I hope we can leave this dark page behind us and continue to work on improving Agda.