### PR TITLE
Ignore .mjs files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,12 +50,15 @@
 /test/**/MAlonzo
 /test/api/*.api
 /test/Compiler/simple/agda-rts.js
+/test/Compiler/simple/agda-rts.mjs
 /test/Compiler/simple/Erasure-Issue2640
 /test/Compiler/simple/highlight-hover.js
+/test/Compiler/simple/highlight-hover.mjs
 /test/Compiler/simple/Issue4168
 /test/Compiler/simple/Issue4168-4185
 /test/Compiler/simple/Issue4168-shirr
 /test/Compiler/simple/jAgda.*.js
+/test/Compiler/simple/jAgda.*.mjs
 /test/Compiler/simple/Literals
 /test/Compiler/simple/ModuleArgs
 /test/Compiler/simple/VecReverse
@@ -63,10 +66,13 @@
 /test/Compiler/simple/VecReverseHand
 /test/Compiler/simple/Word
 /test/Compiler/with-stdlib/agda-rts.js
+/test/Compiler/with-stdlib/agda-rts.mjs
 /test/Compiler/with-stdlib/AllStdLib
 /test/Compiler/with-stdlib/highlight-hover.js
+/test/Compiler/with-stdlib/highlight-hover.mjs
 /test/interaction/Issue6261?.out
 /test/Succeed/agda-rts.js
+/test/Succeed/agda-rts.mjs
 /test/Succeed/Issue296
 /test/Succeed/Issue867
 /test/Succeed/Options-in-right-order
@@ -81,6 +87,7 @@ dist-*/
 dist/
 hlint-report.html
 jAgda.*.js
+jAgda.*.mjs
 module-dependency-graph.dot
 module-dependency-graph.pdf
 pkg-build*


### PR DESCRIPTION
When working on another PR and trying to run the full test suite locally, I noticed the creation of some untracked .mjs files. I hypothesize that they should be .gitignored (though I don't actually understand the relevant context).