### PR TITLE
Fix #8529

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -692,7 +692,7 @@ niceDeclarations fixs ds = do
       Record{}                      -> True
       RecordSig{}                   -> True
       RecordDef{}                   -> True
-      Pragma p | isAttachedPragma p -> canHaveNoPositivityCheckPragma ds
+      Pragma p | isAttachedPragma p -> canHaveNoUniverseCheckPragma ds
       _                             -> False
 
     -- Pragma that attaches to the following declaration.

--- a/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
@@ -206,50 +206,40 @@ loneSigsFromLoneNames = Map.fromListWith __IMPOSSIBLE__ . map (\(r,x,k) -> (x, L
 terminationCheckPragma :: Lens' NiceState TerminationCheck
 terminationCheckPragma f e = f (_termChk e) <&> \ s -> e { _termChk = s }
 
+-- | Set 'terminationCheckPragma' to given value for a local computation.
+
 withTerminationCheckPragma :: TerminationCheck -> Nice a -> Nice a
-withTerminationCheckPragma tc f = do
-  tc_old <- use terminationCheckPragma
-  terminationCheckPragma .= tc
-  result <- f
-  terminationCheckPragma .= tc_old
-  return result
+withTerminationCheckPragma = locallyState terminationCheckPragma . const
+
+-- | Lens for field '_covChk'.
 
 coverageCheckPragma :: Lens' NiceState CoverageCheck
 coverageCheckPragma f e = f (_covChk e) <&> \ s -> e { _covChk = s }
 
+-- | Set 'coverageCheckPragma' to given value for a local computation.
+
 withCoverageCheckPragma :: CoverageCheck -> Nice a -> Nice a
-withCoverageCheckPragma tc f = do
-  tc_old <- use coverageCheckPragma
-  coverageCheckPragma .= tc
-  result <- f
-  coverageCheckPragma .= tc_old
-  return result
+withCoverageCheckPragma = locallyState coverageCheckPragma . const
 
 -- | Lens for field '_posChk'.
 
 positivityCheckPragma :: Lens' NiceState PositivityCheck
 positivityCheckPragma f e = f (_posChk e) <&> \ s -> e { _posChk = s }
 
+-- | Set 'positivityCheckPragma' to given value for a local computation.
+
 withPositivityCheckPragma :: PositivityCheck -> Nice a -> Nice a
-withPositivityCheckPragma pc f = do
-  pc_old <- use positivityCheckPragma
-  positivityCheckPragma .= pc
-  result <- f
-  positivityCheckPragma .= pc_old
-  return result
+withPositivityCheckPragma = locallyState positivityCheckPragma . const
 
 -- | Lens for field '_uniChk'.
 
 universeCheckPragma :: Lens' NiceState UniverseCheck
 universeCheckPragma f e = f (_uniChk e) <&> \ s -> e { _uniChk = s }
 
+-- | Set 'universeCheckPragma' to given value for a local computation.
+
 withUniverseCheckPragma :: UniverseCheck -> Nice a -> Nice a
-withUniverseCheckPragma uc f = do
-  uc_old <- use universeCheckPragma
-  universeCheckPragma .= uc
-  result <- f
-  universeCheckPragma .= uc_old
-  return result
+withUniverseCheckPragma = locallyState universeCheckPragma . const
 
 -- | Get universe check pragma from a data/rec signature.
 --   Defaults to 'YesUniverseCheck'.
@@ -270,13 +260,10 @@ popCatchallPragma = do
   catchallPragma .= empty
   return ca
 
+-- | Set 'catchallPragma' to given value for a local computation.
+
 withCatchallPragma :: Catchall -> Nice a -> Nice a
-withCatchallPragma ca f = do
-  ca_old <- use catchallPragma
-  catchallPragma .= ca
-  result <- f
-  catchallPragma .= ca_old
-  return result
+withCatchallPragma = locallyState catchallPragma . const
 
 -- | Add a new warning.
 niceWarning :: DeclarationWarning -> Nice ()

--- a/test/Fail/Issue8529.agda
+++ b/test/Fail/Issue8529.agda
@@ -1,0 +1,19 @@
+-- Andreas, 2026-04-22, issue 8529
+-- NO_UNIVERSE_CHECK does not attach to mutual blocks.
+-- Bug: if you repeat it, it does, due to a cut-and-paste error in Syntax.Concrete.Definitions.
+
+module _ where
+
+{-# NO_UNIVERSE_CHECK #-}   -- WAS: No deadcode highlighting
+{-# NO_UNIVERSE_CHECK #-}   -- Deadcode highlighting
+mutual
+  data D1 : Set where
+    wrap : D2 → D1          -- WAS: No error: [ConstructorDoesNotFitInData]
+
+  data D2 : Set1 where
+    wrap : Set → D2
+
+-- Expected error: [ConstructorDoesNotFitInData]
+-- Constructor wrap
+-- of inferred sort Set₁
+-- does not fit into data type of sort Set.

--- a/test/Fail/Issue8529.err
+++ b/test/Fail/Issue8529.err
@@ -1,0 +1,15 @@
+
+Issue8529.agda:7.1-26: warning: -W[no]InvalidNoUniverseCheckPragma
+NO_UNIVERSE_CHECKING pragmas can only precede a data/record
+definition.
+
+Issue8529.agda:8.1-26: warning: -W[no]InvalidNoUniverseCheckPragma
+NO_UNIVERSE_CHECKING pragmas can only precede a data/record
+definition.
+Issue8529.agda:11.5-9: error: [ConstructorDoesNotFitInData]
+Constructor wrap
+of inferred sort Set₁
+does not fit into data type of sort Set.
+(Reason: Set₁ is not less or equal than Set)
+when checking that the type D2 of an argument to the constructor
+wrap fits in the sort Set of the datatype.


### PR DESCRIPTION
- **Refactor: use locallyState in Syntax.Concrete.Definitions.with???Pragma**
  Less cut and paste, would have prevented issue #3327.
  

- **Fix #8529 by correcting cut-and-paste error**
  