### PR TITLE
Fix #8395 by printing `delta` in the correct context.

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -692,7 +692,7 @@ instance Monoid ClausesPostChecks where
   mempty  = CPC empty
   mappend = (<>)
 
--- | The LHS part of checkClause.
+-- | The LHS part of 'checkClause'.
 checkClauseLHS :: Type -> IsWithFunction Substitution -> A.SpineClause -> (LHSResult -> TCM a) -> TCM a
 checkClauseLHS t withSub c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats _rhs0 _wh _catchall) ret = do
     reportSDoc "tc.lhs.top" 30 $ "Checking clause" $$ prettyA c
@@ -779,14 +779,14 @@ checkClause t withSubAndLets c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats r
         reportSDoc "tc.lhs.top" 10 $ vcat
           [ "Clause before translation:"
           , nest 2 $ vcat
-            [ "delta =" <+> do escapeContext impossible (size delta) $ prettyTCM delta
+            [ "delta =" <+> prettyTCM delta
             , "ps    =" <+> do P.fsep <$> prettyTCMPatterns ps
             , "body  =" <+> maybe "_|_" prettyTCM body
             , "type  =" <+> prettyTCM t
             ]
           ]
 
-        reportSDoc "tc.lhs.top" 90 $ escapeContext impossible (size delta) $ vcat
+        reportSDoc "tc.lhs.top" 90 $ vcat
           [ "Clause before translation (raw):"
           , nest 2 $ vcat
             [ "ps    =" <+> text (show ps)

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -606,6 +606,9 @@ data LHSResult = LHSResult
   , lhsVarTele      :: Telescope
     -- ^ Δ : The types of the pattern variables, in internal dependency order.
     -- Corresponds to 'clauseTel'.
+    -- Like the other components (e.g. `lhsBodyType`), this telescope lives
+    -- in the ambient context.
+    -- To print it, we need /not/ drop Δ from the ambient context.
   , lhsPatterns     :: [NamedArg DeBruijnPattern]
     -- ^ The patterns in internal syntax.
   , lhsHasAbsurd    :: Bool
@@ -711,7 +714,9 @@ checkLeftHandSide :: forall a.
      -- ^ Patterns that have been stripped away by with-desugaring.
      -- ^ These should not contain any proper matches.
   -> (LHSResult -> TCM a)
-     -- ^ Continuation.
+     -- ^ Continuation, called in the context constructed from
+     --   the 'lhsVarTele' via 'computeLHSContext'.
+     --   All components of 'LHSResult' live in this context, including 'lhsVarTele'.
   -> TCM a
 checkLeftHandSide call lhsRng f ps a withSub' strippedPats =
  Bench.billToCPS [Bench.Typing, Bench.CheckLHS] $

--- a/test/Succeed/Issue8395.agda
+++ b/test/Succeed/Issue8395.agda
@@ -1,0 +1,30 @@
+-- Andreas, 2026-05-01, issue #8395
+-- Crash in debug printing due to wrong context.
+
+{-# OPTIONS -v tc.lhs.top:10 #-}
+
+module Issue8395 where
+
+postulate
+  _≡_ : {A : Set} → A → A → Set
+  List : Set → Set
+  Any : {A : Set} (P : A → Set) → List A → Set
+
+record Setoid : Set₁ where
+  field
+    Carrier : Set
+    _≈_     : Carrier → Carrier → Set
+
+setoid : Set → Setoid
+setoid A = record
+  { Carrier = A
+  ; _≈_     = _≡_
+  }
+
+module Membership (S : Setoid) where
+  open module S = Setoid S
+
+  _∈_ : Carrier → List Carrier → Set _
+  x ∈ xs = Any (_≈_ x) xs
+
+-- Debug printing should succeed.


### PR DESCRIPTION
`delta` lives in the ambient context.

Closes #8395.
