### PR TITLE
Serialize fewer generalization records

### DIFF
--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -164,8 +164,11 @@ instance NamesIn Defn where
     PrimitiveSort _ s  -> namesAndMetasIn' sg s
     AbstractDefn{}     -> __IMPOSSIBLE__
     -- Andreas 2017-07-27, Q: which names can be in @cc@ which are not already in @cl@?
-    Function cl cc _ _ _ _ _ _ _ _ el _ _ _
-      -> namesAndMetasIn' sg (cl, cc, el)
+    Function cl cc _ _ _ _ _ prj _ _ el _ _ _
+      -- Andreas, 2025-11-18, issue #8037
+      -- When copying the record type along with one of its projections in a module application,
+      -- we need to make sure the record type has not been deleted as deadcode.
+      -> namesAndMetasIn' sg (cl, cc, el, prj)
     Datatype _ _ cl cs s _ _ _ _ trX trD
       -> namesAndMetasIn' sg (cl, cs, s, trX, trD)
     Record _ cl c _ fs recTel _ _ _ _ _ _ _ comp
@@ -178,6 +181,20 @@ instance NamesIn Defn where
 instance NamesIn Clause where
   namesAndMetasIn' sg (Clause _ _ tel ps b t _ _ _ _ _) =
     namesAndMetasIn' sg (tel, ps, b, t)
+
+instance NamesIn ProjectionLikenessMissing where
+  {-# INLINE namesAndMetasIn' #-}
+  namesAndMetasIn' _ = mempty
+
+instance NamesIn Projection where
+  {-# INLINE namesAndMetasIn' #-}
+  namesAndMetasIn' sg p = namesAndMetasIn' sg (projProper p)
+
+instance (NamesIn a, NamesIn b) => NamesIn (Either a b) where
+  {-# INLINE namesAndMetasIn' #-}
+  namesAndMetasIn' sg = \case
+    Left a  -> namesAndMetasIn' sg a
+    Right b -> namesAndMetasIn' sg b
 
 instance NamesIn CompiledClauses where
   namesAndMetasIn' sg = \case

--- a/src/full/Agda/TypeChecking/DeadCode.hs
+++ b/src/full/Agda/TypeChecking/DeadCode.hs
@@ -61,10 +61,6 @@ eliminateDeadCode !scope = Bench.billTo [Bench.DeadCode] $ do
 
       extraRootsFilter (name, def)
         | hasCompilePragma def || isPrimitive (theDef def) = Just name
-          -- Andreas, 2025-11-18, issue #8037
-          -- When copying the record type along with one of its projections in a module application,
-          -- we need to make sure the record type has not been deleted as deadcode.
-        | Just Projection{ projProper = Just r } <- isProjection_ (theDef def) = Just r
         | otherwise = Nothing
 
   let !pubModules = publicModules scope


### PR DESCRIPTION
Previously, all record types created by `TypeChecking.Generalize` ended up in interfaces because of d2f238c408d1c3751f3bc4942257ad2300187a0a, which effectively marked all non-empty record types as alive for DeadCode. We remove this marking and instead modify dead code elimination to visit record types whenever a record field is visited. As a result, almost all Generalize record types (and fields and constructors) should end up as dead.

Some record types may remain in interfaces:

- through definitions of *extended lambdas* that occur in generalized types. Normally, the record types are eliminated by the "unpacking substitution" in `Generalize`, but this substitution does not go into extended lambda definitions.
- through local `open`-s, which likewise create definitions that are parametrized over the generalizing record. This is being observed in #7551

In TypeTopology f9352e8e, total build size goes from 146.1MB to 142.8MB. 
