### PR TITLE
Clean nicifier: remove superfluous NO_UNIVERSE_CHECK propagation

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -409,7 +409,6 @@ niceDeclarations fixs ds = do
           -- Universe check is performed if both the current value of
           -- 'universeCheckPragma' AND the one from the signature say so.
           uc <- use universeCheckPragma
-          uc <- if uc == NoUniverseCheck then return uc else getUniverseCheckFromSig x
           (pc, uc) <- retrieveTypeSig (DataName pc uc) x >>= \case
              DataName pc uc -> pure (pc, uc)
              _ -> __IMPOSSIBLE__
@@ -443,7 +442,6 @@ niceDeclarations fixs ds = do
           -- Universe check is performed if both the current value of
           -- 'universeCheckPragma' AND the one from the signature say so.
           uc <- use universeCheckPragma
-          uc <- if uc == NoUniverseCheck then return uc else getUniverseCheckFromSig x
           (pc, uc) <- retrieveTypeSig (RecName pc uc) x >>= \case
             RecName pc uc -> pure (pc, uc)
             _ -> __IMPOSSIBLE__

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -397,12 +397,7 @@ niceDeclarations fixs ds = do
 
         Data r erased x tel t cs -> do
           pc <- use positivityCheckPragma
-          -- Andreas, 2018-10-27, issue #3327
-          -- Propagate {-# NO_UNIVERSE_CHECK #-} pragma from signature to definition.
-          -- Universe check is performed if both the current value of
-          -- 'universeCheckPragma' AND the one from the signature say so.
           uc <- use universeCheckPragma
-          uc <- if uc == NoUniverseCheck then return uc else getUniverseCheckFromSig x
           (,ds) <$> dataOrRec pc uc NiceDataDef
                       (flip NiceDataSig erased) (niceAxioms DataBlock) r
                       x (Just (tel, t)) (Just (parametersToDefParameters tel, cs))
@@ -434,12 +429,7 @@ niceDeclarations fixs ds = do
 
         Record r erased x dir tel t cs -> do
           pc <- use positivityCheckPragma
-          -- Andreas, 2018-10-27, issue #3327
-          -- Propagate {-# NO_UNIVERSE_CHECK #-} pragma from signature to definition.
-          -- Universe check is performed if both the current value of
-          -- 'universeCheckPragma' AND the one from the signature say so.
           uc <- use universeCheckPragma
-          uc <- if uc == NoUniverseCheck then return uc else getUniverseCheckFromSig x
           (,ds) <$> dataOrRec pc uc
                       (\r o a pc uc x tel cs ->
                         NiceRecDef r o a pc uc x dir tel cs)

--- a/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
@@ -241,12 +241,6 @@ universeCheckPragma f e = f (_uniChk e) <&> \ s -> e { _uniChk = s }
 withUniverseCheckPragma :: UniverseCheck -> Nice a -> Nice a
 withUniverseCheckPragma = locallyState universeCheckPragma . const
 
--- | Get universe check pragma from a data/rec signature.
---   Defaults to 'YesUniverseCheck'.
-
-getUniverseCheckFromSig :: Name -> Nice UniverseCheck
-getUniverseCheckFromSig x = maybe YesUniverseCheck universeCheck <$> getSig x
-
 -- | Lens for field '_catchall'.
 
 catchallPragma :: Lens' NiceState Catchall


### PR DESCRIPTION
- **Refactor: remove superfluous code introduced by #3424**
  This code is only relevant for {Data/Record}Def, not for Data/Record,
  since the latter have no preceding {Data/Record}Sig.
  
  See comments:
  - https://github.com/agda/agda/pull/3424/changes#r3123893191
  - https://github.com/agda/agda/pull/3424/changes#r3123895551
  

- **Refactor: getUniverseCheckFromSig is superfluous since #8433**
  See comments:
  - https://github.com/agda/agda/pull/8433/changes#r3123932028
  - https://github.com/agda/agda/pull/8433/changes#r3123933291
  