### PR TITLE
Fix #6670 #5411 #6240 generalizeTel with open

### DIFF
--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -184,12 +184,12 @@ generalizeTelescope vars typecheckAction ret = billTo [Typing, Generalize] $ wit
       return (xs, tel, lbs, anons)
   sectionsAfter <- useTC (stSignature . sigSections)
   definitionsAfter <- useTC (stSignature . sigDefinitions)
-  let sectionApps = Map.keysSet $ Map.difference sectionsAfter sectionsBefore
+  let newSections = Map.keysSet $ Map.difference sectionsAfter sectionsBefore
       sectionDefs = Set.fromList
         [ q
         | q <- HMap.keys definitionsAfter
         , not $ HMap.member q definitionsBefore
-        , Set.member (qnameModule q) sectionApps
+        , Set.member (qnameModule q) newSections
         ]
       newAnonymousModules = take' (length anonymousModules - length anonymousModulesBefore) anonymousModules
 
@@ -228,20 +228,25 @@ generalizeTelescope vars typecheckAction ret = billTo [Typing, Generalize] $ wit
   -- And we shouldn't forget about the let-bindings (#3470)
   --   Γ (r : R) Θ ⊢ letbinds
   --   Γ Δ Θρ      ⊢ letbinds' = letbinds(lift |Θ| ρ)
+  letbinds' <- applySubst (liftS (size tel) sub) <$> instantiateFull letbinds
   -- And sections created by module applications in the telescope (#6916)
   --   Γ (r : R) ⊢ Σ            Σ = sectionApps
   --   Γ Δ       ⊢ Σρ
-  letbinds' <- applySubst (liftS (size tel) sub) <$> instantiateFull letbinds
-  rewriteGeneralizedSectionsAndDefinitions sub sectionApps sectionDefs
-  let addLet (x, LetBinding isAxiom o v dom) = addLetBinding' isAxiom o x v dom
-      addAnonymousModule (m, n) = withAnonymousModule m n
+  forM_ newSections \ m -> do
+    sec <- fromMaybe __IMPOSSIBLE__ <$> getSection m
+    tel <- applySubst sub <$> instantiateFull (sec ^. secTelescope)
+    modifySignature $ over sigSections $ Map.adjust (set secTelescope tel) m
+      -- TODO: do we need to update the module checkpoint for m
+  forM_ sectionDefs \ q -> do
+    t <- applySubst sub <$> do instantiateFull . defType =<< getConstInfo q
+    modifySignature $ updateDefinition q $ updateDefType $ const t
 
+  let addLet (x, LetBinding isAxiom o v dom) = addLetBinding' isAxiom o x v dom
   updateContext sub (cxPrepend genTelCxt . cxDrop 1) $
     updateContext (raiseS (size tel')) (cxPrepend newTelCxt) $
-      foldr addAnonymousModule
-        (foldr addLet (ret genTelVars $ abstract genTel tel') letbinds')
-        newAnonymousModules
-
+      flip (foldr $ uncurry withAnonymousModule) newAnonymousModules $
+      flip (foldr addLet) letbinds' $
+      ret genTelVars $ abstract genTel tel'
 
 -- | Generalize a type over a set of (used) generalizable variables.
 generalizeType :: Set QName -> TCM Type -> TCM ([Maybe QName], Type)
@@ -278,17 +283,6 @@ createMetasAndTypeCheck s typecheckAction = do
     x <- locallyTC eGeneralizedVars (const genvals) typecheckAction
     return (metamap, x)
   return (x, namedMetas, allmetas)
-
-rewriteGeneralizedSectionsAndDefinitions :: Substitution -> Set ModuleName -> Set QName -> TCM ()
-rewriteGeneralizedSectionsAndDefinitions sub sections definitions = do
-  forM_ (Set.toList sections) $ \ m ->
-    whenJustM (Map.lookup m <$> useTC (stSignature . sigSections)) $ \ sec -> do
-      tel <- applySubst sub <$> instantiateFull (sec ^. secTelescope)
-      modifySignature $ over sigSections $ Map.adjust (set secTelescope tel) m
-  forM_ (Set.toList definitions) $ \ q ->
-    whenJustM (HMap.lookup q <$> useTC (stSignature . sigDefinitions)) $ \ def -> do
-      t <- applySubst sub <$> instantiateFull (defType def)
-      modifySignature $ updateDefinition q $ updateDefType $ const t
 
 -- | Add a placeholder variable that will be substituted with a record value packing up all the
 --   generalized variables.

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -124,6 +124,7 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.HashMap.Strict qualified as HMap
 import Data.List (partition, sortBy)
 import Data.Monoid
 
@@ -171,12 +172,26 @@ import qualified Agda.Utils.VarSet as VarSet
 generalizeTelescope :: Map QName Name -> (forall a. (Telescope -> TCM a) -> TCM a) -> ([Maybe Name] -> Telescope -> TCM a) -> TCM a
 generalizeTelescope vars typecheckAction ret | Map.null vars = typecheckAction (ret [])
 generalizeTelescope vars typecheckAction ret = billTo [Typing, Generalize] $ withGenRecVar $ \ genRecMeta -> do
+  sectionsBefore <- useTC (stSignature . sigSections)
+  definitionsBefore <- useTC (stSignature . sigDefinitions)
+  anonymousModulesBefore <- viewTC eAnonymousModules
   let s = Map.keysSet vars
-  ((cxtNames, tel, letbinds), namedMetas, allmetas) <-
+  ((cxtNames, tel, letbinds, anonymousModules), namedMetas, allmetas) <-
     createMetasAndTypeCheck s $ typecheckAction $ \ tel -> do
       xs <- take' (size tel) <$> getContextNames'
       lbs <- getLetBindings -- This gives let-bindings valid in the current context
-      return (xs, tel, lbs)
+      anons <- viewTC eAnonymousModules
+      return (xs, tel, lbs, anons)
+  sectionsAfter <- useTC (stSignature . sigSections)
+  definitionsAfter <- useTC (stSignature . sigDefinitions)
+  let sectionApps = Map.keysSet $ Map.difference sectionsAfter sectionsBefore
+      sectionDefs = Set.fromList
+        [ q
+        | q <- HMap.keys definitionsAfter
+        , not $ HMap.member q definitionsBefore
+        , Set.member (qnameModule q) sectionApps
+        ]
+      newAnonymousModules = take' (length anonymousModules - length anonymousModulesBefore) anonymousModules
 
   reportSDoc "tc.generalize.metas" 60 $ vcat
     [ "open metas =" <+> (text . show . fmap ((miNameSuggestion &&& miGeneralizable) . mvInfo)) (openMetas $ allmetas)
@@ -213,14 +228,19 @@ generalizeTelescope vars typecheckAction ret = billTo [Typing, Generalize] $ wit
   -- And we shouldn't forget about the let-bindings (#3470)
   --   Γ (r : R) Θ ⊢ letbinds
   --   Γ Δ Θρ      ⊢ letbinds' = letbinds(lift |Θ| ρ)
-  -- And modules created in the telescope (#6916)
-  --   TODO
+  -- And sections created by module applications in the telescope (#6916)
+  --   Γ (r : R) ⊢ Σ            Σ = sectionApps
+  --   Γ Δ       ⊢ Σρ
   letbinds' <- applySubst (liftS (size tel) sub) <$> instantiateFull letbinds
+  rewriteGeneralizedSectionsAndDefinitions sub sectionApps sectionDefs
   let addLet (x, LetBinding isAxiom o v dom) = addLetBinding' isAxiom o x v dom
+      addAnonymousModule (m, n) = withAnonymousModule m n
 
   updateContext sub (cxPrepend genTelCxt . cxDrop 1) $
     updateContext (raiseS (size tel')) (cxPrepend newTelCxt) $
-      foldr addLet (ret genTelVars $ abstract genTel tel') letbinds'
+      foldr addAnonymousModule
+        (foldr addLet (ret genTelVars $ abstract genTel tel') letbinds')
+        newAnonymousModules
 
 
 -- | Generalize a type over a set of (used) generalizable variables.
@@ -258,6 +278,17 @@ createMetasAndTypeCheck s typecheckAction = do
     x <- locallyTC eGeneralizedVars (const genvals) typecheckAction
     return (metamap, x)
   return (x, namedMetas, allmetas)
+
+rewriteGeneralizedSectionsAndDefinitions :: Substitution -> Set ModuleName -> Set QName -> TCM ()
+rewriteGeneralizedSectionsAndDefinitions sub sections definitions = do
+  forM_ (Set.toList sections) $ \ m ->
+    whenJustM (Map.lookup m <$> useTC (stSignature . sigSections)) $ \ sec -> do
+      tel <- applySubst sub <$> instantiateFull (sec ^. secTelescope)
+      modifySignature $ over sigSections $ Map.adjust (set secTelescope tel) m
+  forM_ (Set.toList definitions) $ \ q ->
+    whenJustM (HMap.lookup q <$> useTC (stSignature . sigDefinitions)) $ \ def -> do
+      t <- applySubst sub <$> instantiateFull (defType def)
+      modifySignature $ updateDefinition q $ updateDefType $ const t
 
 -- | Add a placeholder variable that will be substituted with a record value packing up all the
 --   generalized variables.

--- a/test/Succeed/Issue5411.agda
+++ b/test/Succeed/Issue5411.agda
@@ -1,0 +1,27 @@
+-- Andreas, 2026-04-30, issue #5411, duplicate of #6770
+
+open import Agda.Primitive
+
+module _ (Sort : Set) (Foo : Set) where
+
+record Setoid ℓ : Set (lsuc ℓ) where
+  field Carrier : Set ℓ
+
+record SetoidModel ℓ : Set (lsuc ℓ) where
+  field Den : Sort → Setoid ℓ
+
+variable
+  ℓ : Level  -- necessary
+
+module Works (M : SetoidModel ℓ) where
+  open SetoidModel M
+  postulate works : ∀ s → Den s .Setoid.Carrier
+
+module Test (M : SetoidModel ℓ) (open SetoidModel M) where
+  postulate test : ∀ s → Den s .Setoid.Carrier
+
+-- (Foo → Setoid (ℓ _24)) !=< Setoid _ℓ_23
+-- when checking that the inferred type of an application
+--   Foo → Setoid (ℓ _24)
+-- matches the expected type
+--   Setoid _ℓ_23

--- a/test/Succeed/Issue6770.agda
+++ b/test/Succeed/Issue6770.agda
@@ -1,0 +1,10 @@
+postulate A : Set
+
+module M (x : A) where
+  postulate a : A
+
+variable x : A
+
+module _ (open M x) where
+  _ : A
+  _ = a

--- a/test/Succeed/Issue6770.agda
+++ b/test/Succeed/Issue6770.agda
@@ -1,3 +1,6 @@
+-- Andreas, 2026-04-30, issue #6770, reported by Orestis Melkonian
+-- Shrunk test case by Szumi Xi
+
 postulate A : Set
 
 module M (x : A) where
@@ -8,3 +11,12 @@ variable x : A
 module _ (open M x) where
   _ : A
   _ = a
+
+-- WAS: error [UnequalTypes]
+-- The type
+--   (genTel : Issue6770..GeneralizeTel) → A
+-- is not a subtype of
+--   A
+-- when checking that the expression a has type A
+
+-- Should succeed.

--- a/test/Succeed/Issue6770NAD.agda
+++ b/test/Succeed/Issue6770NAD.agda
@@ -1,0 +1,26 @@
+-- Andreas, 2026-04-30, issue #6770, reported by Orestis Melkonian
+-- Alternative reproducer by nad
+
+postulate
+  A : Set
+
+variable
+  x : A
+
+record R (x : A) : Set₁ where
+  field
+    B : Set
+
+-- The following code works:
+
+module _ {x} (r : R x) (open R r) where
+
+  _ : Set
+  _ = B
+
+-- However, the following code is rejected:
+
+module _ (r : R x) (open R r) where
+
+  _ : Set
+  _ = B

--- a/test/Succeed/Issue6770OMelkonian.agda
+++ b/test/Succeed/Issue6770OMelkonian.agda
@@ -1,0 +1,22 @@
+-- Andreas, 2026-04-30, issue #6770, reported by Orestis Melkonian
+
+open import Agda.Builtin.Equality
+postulate
+  X Y : Set
+  f : X → Y
+  P : Y → Set
+variable
+  x : X
+module M (x : X) where
+  y = f x
+-- ** these all work
+module _ {x} (open M x) where
+  postulate _ : P y
+postulate
+  _ : let open M x in P y
+  _ : (open M x) → P y
+-- ** this raises unexpected error on `y`, suggesting that it has not been properly instantiated
+module _ (open M x) where
+  postulate _ : P y
+
+-- Should succeed


### PR DESCRIPTION
- **Fix #6770 by updating modules and definition created during generalizeTelescope**
  [Storch]
  
  This Agda snippet should succeed:
  ```agda
  postulate A : Set
  
  module M (x : A) where
    postulate a : A
  
  variable x : A
  
  module _ (open M x) where
    _ : A
    _ = a
  ```
  But it produces the following error on Agda of current `master` (as checked out):
  ```
  [UnequalTypes]
  The type
    (genTel : Issue6770..GeneralizeTel) → A
  is not a subtype of
    A
  when checking that the expression a has type A
  ```
  This bug is at the intersection of the following features:
  - generalization (the `variable` declarations)
  - parametrized modules, `open` in module headers
  - generalization in module headers
  
  Relevant source files include:
  - src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs : Scope-checking phase, including handling of module parameters.
  - src/full/Agda/TypeChecking/Generalize.hs : Generalization happening in type-checking phase.
  - src/full/Agda/TypeChecking/Monad/Signature.hs : module applications as handled in the type-checker.
  
  Building:
  - after `cabal build` the generated Agda executable can be run just with `agda` since it is linked from the PATH.
  - special configuration in `mk/config.mk` enables running the testsuite directly via the `Makefile`,  e.g. `make succeed`, `make fail`
  - the reproducer from above sits in `./Issue6770.agda` so can just be tested via `agda Issue6770.agda`
  
  Please:
  - locate the source of the bug
  - describe what is causing the wrong behavior
  - fix the bug
  - test your fix works
  - test your fix does not break anything
  

- **More idiomatic code, added more tests**

Closes #5411. Closes #6240. Closes #6670.
  