### PR TITLE
Fix #7629 by correction countPatternVars for HITs

### DIFF
--- a/src/full/Agda/Syntax/Internal/Pattern.hs
+++ b/src/full/Agda/Syntax/Internal/Pattern.hs
@@ -316,9 +316,13 @@ instance CountPatternVars (Pattern' x) where
   countPatternVars p =
     case p of
       VarP{}      -> 1
+      LitP{}      -> 0
+      ProjP{}     -> 0
       ConP _ _ ps -> countPatternVars ps
       DotP{}      -> 1   -- dot patterns are treated as variables in the clauses
-      _           -> 0
+      -- Andreas, 2026-05-01, issue #7629, need to also count interval variables:
+      IApplyP{}   -> 1
+      DefP _ _ ps -> countPatternVars ps
 
 -- Computing modalities of pattern variables ------------------------------
 

--- a/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
@@ -415,7 +415,22 @@ expandCatchalls single n cs =
         -- The following pattern match cannot fail (by construction of @ps@).
         (ps0, _:ps1) = splitAt n ps
 
-        n' = countPatternVars ps1
+        -- Catch-all expansion substitutes into clause bodies, so it must count
+        -- every binder to the right of the expanded pattern, including IApply
+        -- variables. `countPatternVars` intentionally ignores IApplyP.
+        n' = countClausePatternVars ps1
+
+    countClausePatternVars :: [Arg Pattern] -> Int
+    countClausePatternVars = sum . map (go . unArg)
+      where
+        go = \case
+          VarP{}        -> 1
+          DotP{}        -> 1
+          IApplyP{}     -> 1
+          ConP _ _ ps   -> countClausePatternVars $ map (fmap namedThing) ps
+          LitP{}        -> 0
+          DefP _ _ ps   -> countClausePatternVars $ map (fmap namedThing) ps
+          ProjP{}       -> 0
 
 -- | Make sure (by eta-expansion) that clause has arity at least @n@
 --   where @n@ is also the length of the provided list.

--- a/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
@@ -415,22 +415,11 @@ expandCatchalls single n cs =
         -- The following pattern match cannot fail (by construction of @ps@).
         (ps0, _:ps1) = splitAt n ps
 
+        -- Andreas, 2026-05-01, issue #7629.
         -- Catch-all expansion substitutes into clause bodies, so it must count
         -- every binder to the right of the expanded pattern, including IApply
-        -- variables. `countPatternVars` intentionally ignores IApplyP.
-        n' = countClausePatternVars ps1
-
-    countClausePatternVars :: [Arg Pattern] -> Int
-    countClausePatternVars = sum . map (go . unArg)
-      where
-        go = \case
-          VarP{}        -> 1
-          DotP{}        -> 1
-          IApplyP{}     -> 1
-          ConP _ _ ps   -> countClausePatternVars $ map (fmap namedThing) ps
-          LitP{}        -> 0
-          DefP _ _ ps   -> countClausePatternVars $ map (fmap namedThing) ps
-          ProjP{}       -> 0
+        -- variables.
+        n' = countPatternVars ps1
 
 -- | Make sure (by eta-expansion) that clause has arity at least @n@
 --   where @n@ is also the length of the provided list.

--- a/test/Fail/Issue7629.agda
+++ b/test/Fail/Issue7629.agda
@@ -1,0 +1,66 @@
+{-# OPTIONS --cubical #-}
+
+module Issue7629 where
+
+open import Agda.Primitive
+open import Agda.Primitive.Cubical using (I; i0; i1)
+open import Agda.Builtin.Cubical.Path using (PathP)
+open import Agda.Builtin.Nat using (Nat; zero)
+open import Agda.Builtin.Sigma using (Σ; _,_; fst; snd)
+
+infix 4 _≡_ _<_ _<'_
+
+_≡_ : ∀ {ℓ} {A : Set ℓ} → A → A → Set ℓ
+_≡_ {A = A} = PathP (λ _ → A)
+
+isProp : Set → Set
+isProp A = (x y : A) → x ≡ y
+
+hProp : Set₁
+hProp = Σ Set isProp
+
+postulate
+  _<_ : Nat → Nat → Set
+  isProp< : (x y : Nat) → isProp (x < y)
+
+record Wrap : Set where
+  constructor wrap
+  field get : Nat
+open Wrap
+
+data ℚ : Set where
+  [_] : Wrap → ℚ
+  eq/ : (wa wb : Wrap) → [ wa ] ≡ [ wb ]
+
+postulate
+  lemma< : (wa wb wc : Wrap) → (get wa < get wb) ≡ (get wa < get wc)
+  isPropIsProp : ∀ (A : Set) → isProp (isProp A)
+  isProp→PathP :
+    ∀ {B : I → Set}
+    → ((i : I) → isProp (B i))
+    → (b0 : B i0) (b1 : B i1)
+    → PathP B b0 b1
+
+mutual
+  fun₀ : Wrap → ℚ → hProp
+  fun₀ (wrap a) [ wrap c ] .fst = a < c
+  fun₀ _        [ _ ]      .snd = isProp< _ _
+  fun₀ wa (eq/ wb wc i)    .fst = lemma< wa wb wc i
+  fun₀ wa (eq/ wb wc i)    .snd =
+    isProp→PathP (λ i → isPropIsProp (lemma< wa wb wc i))
+                 (isProp< _ _)
+                 (isProp< _ _)
+                 i
+
+postulate
+  toPath : ∀ wa wb (y : ℚ) → fun₀ wa y ≡ fun₀ wb y
+
+_<'_ : ℚ → ℚ → hProp
+_<'_ [ wa ]        y = fun₀ wa y
+_<'_ (eq/ wa wb i) y = toPath wa wb y i
+
+0ℚ : ℚ
+0ℚ = [ wrap zero ]
+
+boom : (wa wb : Wrap) → (i : I) → fst (0ℚ <' eq/ wa wb i) → Set
+boom wa wb i ()

--- a/test/Fail/Issue7629.agda
+++ b/test/Fail/Issue7629.agda
@@ -1,3 +1,6 @@
+-- Andreas, 2026-05-01, issue #7629
+-- Internal error due to bug in clause compiler concerning HITs.
+
 {-# OPTIONS --cubical #-}
 
 module Issue7629 where
@@ -62,5 +65,12 @@ _<'_ (eq/ wa wb i) y = toPath wa wb y i
 0ℚ : ℚ
 0ℚ = [ wrap zero ]
 
-boom : (wa wb : Wrap) → (i : I) → fst (0ℚ <' eq/ wa wb i) → Set
-boom wa wb i ()
+test : (wa wb : Wrap) → (i : I) → fst (0ℚ <' eq/ wa wb i) → Set
+test wa wb i ()
+
+-- WAS: Internal error.
+
+-- Expected error: [ShouldBeEmpty]
+-- fst (0ℚ <' eq/ wa wb i) should be empty, but that's not obvious to me
+-- when checking the clause left hand side
+-- test wa wb i ()

--- a/test/Fail/Issue7629.err
+++ b/test/Fail/Issue7629.err
@@ -1,0 +1,5 @@
+Issue7629.agda:66.1-16: error: [ShouldBeEmpty]
+fst (0ℚ <' eq/ wa wb i) should be empty, but that's not obvious to
+me
+when checking the clause left hand side
+boom wa wb i ()

--- a/test/Fail/Issue7629.err
+++ b/test/Fail/Issue7629.err
@@ -1,5 +1,5 @@
-Issue7629.agda:66.1-16: error: [ShouldBeEmpty]
+Issue7629.agda:69.1-16: error: [ShouldBeEmpty]
 fst (0ℚ <' eq/ wa wb i) should be empty, but that's not obvious to
 me
 when checking the clause left hand side
-boom wa wb i ()
+test wa wb i ()

--- a/test/Succeed/Issue7629Regression.agda
+++ b/test/Succeed/Issue7629Regression.agda
@@ -1,0 +1,78 @@
+{-# OPTIONS --cubical #-}
+
+module Issue7629Regression where
+
+open import Agda.Primitive using (lzero; lsuc; Set)
+open import Agda.Primitive.Cubical using (I; i0; i1)
+open import Agda.Builtin.Cubical.Path using (PathP)
+open import Agda.Builtin.Nat using (Nat; zero)
+open import Agda.Builtin.Sigma using (Σ; _,_; fst; snd)
+
+_==_ : ∀ {ℓ} {A : Set ℓ} → A → A → Set ℓ
+_==_ {A = A} = PathP (λ _ → A)
+
+isProp : ∀ {ℓ} → Set ℓ → Set ℓ
+isProp A = (x y : A) → x == y
+
+hProp : ∀ ℓ → Set (lsuc ℓ)
+hProp ℓ = Σ (Set ℓ) isProp
+
+data Z : Set where
+  pos : Nat → Z
+
+Pair : Set
+Pair = Σ Z (λ _ → Nat)
+
+postulate
+  mul : Z → Z → Z
+  lt : Z → Z → Set
+  isPropLt : (x y : Z) → isProp (lt x y)
+  natToZ : Nat → Z
+
+_~_ : Pair → Pair → Set
+(a , b) ~ (c , d) = mul a (natToZ d) == mul c (natToZ b)
+
+data Rat : Set where
+  [_] : Pair → Rat
+  eq/ : (ab cd : Pair) → ab ~ cd → [ ab ] == [ cd ]
+
+postulate
+  lemma :
+      ((a , b) (c , d) (e , f) : Pair)
+    → mul c (natToZ f) == mul e (natToZ d)
+    → lt (mul a (natToZ d)) (mul c (natToZ b))
+    == lt (mul a (natToZ f)) (mul e (natToZ b))
+
+  isPropIsProp : ∀ {ℓ} {A : Set ℓ} → isProp (isProp A)
+
+  isPropToPathP :
+      ∀ {ℓ} {B : I → Set ℓ}
+    → ((i : I) → isProp (B i))
+    → (b0 : B i0) (b1 : B i1)
+    → PathP B b0 b1
+
+mutual
+  fun0 : Pair → Rat → hProp lzero
+  less : Rat → Rat → hProp lzero
+
+  postulate
+    toPath : ∀ ab cd (x : ab ~ cd) (y : Rat) → fun0 ab y == fun0 cd y
+
+  fun0 (a , b) [ c , d ] .fst = lt (mul a (natToZ d)) (mul c (natToZ b))
+  fun0 _       [ _ ]     .snd = isPropLt _ _
+  fun0 ab (eq/ cd ef cfEqEd i) = record
+    { fst = lemma ab cd ef cfEqEd i
+    ; snd = isPropToPathP (λ i → isPropIsProp {A = lemma ab cd ef cfEqEd i})
+                          (isPropLt _ _)
+                          (isPropLt _ _) i
+    }
+
+  less [ ab ] y = fun0 ab y
+  less (eq/ ab cd adEqCb i) y = toPath ab cd adEqCb y i
+
+zeroRat : Rat
+zeroRat = [ pos zero , zero ]
+
+test : Σ Rat (λ q → fst (less zeroRat q)) → Set
+test ([ q ] , q+) = Rat
+test (eq/ ab cd adEqCb i , q+) = Rat

--- a/test/Succeed/Issue7629Regression.agda
+++ b/test/Succeed/Issue7629Regression.agda
@@ -1,3 +1,7 @@
+-- Andreas, 2026-05-01, issue #7629
+-- Internal error due to bug in clause compiler concerning HITs.
+-- Regression test.
+
 {-# OPTIONS --cubical #-}
 
 module Issue7629Regression where
@@ -76,3 +80,5 @@ zeroRat = [ pos zero , zero ]
 test : Σ Rat (λ q → fst (less zeroRat q)) → Set
 test ([ q ] , q+) = Rat
 test (eq/ ab cd adEqCb i , q+) = Rat
+
+-- Should succeed.

--- a/test/interaction/Issue7629.agda
+++ b/test/interaction/Issue7629.agda
@@ -1,0 +1,81 @@
+-- Andreas, 2026-05-01, issue #7629
+-- Internal error when splitting on hit.
+
+{-# OPTIONS --cubical #-}
+
+open import Agda.Primitive using (Set)
+open import Agda.Primitive.Cubical using (I; i0; i1)
+open import Agda.Builtin.Cubical.Path using (PathP)
+open import Agda.Builtin.Nat using (Nat; zero)
+open import Agda.Builtin.Sigma using (Σ; _,_; fst; snd)
+
+_≡_ : ∀ {ℓ} {A : Set ℓ} → A → A → Set ℓ
+_≡_ {A = A} = PathP (λ _ → A)
+
+_×_ : Set → Set → Set
+A × B = Σ A (λ _ → B)
+
+isProp : Set → Set
+isProp A = (x y : A) → x ≡ y
+
+hProp : Set₁
+hProp = Σ Set isProp
+
+data ℤ : Set where
+  pos : Nat → ℤ
+
+postulate
+  _·_ : ℤ → ℤ → ℤ
+  _<_ : ℤ → ℤ → Set
+  isProp< : (x y : ℤ) → isProp (x < y)
+  Nat→ℤ : Nat → ℤ
+
+_∼_ : ℤ × Nat → ℤ × Nat → Set
+(a , b) ∼ (c , d) = (a · Nat→ℤ d) ≡ (c · Nat→ℤ b)
+
+data ℚ : Set where
+  [_] : ℤ × Nat → ℚ
+  eq/ : (a/b c/d : ℤ × Nat) → a/b ∼ c/d → [ a/b ] ≡ [ c/d ]
+
+postulate
+  lemma< : ((a , b) (c , d) (e , f) : (ℤ × Nat))
+         → (c · Nat→ℤ f) ≡ (e · Nat→ℤ d)
+         → ((a · Nat→ℤ d) < (c · Nat→ℤ b))
+         ≡ ((a · Nat→ℤ f) < (e · Nat→ℤ b))
+
+  isPropIsProp : ∀ (A : Set) → isProp (isProp A)
+
+  isProp→PathP :
+    ∀ {B : I → Set}
+    → ((i : I) → isProp (B i))
+    → (b0 : B i0) (b1 : B i1)
+    → PathP B b0 b1
+
+mutual
+  fun₀ : ℤ × Nat → ℚ → hProp
+
+  postulate
+    toPath : ∀ a/b c/d (x : a/b ∼ c/d) (y : ℚ) → fun₀ a/b y ≡ fun₀ c/d y
+
+  fun₀ (a , b) [ c , d ]         .fst = (a · Nat→ℤ d) < (c · Nat→ℤ b)
+  fun₀ _       [ _ ]             .snd = isProp< _ _
+  fun₀ a/b (eq/ c/d e/f cf≡ed i) .fst = lemma< a/b c/d e/f cf≡ed i
+  fun₀ a/b (eq/ c/d e/f cf≡ed i) .snd =
+    isProp→PathP (λ i → isPropIsProp (lemma< a/b c/d e/f cf≡ed i))
+                 (isProp< _ _)
+                 (isProp< _ _)
+                 i
+
+_<'_ : ℚ → ℚ → hProp
+_<'_ [ a/b ]               y = fun₀ a/b y
+_<'_ (eq/ a/b c/d ad≡cb i) y = toPath a/b c/d ad≡cb y i
+
+0ℚ : ℚ
+0ℚ = [ pos zero , zero ]
+
+test : Σ ℚ (λ q → fst (0ℚ <' q)) → Set
+test (q , q+) = {!q!}  -- C-c C-c
+
+-- WAS: Internal error.
+
+-- Splitting should succeed (with unsolved constraints).

--- a/test/interaction/Issue7629.in
+++ b/test/interaction/Issue7629.in
@@ -1,0 +1,2 @@
+top_command (cmd_load currentFile [])
+goal_command 0 cmd_make_case "q"

--- a/test/interaction/Issue7629.out
+++ b/test/interaction/Issue7629.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals*" "?0 : Set" nil)
+((last . 1) . (agda2-goals-action '(0)))
+((last . 2) . (agda2-make-case-action '("test ([ x ] , q+) = ?" "test (eq/ a/b c/d x x₁ , q+) = ?")))
+((last . 1) . (agda2-goals-action '(0)))


### PR DESCRIPTION
- **Fix #7629 by correcting countPatternVars for Cubical (IApplyP)**
  [Storch]
  
  expandCatchalls rewrites clause bodies using an offset n' = countPatternVars ps1. For
  cubical/HIT clauses, ps1 can contain IApplyP binders, but countPatternVars ignores them. That
  made the substitution land one binder too far to the right after expanding a catch-all under
  a record split. In the minimized repro, this corrupted the compiled fun₀ branch from the
  intended shape lemma< (wrap @3) @2 @1 @0 into lemma< @3 (wrap @2) @1 @0, which later reduces
  to a malformed projection like Wrap.get zero and crashes in conApp.
  
  I changed catch-all expansion to count all clause binders, including IApplyP, before
  substituting into the body. I also added a focused regression in test/Fail/Issue7629.agda
  with test/Fail/Issue7629.err.
  
  Results: agda cubical/tmp/Shrink042.agda now gives a normal ShouldBeEmpty, agda
  Issue7629.agda now gives the expected CoverageIssue, and cabal build, make fail, and make
  succeed all pass.
  

- **Correct countPatternVars rather than adding function.**
  