### PR TITLE
Remove inaccurate claim in two-level.lagda.rst

### DIFF
--- a/doc/user-manual/language/two-level.lagda.rst
+++ b/doc/user-manual/language/two-level.lagda.rst
@@ -40,8 +40,7 @@ Function-types belong to ``Set`` if both their domain and codomain do,
 and to ``SSet`` otherwise.  Records and datatypes can always be
 declared to belong to ``SSet``, and can be declared to belong to
 ``Set`` instead if all their inputs belong to ``Set``.  In particular,
-any type in ``Set`` has an isomorphic copy in ``SSet`` defined as a
-trivial record::
+any type in ``Set`` can be lifted to ``SSet`` using a trivial record::
 
   record c (A : Set) : SSet where
     constructor ↑


### PR DESCRIPTION
The two-level page claims that the record in SSet is an isomorphic copy of its argument from Set.
The image cannot be isomorphic in general, since types need not be h-sets, but everything in SSet is one due to UIP.

I use the word "lift" because being a datatype being in Set is a stricter condition than being in SSet, although the analogy breaks a bit (Set can't be eliminated into SSet)

I think there might be a better word?