### PR TITLE
Dependencies: allow pqueue-1.7

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -512,7 +512,7 @@ library
     , nonempty-containers  >= 0.3.4.4   && < 0.4
     , parallel             >= 3.2.2.0   && < 3.4
     , peano                >= 0.1.0.1   && < 0.2
-    , pqueue               >= 1.4.3.0   && < 1.7
+    , pqueue               >= 1.4.3.0   && < 1.8
     , primitive            >= 0.7       && < 0.10
     , pretty               >= 1.1.3.6   && < 1.2
     , process              >= 1.6.16.0  && < 1.7


### PR DESCRIPTION

- Downstream issue: https://github.com/commercialhaskell/stackage/issues/7987
- [x] We need to revise 2.8.0 to allow pqueue-1.7.