### PR TITLE
Update inaccurate Agda example in record-types.lagda.rst

### DIFF
--- a/doc/user-manual/language/record-types.lagda.rst
+++ b/doc/user-manual/language/record-types.lagda.rst
@@ -639,6 +639,7 @@ can be changed globally by option :option:`--no-eta-equality`.
     record Rec : Set where
       constructor con
       no-eta-equality
+      pattern
       field
         f : Nat
     open Rec
@@ -646,7 +647,7 @@ can be changed globally by option :option:`--no-eta-equality`.
     eta : (r : Rec) → r ≡ con (f r)
     eta (con n) = refl
 
-    bar : R
+    bar : Rec
     f bar = 0
 
   If this code were allowed, then ``eta bar`` is a closed term of type


### PR DESCRIPTION
There is a note in "Record Types" documentation page that reads:

> It is not allowed to use copattern matching to define values of inductive record types with pattern matching enabled.

Then, the documentation gives an example that should fail as explained in the note:

> If this code were allowed [...] (contradicting the no-eta-equality directive) or else [...] (breaking canonicity).

But the given example only uses "no-eta-equality", without "pattern". When we change `R` to `Rec` and compile in the nightly `agda-2.9.0` from nix, we get the following error:

```
% agda Rec2.agda
Checking Rec2 (/.../Rec2.agda).
/.../Rec2.agda:14.6-11: error: [SplitOnNonEtaRecord]
Pattern matching on no-eta record type Rec
(defined at /.../Rec2.agda:6.8-11)
is not allowed
(to activate, add declaration `pattern` to record definition)
when checking that the pattern con n has type Rec
```

When we add the `pattern`, as in the proposed code, we get the following error:

```
% agda Rec3.agda
Checking Rec3 (/.../Rec3.agda).
/.../Rec3.agda:18.1-6: error: [ComatchingDisabledForRecord]
Copattern matching is disabled for record Rec
when checking the clause left hand side
f bar
```

This error expresses the issue in the note in the documentation. Therefore, we update the documentation example in "record-types.lagda.rst" to have both `no-eta-equality` and `pattern` as a failing example. We also run a version with `eta-equality` which type-checks successfully with the `bar : R` to `bar : Rec` change, as expected.

Agda Version (from nix):
```
% agda --version
Agda version 2.9.0-7020343
Built with flags (cabal -f)
 - optimise-heavily: extra optimisations
 - use-xdg-data-home: install and locate data files under $XDG_DATA_HOME/agda/$AGDA_VERSION by default instead of the location defined by Cabal
 ``` 