### PR TITLE
Fix #6492 (debug in wrong context) plus refactorings

### DIFF
--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -203,7 +203,7 @@ alwaysInline :: QName -> TCM Bool
 alwaysInline q = do
   def <- theDef <$> getConstInfo q
   pure $ case def of  -- always inline with functions and pattern lambdas
-    Function{funClauses = cs} -> (isJust (funExtLam def) && not recursive) || isJust (funWith def)
+    Function{funClauses = cs} -> (isJust (funExtLam def) && not recursive) || isWithFunction def
             where
               recursive = any (couldBeRecursive . clauseRecursive) cs
     _ -> False

--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -243,7 +243,7 @@ getClauseZipperForIP f clauseNo = do
         ]
       __IMPOSSIBLE__
 
-recheckAbstractClause :: Type -> Maybe Substitution -> A.SpineClause -> TCM (Clause, Context, [AsBinding])
+recheckAbstractClause :: Type -> IsWithFunction Substitution -> A.SpineClause -> TCM (Clause, Context, [AsBinding])
 recheckAbstractClause t sub acl = checkClauseLHS t sub acl $ \ lhs -> do
   let cl = Clause { clauseLHSRange    = getRange acl
                   , clauseFullRange   = getRange acl

--- a/src/full/Agda/Mimer/Monad.hs
+++ b/src/full/Agda/Mimer/Monad.hs
@@ -310,7 +310,7 @@ collectComponents opts costs ii mDefName whereNames metaId = do
             | otherwise     -> done
           -- We can't use pattern lambdas as components nor with-functions.
           -- If the function is in the same mutual block, do not include it.
-          f@Function{ funWith = Nothing, funExtLam = Nothing }
+          f@Function{ funWith = NoWithFunction, funExtLam = Nothing }
             | Just qname == mDefName   -> addThisFn
             | notMutual, isToLevel typ -> addLevel
             | notMutual, shouldKeep    -> addFn

--- a/src/full/Agda/TypeChecking/IApplyConfluence.hs
+++ b/src/full/Agda/TypeChecking/IApplyConfluence.hs
@@ -26,7 +26,7 @@ import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records
 import Agda.TypeChecking.Reduce
-import Agda.TypeChecking.Rules.LHS (buildLHSSubstitutions, LHSSubstitutionCase (..))
+import Agda.TypeChecking.Rules.LHS (buildLHSSubstitutions)
 import Agda.TypeChecking.Telescope.Path
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Conversion.Errors
@@ -87,7 +87,7 @@ checkIApplyConfluence f cl = case cl of
           ps    <- normaliseProjP ps
           cxt   <- getContext
           clCxt <- inTopContext $ addContext clTel $ getContext
-          let (_, clSub) = buildLHSSubstitutions cxt ps NormalFunction
+          let (_, clSub) = buildLHSSubstitutions cxt ps NoWithFunction
           forM_ (iApplyVars ps) $ \ i -> do
             unview <- intervalUnview'
             let phi = unview $ IMax (argN $ unview (INeg $ argN $ var i)) $ argN $ var i

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -728,13 +728,13 @@ etaExpandMetaTCM kinds m =
                     u <- withMetaInfo' meta $
                       newRecordMetaCtx (miNameSuggestion (mvInfo meta))
                         (mvFrozen meta) r ps tel (idP $ size tel) $ teleArgs tel
+                    reportSDoc "tc.meta.eta" 15 $ sep
+                        [ "eta expanding: " <+> pretty m <+> " --> "
+                        , nest 2 $ prettyTCM u
+                        ]
                     -- Andreas, 2019-03-18, AIM XXIX, issue #3597
                     -- When meta is frozen instantiate it with in-turn frozen metas.
                     inTopContext $ do
-                      reportSDoc "tc.meta.eta" 15 $ sep
-                          [ "eta expanding: " <+> pretty m <+> " --> "
-                          , nest 2 $ prettyTCM u
-                          ]
                       -- Andreas, 2012-03-29: No need for occurrence check etc.
                       -- we directly assign the solution for the meta
                       -- 2012-05-23: We also bypass the check for frozen.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2292,7 +2292,7 @@ data IPClause = IPClause
   { ipcQName    :: QName              -- ^ The name of the function.
   , ipcClauseNo :: ClauseNumber       -- ^ The number of the clause of this function.
   , ipcType     :: Type               -- ^ The type of the function
-  , ipcWithSub  :: Maybe Substitution -- ^ Module parameter substitution
+  , ipcWithSub  :: IsWithFunction Substitution -- ^ Module parameter substitution
   , ipcClause   :: A.SpineClause      -- ^ The original AST clause.
   , ipcClosure  :: Closure ()         -- ^ Environment for rechecking the clause.
   }
@@ -2939,7 +2939,7 @@ data FunctionData = FunctionData
   , _funExtLam         :: Maybe ExtLamInfo
       -- ^ Is this function generated from an extended lambda?
       --   If yes, then return the number of hidden and non-hidden lambda-lifted arguments.
-  , _funWith           :: Maybe QName
+  , _funWith           :: IsWithFunction QName
       -- ^ Is this a generated with-function?
       --   If yes, then what's the name of the parent function?
   , _funIsKanOp        :: Maybe QName
@@ -2963,7 +2963,7 @@ pattern Function
   -> SmallSet FunctionFlag
   -> Maybe Bool
   -> Maybe ExtLamInfo
-  -> Maybe QName
+  -> IsWithFunction QName
   -> Maybe QName
   -> IsOpaque
   -> Defn
@@ -3356,6 +3356,11 @@ instance Pretty a => Pretty (DataOrRecord' a) where
     IsData -> "data"
     IsRecord a -> "record" <+> pretty a
 
+instance Pretty a => Pretty (IsWithFunction a) where
+  pretty = \case
+    NoWithFunction -> "NoWithFunction"
+    WithFunction a -> "WithFunction" <+> pretty a
+
 instance Pretty ProjectionLikenessMissing where
   pretty MaybeProjection = "MaybeProjection"
   pretty NeverProjection = "NeverProjection"
@@ -3546,7 +3551,7 @@ emptyFunctionData_ erasure = FunctionData
     , _funFlags       = SmallSet.fromList [ FunErasure | erasure ]
     , _funTerminates  = Nothing
     , _funExtLam      = Nothing
-    , _funWith        = Nothing
+    , _funWith        = empty
     , _funCovering    = []
     , _funIsKanOp     = Nothing
     , _funOpaque      = TransparentDef
@@ -3627,7 +3632,7 @@ isExtendedLambda def =
 isWithFunction :: Defn -> Bool
 isWithFunction def =
   case def of
-    Function { funWith = Just{} } -> True
+    Function { funWith = WithFunction{} } -> True
     _ -> False
 
 isCopatternLHS :: Foldable f => f Clause -> Bool
@@ -7239,6 +7244,10 @@ instance KillRange ProjectionLikenessMissing where
 
 instance KillRange BuiltinSort where
   killRange = id
+
+instance KillRange a => KillRange (IsWithFunction a) where
+  killRange NoWithFunction = NoWithFunction
+  killRange (WithFunction a) = WithFunction (killRange a)
 
 instance KillRange Defn where
   killRange def =

--- a/src/full/Agda/TypeChecking/Monad/Base/Types.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base/Types.hs
@@ -239,6 +239,21 @@ data NamedMeta = NamedMeta
   , nmid         :: {-# UNPACK #-} !MetaId
   }
 
+---------------------------------------------------------------------------
+-- * @with@ functions
+---------------------------------------------------------------------------
+
+data IsWithFunction a
+  = NoWithFunction
+  | WithFunction !a
+  deriving (Eq, Show, Generic, Functor, Foldable, Traversable)
+
+instance Null (IsWithFunction a) where
+  empty = NoWithFunction
+  null = \case
+    NoWithFunction -> True
+    WithFunction{} -> False
+
 -- Feel free to move more types from Agda.TypeChecking.Monad.Base here when needed...
 
 -- Null instances
@@ -261,3 +276,4 @@ instance NFData FileDictWithBuiltins
 instance NFData SourceFile
 instance NFData IsBuiltinModule
 instance NFData TopLevelModuleNameWithSourceFile
+instance NFData a => NFData (IsWithFunction a)

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -691,7 +691,7 @@ applySection' new ptel old ts ren@ScopeCopyInfo{ renNames = rd, renModules = rm 
             isCon  = case oldDef of { Constructor{} -> True ; _ -> False }
             mutual = case oldDef of { Function{funMutual = m} -> m              ; _ -> Nothing }
             extlam = case oldDef of { Function{funExtLam = e} -> e              ; _ -> Nothing }
-            with   = case oldDef of { Function{funWith = w}   -> copyName <$> w ; _ -> Nothing }
+            with   = case oldDef of { Function{funWith = w}   -> copyName <$> w ; _ -> empty }
             -- Andreas, 2015-05-11, to fix issue 1413:
             -- Even if we apply the record argument (must be @var 0@), we stay a projection.
             -- This is because we may abstract the record argument later again.

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -401,6 +401,12 @@ instance (Pretty a, PrettyTCM a, EndoSubst a) => PrettyTCM (Substitution' a) whe
       u            = lookupS rho2 0
 {-# SPECIALIZE prettyTCM :: (Pretty a, PrettyTCM a, EndoSubst a) => Substitution' a -> TCM Doc #-}
 
+instance {-# OVERLAPPABLE #-} PrettyTCM a => PrettyTCM (IsWithFunction a) where
+  prettyTCM = \case
+    NoWithFunction -> "(no with function)"
+    WithFunction a -> prettyTCM a
+{-# SPECIALIZE prettyTCM :: PrettyTCM a => IsWithFunction a -> TCM Doc #-}
+
 instance PrettyTCM Clause where
   prettyTCM cl = do
     x <- qualify_ <$> freshName_ ("<unnamedclause>" :: String)

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -80,6 +80,7 @@ import qualified Agda.Utils.SmallSet as SmallSet
 import Agda.Utils.Update
 
 import Agda.Utils.Impossible
+import Agda.Utils.Tuple (snd3, fst3)
 
 ---------------------------------------------------------------------------
 -- * Definitions by pattern matching
@@ -120,8 +121,8 @@ checkFunDef i name cs = do
               -- happens.
               whenM (isOpenMeta <$> lookupMetaInstantiation x) $
                 setCurrentRange i $ warning $ MissingTypeSignatureForOpaque name (Info.defOpaque i)
-              checkFunDef' t info Nothing Nothing i name cs
-          _ -> checkFunDef' t info Nothing Nothing i name cs
+              checkFunDef' t info Nothing i name cs
+          _ -> checkFunDef' t info Nothing i name cs
 
         -- If it's a macro check that it ends in Term → TC ⊤
         let ismacro = isMacro . theDef $ def
@@ -166,7 +167,7 @@ checkAlias t ai i name e mc =
                         , clauseRHS          = A.RHS e mc
                         , clauseWhereDecls   = A.noWhereDecls
                         , clauseCatchall     = empty } in
-  atClause name 0 t Nothing clause $ do
+  atClause name 0 t NoWithFunction clause $ do
   reportSDoc "tc.def.alias" 10 $ "checkAlias" <+> vcat
     [ text (prettyShow name) <+> colon  <+> prettyTCM t
     , text (prettyShow name) <+> equals <+> prettyTCM e
@@ -224,33 +225,33 @@ checkAlias t ai i name e mc =
 
 
 -- | Type check a definition by pattern matching.
-checkFunDef' :: Type             -- ^ the type we expect the function to have
-             -> ArgInfo          -- ^ is it irrelevant (for instance)
-             -> Maybe ExtLamInfo -- ^ does the definition come from an extended lambda
-                                 --   (if so, we need to know some stuff about lambda-lifted args)
-             -> Maybe QName      -- ^ is it a with function (if so, what's the name of the parent function)
-             -> A.DefInfo        -- ^ range info
-             -> QName            -- ^ the name of the function
-             -> [A.Clause]       -- ^ the clauses to check
-             -> TCM ()
-checkFunDef' t ai extlam with i name cs =
-  checkFunDefS t ai extlam with i name Nothing cs
+checkFunDef' ::
+     Type             -- ^ The type we expect the function to have.
+  -> ArgInfo          -- ^ Is it irrelevant or erased etc.?
+  -> Maybe ExtLamInfo -- ^ Does the definition come from an extended lambda?
+                      --   If so, we need to know some stuff about lambda-lifted args.
+  -> A.DefInfo        -- ^ 'Range' info.
+  -> QName            -- ^ The name of the function.
+  -> [A.Clause]       -- ^ The clauses to check.
+  -> TCM ()
+checkFunDef' t ai extlam i name cs =
+  checkFunDefS t ai extlam NoWithFunction i name cs
 
 -- | Type check a definition by pattern matching.
-checkFunDefS :: Type             -- ^ the type we expect the function to have
-             -> ArgInfo          -- ^ is it irrelevant (for instance)
-             -> Maybe ExtLamInfo -- ^ does the definition come from an extended lambda
-                                 --   (if so, we need to know some stuff about lambda-lifted args)
-             -> Maybe QName      -- ^ is it a with function (if so, what's the name of the parent function)
-             -> A.DefInfo        -- ^ range info
-             -> QName            -- ^ the name of the function
-             -> Maybe (Substitution, Map Name LetBinding)
-                                 -- ^ substitution (from with abstraction) that needs to be applied
-                                 --   to module parameters, and let-bindings inherited from parent
-                                 --   clause
-             -> [A.Clause]       -- ^ the clauses to check
-             -> TCM ()
-checkFunDefS t ai extlam with i name withSubAndLets cs = do
+checkFunDefS ::
+     Type             -- ^ The type we expect the function to have.
+  -> ArgInfo          -- ^ Is it irrelevant or erased etc.?
+  -> Maybe ExtLamInfo -- ^ Does the definition come from an extended lambda?
+                      --   If so, we need to know some stuff about lambda-lifted args.
+  -> IsWithFunction (QName, Substitution, Map Name LetBinding)
+       -- ^ Is it a with function (if so, what's the name of the parent function)?
+       -- ^ In that case, also substitution (from with abstraction) that needs to be applied
+       --   to module parameters, and let-bindings inherited from parent clause.
+  -> A.DefInfo        -- ^ 'Range' info.
+  -> QName            -- ^ The name of the function.
+  -> [A.Clause]       -- ^ The clauses to check.
+  -> TCM ()
+checkFunDefS t ai extlam with i name cs = do
 
     traceCall (CheckFunDefCall (getRange i) name True) $ do
         reportSDoc "tc.def.fun" 10 $
@@ -277,9 +278,9 @@ checkFunDefS t ai extlam with i name withSubAndLets cs = do
         -- Check the clauses
         cs <- traceCall NoHighlighting $ do -- To avoid flicker.
           forM (zip' cs [0..]) $ \ (c, clauseNo) -> do
-            atClause name clauseNo t (fst <$> withSubAndLets) c $ do
+            atClause name clauseNo t (snd3 <$> with) c $ do
               (c,b) <- applyModalityToContextFunBody ai $ do
-                checkClause t withSubAndLets c
+                checkClause t with c
               -- Andreas, 2013-11-23 do not solve size constraints here yet
               -- in case we are checking the body of an extended lambda.
               -- 2014-04-24: The size solver requires each clause to be
@@ -455,7 +456,7 @@ checkFunDefS t ai extlam with i name withSubAndLets cs = do
              , _funInv            = inv
              , _funOpaque         = Info.defOpaque i
              , _funExtLam         = (\ e -> e { extLamSys = sys }) <$> extlam
-             , _funWith           = with
+             , _funWith           = fmap fst3 with
              , _funCovering       = covering
              }
           lang <- getLanguage
@@ -549,9 +550,9 @@ insertPatternsLHSCore pats = \case
   core                  -> A.LHSWith core pats []
 
 -- | Parameters for creating a @with@-function.
-data WithFunctionProblem
-  = NoWithFunction
-  | WithFunction
+type WithFunctionProblem = IsWithFunction WithFunctionProblemData
+
+data WithFunctionProblemData = WithFunctionProblemData
     { wfParentName   :: QName                            -- ^ Parent function name.
     , wfName         :: QName                            -- ^ With function name.
     , wfParentType   :: Type                             -- ^ Type of the parent function.
@@ -692,7 +693,7 @@ instance Monoid ClausesPostChecks where
   mappend = (<>)
 
 -- | The LHS part of checkClause.
-checkClauseLHS :: Type -> Maybe Substitution -> A.SpineClause -> (LHSResult -> TCM a) -> TCM a
+checkClauseLHS :: Type -> IsWithFunction Substitution -> A.SpineClause -> (LHSResult -> TCM a) -> TCM a
 checkClauseLHS t withSub c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats _rhs0 _wh _catchall) ret = do
     reportSDoc "tc.lhs.top" 30 $ "Checking clause" $$ prettyA c
     () <- List1.unlessNull (trailingWithPatterns aps) $ \ withPats -> do
@@ -707,18 +708,22 @@ checkClauseLHS t withSub c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats _rhs0
 -- | Type check a function clause.
 
 checkClause
-  :: Type          -- ^ Type of function defined by this clause.
-  -> Maybe (Substitution, Map Name LetBinding)  -- ^ Module parameter substitution arising from with-abstraction, and inherited let-bindings.
-  -> A.SpineClause -- ^ Clause.
-  -> TCM (Clause, ClausesPostChecks)  -- ^ Type-checked clause
+  :: Type
+       -- ^ Type of function defined by this clause.
+  -> IsWithFunction (QName, Substitution, Map Name LetBinding)
+       -- ^ Parent function, module parameter substitution arising from with-abstraction, and inherited let-bindings.
+  -> A.SpineClause
+       -- ^ Clause.
+  -> TCM (Clause, ClausesPostChecks)
+       -- ^ Type-checked clause
 
 checkClause t withSubAndLets c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats rhs0 wh catchall) = do
-  let withSub = fst <$> withSubAndLets
+  let withSub = snd3 <$> withSubAndLets
   cxtNames <- getContextNames
   checkClauseLHS t withSub c $ \ lhsResult@(LHSResult npars delta ps absurdPat trhs patSubst asb psplit ixsplit) -> do
 
     let installInheritedLets k
-          | Just (withSub, lets) <- withSubAndLets = do
+          | WithFunction (_f, withSub, lets) <- withSubAndLets = do
             lets' <- traverse makeOpen $ applySubst (patSubst `composeS` withSub) lets
             locallyTC eLetBindings (lets' <>) k
           | otherwise = k
@@ -731,8 +736,8 @@ checkClause t withSubAndLets c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats r
         -- type. If we're checking a with-function that's already the case,
         -- otherwise we need to abstract over the module telescope.
         t' <- case withSub of
-                Just{}  -> return t
-                Nothing -> do
+                WithFunction{} -> return t
+                NoWithFunction -> do
                   theta <- lookupSection (qnameModule x)
                   return $! abstract theta t
 
@@ -1142,12 +1147,12 @@ checkWithRHS x aux t (LHSResult npars delta ps _absurdPat trhs _ _asb _ _) vtys0
         -- should not be carried over.
         lets <- Map.filter ((== UserWritten) . letOrigin) <$> (traverse getOpen =<< viewTC eLetBindings)
 
-        return (v, WithFunction x aux t delta delta1 delta2 vtys t' ps npars perm' perm finalPerm cs argsS lets)
+        return (v, WithFunction (WithFunctionProblemData x aux t delta delta1 delta2 vtys t' ps npars perm' perm finalPerm cs argsS lets))
 
 -- | Invoked in empty context.
 checkWithFunction :: [Name] -> WithFunctionProblem -> TCM (Maybe Term)
 checkWithFunction _ NoWithFunction = return Nothing
-checkWithFunction cxtNames (WithFunction f aux t delta delta1 delta2 vtys b qs npars perm' perm finalPerm cs argsS lets) = do
+checkWithFunction cxtNames (WithFunction (WithFunctionProblemData f aux t delta delta1 delta2 vtys b qs npars perm' perm finalPerm cs argsS lets)) = do
   let -- Δ₁ ws Δ₂ ⊢ withSub : Δ′    (where Δ′ is the context of the parent lhs)
       withSub :: Substitution
       withSub = let as = fmap (snd . unArg) vtys in
@@ -1260,7 +1265,7 @@ checkWithFunction cxtNames (WithFunction f aux t delta delta1 delta2 vtys b qs n
   -- Check the with function
   let info = Info.mkDefInfo (nameConcrete $ qnameName aux) noFixity' PublicAccess abstr (getRange cs)
   ai <- defArgInfo <$> getConstInfo f
-  checkFunDefS withFunType ai Nothing (Just f) info aux (Just (withSub, lets)) $ List1.toList cs
+  checkFunDefS withFunType ai Nothing (WithFunction (f, withSub, lets)) info aux $ List1.toList cs
   return $ Just $ call_in_parent
 
 -- | Type check a where clause.
@@ -1338,7 +1343,7 @@ newSection e m gtel@(A.GeneralizeTel _ tel) cont = do
 
 -- | Set the current clause number.
 
-atClause :: QName -> Int -> Type -> Maybe Substitution -> A.SpineClause -> TCM a -> TCM a
+atClause :: QName -> Int -> Type -> IsWithFunction Substitution -> A.SpineClause -> TCM a -> TCM a
 atClause name i t sub cl ret = do
   clo <- buildClosure ()
   localTC (set eClause (IPClause name i t sub cl clo)) ret

--- a/src/full/Agda/TypeChecking/Rules/Def.hs-boot
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs-boot
@@ -9,7 +9,7 @@ import qualified Agda.Syntax.Internal as I
 
 checkFunDef :: DefInfo -> QName -> [Clause] -> TCM ()
 
-checkFunDef' :: I.Type -> ArgInfo -> Maybe ExtLamInfo -> Maybe QName -> DefInfo -> QName -> [Clause] -> TCM ()
+checkFunDef' :: I.Type -> ArgInfo -> Maybe ExtLamInfo -> DefInfo -> QName -> [Clause] -> TCM ()
 
 newSection ::
    Erased -> ModuleName -> A.GeneralizeTelescope -> TCM a -> TCM a

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -10,7 +10,6 @@ module Agda.TypeChecking.Rules.LHS
   , checkSortOfSplitVar
   , LetOrClause(LetLHS, ClauseLHS)
   , buildLHSSubstitutions
-  , LHSSubstitutionCase(..)
   ) where
 
 import Prelude hiding ( null )
@@ -640,14 +639,6 @@ instance InstantiateFull LHSResult where
     <*> pure psplit
     <*> pure ixsplit
 
--- | Building substitutions from out patterns needs to handle with-functions
---   specially.
-data LHSSubstitutionCase = NormalFunction | WithFunction Int Substitution
-
-lhsSubstitutionCase :: Int -> Maybe Substitution -> LHSSubstitutionCase
-lhsSubstitutionCase arity Nothing        = NormalFunction
-lhsSubstitutionCase arity (Just withSub) = WithFunction arity withSub
-
 -- | Compute substitution from the out patterns @ps@
 --
 ---  We have two slightly different cases here: normal function and
@@ -681,18 +672,17 @@ lhsSubstitutionCase arity (Just withSub) = WithFunction arity withSub
 --      To compute Θ we can look at the arity of the with-function
 --      and compare it to numPats. This works since the with-function
 --      type is fully reduced.
-buildLHSSubstitutions :: Context -> NAPs -> LHSSubstitutionCase
+buildLHSSubstitutions :: Context -> NAPs -> IsWithFunction (Arity, Substitution)
   -> (Substitution, Substitution)
 buildLHSSubstitutions cxt ps isWithFun = do
-  let notProj ProjP{} = False
-      notProj _       = True
-      numPats = length $ takeWhile (notProj . namedArg) ps
-      patSub = map' (patternToTerm . namedArg) (reverse $ take' numPats ps) ++#
+  let notProjPats = takeWhile (isNothing . isProjP) ps
+      numPats = length notProjPats
+      patSub = map' (patternToTerm . namedArg) (reverse notProjPats) ++#
         EmptyS impossible
       (weakSub, withSub) = case isWithFun of
-        NormalFunction             ->
+        NoWithFunction             ->
           (wkS (numPats - length cxt) idS, idS)
-        WithFunction arity withSub ->
+        WithFunction (arity, withSub) ->
           -- if numPats < arity, Θ is empty
           (wkS (max 0 $ numPats - arity) idS, withSub)
       paramSub = patSub `composeS` weakSub `composeS` withSub
@@ -715,7 +705,7 @@ checkLeftHandSide :: forall a.
      -- ^ The patterns.
   -> Type
      -- ^ The expected type @a = Γ → b@.
-  -> Maybe Substitution
+  -> IsWithFunction Substitution
      -- ^ Module parameter substitution from with-abstraction.
   -> [ProblemEq]
      -- ^ Patterns that have been stripped away by with-desugaring.
@@ -779,7 +769,7 @@ checkLeftHandSide call lhsRng f ps a withSub' strippedPats =
           ]
 
         let (patSub, paramSub) = buildLHSSubstitutions cxt qs0 $
-              lhsSubstitutionCase arity_a withSub'
+              fmap (arity_a,) withSub'
 
         eqs <- addContext delta $ checkPatternLinearity eqs
 
@@ -848,7 +838,9 @@ checkLeftHandSide call lhsRng f ps a withSub' strippedPats =
 
   -- after we have introduced variables, we can add the patterns stripped by
   -- with-desugaring to the state.
-  let withSub = fromMaybe __IMPOSSIBLE__ withSub'
+  let withSub = case withSub' of
+        NoWithFunction -> __IMPOSSIBLE__
+        WithFunction sub -> sub
   withEqs <- updateProblemEqs $ applySubst withSub strippedPats
   -- Jesper, 2017-05-13: re-check the stripped patterns here!
   inTopContext $ addContext (st0 ^. lhsTel) $

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -977,7 +977,7 @@ checkExtendedLambda cmp i di erased qname cs e t = do
           useTerPragma $
             (defaultDefn info qname t lang fun)
               { defMutual = j }
-        checkFunDef' t info (Just $ ExtLamInfo lamMod False empty) Nothing di qname $
+        checkFunDef' t info (Just $ ExtLamInfo lamMod False empty) di qname $
           List1.toList cs
         whenNothingM (viewTC eMutualBlock) $
           -- Andrea 10-03-2018: Should other checks be performed here too? e.g. termination/positivity/..
@@ -2022,7 +2022,7 @@ checkLetBinding' b@(A.LetPatBind i ai p e) ret = do
         ]
       ]
     fvs <- getContextSize
-    checkLeftHandSide (CheckPattern p EmptyTel t) noRange LetLHS [p0] t0 Nothing [] $ \ (LHSResult _ delta0 ps _ _t _ asb _ _) -> setCurrentRange p $ bindAsPatterns asb $ do
+    checkLeftHandSide (CheckPattern p EmptyTel t) noRange LetLHS [p0] t0 NoWithFunction [] $ \ (LHSResult _ delta0 ps _ _t _ asb _ _) -> setCurrentRange p $ bindAsPatterns asb $ do
           -- After dropping the free variable patterns there should be a single pattern left.
       let p = case drop fvs ps of [p] -> namedArg p; _ -> __IMPOSSIBLE__
           -- Also strip the context variables from the telescope

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 #include "MachDeps.h"
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20260421 * 10 + 0
+currentInterfaceVersion = 20260501 * 10 + 0
 
 ifaceVersionSize :: Int
 ifaceVersionSize = SIZEOF_WORD64

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -449,6 +449,15 @@ instance EmbPrj BuiltinSort where
     (N1 3)   -> valuN SortLevelUniv
     _        -> malformed
 
+instance EmbPrj a => EmbPrj (IsWithFunction a) where
+  icod_ NoWithFunction   = icodeN' NoWithFunction
+  icod_ (WithFunction a) = icodeN' WithFunction a
+
+  value = vcase \case
+    N0   -> valuN NoWithFunction
+    N1 a -> valuN WithFunction a
+    _ -> malformed
+
 instance EmbPrj Defn where
   icod_ (Axiom       a)                                 = icodeN 0 Axiom a
   icod_ (Function    a b s t u c d e f g h i j k)       = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k

--- a/src/full/Agda/TypeChecking/Substitute/Class.hs
+++ b/src/full/Agda/TypeChecking/Substitute/Class.hs
@@ -286,20 +286,28 @@ strengthenS' err m rho = case compare m 0 of
 
 {-# INLINABLE lookupS #-}
 lookupS :: EndoSubst a => Substitution' a -> Nat -> a
-lookupS rho i = case rho of
-  IdS                    -> deBruijnVar i
+lookupS = lookupS' 0
+
+{-# INLINABLE lookupS' #-}
+lookupS' :: EndoSubst a
+  => Nat              -- ^ Raise the looked up term/thing by this amount.
+  -> Substitution' a  -- ^ The substitution.
+  -> Nat              -- ^ Index to lookup in the substitution.
+  -> a                -- ^ The raised result.
+lookupS' w rho i = case rho of
+  IdS                    -> deBruijnVar (w + i)
   Wk n IdS               -> let j = i + n in
-                            if  j < 0 then __IMPOSSIBLE__ else deBruijnVar j
-  Wk n rho               -> applySubst (raiseS n) (lookupS rho i)
-  u :# rho   | i == 0    -> u
+                            if  j < 0 then __IMPOSSIBLE__ else deBruijnVar (w + j)
+  Wk n rho               -> lookupS' (n + w) rho i
+  u :# rho   | i == 0    -> raise w u
              | i < 0     -> __IMPOSSIBLE__
-             | otherwise -> lookupS rho (i - 1)
+             | otherwise -> lookupS' w rho (i - 1)
   Strengthen err n rho
              | i < 0     -> __IMPOSSIBLE__
              | i < n     -> throwImpossible err
-             | otherwise -> lookupS rho (i - n)
-  Lift n rho | i < n     -> deBruijnVar i
-             | otherwise -> raise n $ lookupS rho (i - n)
+             | otherwise -> lookupS' w rho (i - n)
+  Lift n rho | i < n     -> deBruijnVar (w + i)
+             | otherwise -> lookupS' (n + w) rho (i - n)
   EmptyS err             -> throwImpossible err
 
 

--- a/test/Fail/Issue6492.agda
+++ b/test/Fail/Issue6492.agda
@@ -1,0 +1,21 @@
+-- Andreas, 2026-05-01, issue #6492, shrunk test case by Amelia.
+-- Debug printing crashed because of wrong context.
+
+{-# OPTIONS -v tc.meta.eta:15 #-}
+
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Unit
+
+data T : Bool → Set where
+  true : T true
+
+f : (x : Σ Bool λ _ → Bool) → T (x .fst) → ⊤
+f _ _ = tt
+
+foo : Bool → ⊤
+foo _ = f _ true
+
+-- WAS: debug printing crashed.
+
+-- Expected error: UnsolvedMetaVariables

--- a/test/Fail/Issue6492.err
+++ b/test/Fail/Issue6492.err
@@ -1,0 +1,5 @@
+eta expanding:  _14@9809346921789678543  --> 
+  (_x.fst_15 (x = x) , _x.snd_16 (x = x))
+Issue6492.agda:17.11-12: error: [UnsolvedMetaVariables]
+Unsolved metas at the following locations:
+  Issue6492.agda:17.11-12


### PR DESCRIPTION
Closes #6492 (commit 3).  

On my way there I encountered some suboptimal code which I improved (hopefully):
- commit 1: Refactor: `IsWithFunction` instead of `Maybe`.
  Also remove a duplicate `take` from `buildLHSSubstitutions` (PR #8520).
- commit 2: optimize `lookupS` bug aggregating calls to `raise`.
