### PR TITLE
Guarded TT: move part of LaterPrims to Agda.Primitive and test/Common

### DIFF
--- a/src/data/lib/prim/Agda/Primitive/Guarded.agda
+++ b/src/data/lib/prim/Agda/Primitive/Guarded.agda
@@ -1,6 +1,8 @@
 {-# OPTIONS --guarded --cubical=compatible #-}
 module Agda.Primitive.Guarded where
 
+open import Agda.Builtin.Equality
+
 module Prims where
   primitive
     primLockUniv : Set₁
@@ -10,3 +12,8 @@ open Prims renaming (primLockUniv to LockU) public
 -- We postulate Tick as it is supposed to be an abstract sort.
 postulate
   Tick : LockU
+
+postulate
+  löb : ∀ {l} {A : Set l} → (((@tick x : Tick) → A) → A) → A
+  löbβ : ∀ {l} {A : Set l} → (f : ((@tick x : Tick) → A) → A) → löb f ≡ f (λ _ → (löb f))
+    -- So in Cubical Agda, we will have to extract a path from löbβ.

--- a/src/data/lib/prim/Agda/Primitive/Guarded.agda
+++ b/src/data/lib/prim/Agda/Primitive/Guarded.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --guarded --cubical=compatible #-}
+module Agda.Primitive.Guarded where
+
+module Prims where
+  primitive
+    primLockUniv : Set₁
+
+open Prims renaming (primLockUniv to LockU) public
+
+-- We postulate Tick as it is supposed to be an abstract sort.
+postulate
+  Tick : LockU

--- a/test/Common/Guarded/Core.agda
+++ b/test/Common/Guarded/Core.agda
@@ -1,0 +1,31 @@
+{-# OPTIONS --guarded --cubical=compatible #-}
+module Common.Guarded.Core where
+
+open import Agda.Primitive
+open import Agda.Primitive.Guarded
+
+private
+  variable
+    l : Level
+    A B : Set l
+
+▹_ : ∀ {l} → Set l → Set l
+▹_ A = (@tick x : Tick) -> A
+
+▸_ : ∀ {l} → ▹ Set l → Set l
+▸ A = (@tick x : Tick) → A x
+
+next : A → ▹ A
+next x _ = x
+
+_⊛_ : ▹ (A → B) → ▹ A → ▹ B
+_⊛_ f x a = f a (x a)
+
+map▹ : (f : A → B) → ▹ A → ▹ B
+map▹ f x α = f (x α)
+
+data gStream (A : Set) : Set where
+  cons : (x : A) (xs : ▹ gStream A) → gStream A
+
+map-gStream : ∀ {A B : Set} → (A → B) → gStream A → gStream B
+map-gStream f = löb \ map-gStream' → \ { (cons a as) → cons (f a) \ α → map-gStream' α (as α) }

--- a/test/Common/Guarded/Cubical.agda
+++ b/test/Common/Guarded/Cubical.agda
@@ -1,0 +1,20 @@
+{-# OPTIONS --cubical --guarded #-}
+module Common.Guarded.Cubical where
+
+open import Agda.Primitive
+open import Agda.Primitive.Cubical renaming (itIsOne to 1=1)
+open import Agda.Primitive.Guarded renaming (löbβ to löbβ-Id)
+open import Agda.Builtin.Cubical.Path
+open import Common.Guarded.Core
+import Common.Equality as Id
+
+private
+  variable
+    l : Level
+    A B : Set l
+
+later-ext : ∀ {A : Set} → {f g : ▹ A} → (▸ \ α → f α ≡ g α) → f ≡ g
+later-ext eq = \ i α → eq α i
+
+löbβ : ∀ {l} {A : Set l} → (f : ▹ A → A) → löb f ≡ f (next (löb f))
+löbβ f = Id.subst (λ a → löb f ≡ a) (löbβ-Id f) (λ i → löb f)

--- a/test/Succeed/LaterPrims.agda
+++ b/test/Succeed/LaterPrims.agda
@@ -6,26 +6,13 @@ open import Agda.Primitive.Cubical renaming (itIsOne to 1=1)
 open import Agda.Primitive.Guarded
 open import Agda.Builtin.Cubical.Path
 open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_]; primSubOut to outS)
+open import Common.Guarded.Core
+open import Common.Guarded.Cubical
 
 private
   variable
     l : Level
     A B : Set l
-
-▹_ : ∀ {l} → Set l → Set l
-▹_ A = (@tick x : Tick) -> A
-
-▸_ : ∀ {l} → ▹ Set l → Set l
-▸ A = (@tick x : Tick) → A x
-
-next : A → ▹ A
-next x _ = x
-
-_⊛_ : ▹ (A → B) → ▹ A → ▹ B
-_⊛_ f x a = f a (x a)
-
-map▹ : (f : A → B) → ▹ A → ▹ B
-map▹ f x α = f (x α)
 
 transpLater : ∀ (A : I → ▹ Set) → ▸ (A i0) → ▸ (A i1)
 transpLater A u0 a = primTransp (\ i → A i a) i0 (u0 a)
@@ -52,8 +39,6 @@ ap f eq = \ i → f (eq i)
 
 _$>_ : ∀ {A B : Set} {f g : A → B} → f ≡ g → ∀ x → f x ≡ g x
 eq $> x = \ i → eq i x
-later-ext : ∀ {A : Set} → {f g : ▹ A} → (▸ \ α → f α ≡ g α) → f ≡ g
-later-ext eq = \ i α → eq α i
 
 postulate
   dfix : ∀ {l} {A : Set l} → (▹ A → A) → ▹ A
@@ -64,10 +49,6 @@ pfix' f α i = pfix f i α
 
 fix : ∀ {l} {A : Set l} → (▹ A → A) → A
 fix f = f (dfix f)
-
-data gStream (A : Set) : Set where
-  cons : (x : A) (xs : ▹ gStream A) → gStream A
-
 
 repeat : ∀ {A : Set} → A → gStream A
 repeat a = fix \ repeat▹ → cons a repeat▹

--- a/test/Succeed/LaterPrims.agda
+++ b/test/Succeed/LaterPrims.agda
@@ -3,23 +3,14 @@ module LaterPrims where
 
 open import Agda.Primitive
 open import Agda.Primitive.Cubical renaming (itIsOne to 1=1)
+open import Agda.Primitive.Guarded
 open import Agda.Builtin.Cubical.Path
 open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_]; primSubOut to outS)
-
-module Prims where
-  primitive
-    primLockUniv : Set₁
-
-open Prims renaming (primLockUniv to LockU) public
 
 private
   variable
     l : Level
     A B : Set l
-
--- We postulate Tick as it is supposed to be an abstract sort.
-postulate
-  Tick : LockU
 
 ▹_ : ∀ {l} → Set l → Set l
 ▹_ A = (@tick x : Tick) -> A


### PR DESCRIPTION
So far, the only importable file containing useful reusable combinators for `--guarded` was `test/Succeed/LaterPrims.agda`.
This PR consists of two commits:

1. The first one moves some of this into Agda.Primitive. This is where primitives that users may want to use, should be made available. We also put the `Tick`, `löb` and `löbβ` postulates there, so that they are not precluded by the `--safe` flag. 
   
   The `löb` postulate has a different type than @Saizan 's `dfix` postulate: its output is available now, rather than after 1 tick (as is usually the case in theory papers). These are logically equivalent, as per `next` and `f` (the function we take a fixpoint of). This is also how @Saizan implements `fix`, which however unfolds definitionally 1x before unfolding propositionally ∞ times. That idea generalizes to a fuelled löb induction as I have implemented [here](https://github.com/anuyts/public/blob/main/agda/guarded/LaterPrimsMLTT.agda) and would like to contribute to some Agda library/ies.

2. The second one (which I don't feel strongly about, it seemed more useful before I set about it than afterwards) moves/copies/adapts some combinators into the test/Common library.

This was discussed a bit with @andreasabel 