### PR TITLE
Fix #8553 OP

### DIFF
--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -60,6 +60,7 @@ import Agda.TypeChecking.Monad.Benchmark (billTo)
 import Agda.Utils.List
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
+import Agda.Utils.Singleton
 import Agda.Utils.Size
 import Agda.Utils.Tuple
 import Agda.Syntax.Common.Pretty (prettyShow)
@@ -86,12 +87,21 @@ initialInstanceCandidates blockOverlap instTy = do
       reportSDoc "tc.instance.cands" 30 $ "Instance type is a variable. "
       runBlocked (getContextCands Nothing)
     OutputTypeName n -> Bench.billTo [Bench.Typing, Bench.InstanceSearch, Bench.InitialCandidates] do
-      reportSDoc "tc.instance.cands" 30 $ "Found instance type head: " <+> prettyTCM n
-      runBlocked do
-        local  <- getContextCands (Just n)
-        global <- getScopeDefs n
-        lift $ tickCandidates n $ length local + length global
-        pure $ local <> global
+      runBlocked (isSingletonType instTy) >>= \case
+        -- Andreas, 2026-05-07, issue #8553
+        -- If we can find a solution by eta-expansion, we do not have go through tedious search.
+        -- Also, 'dropSameCandidates' makes wrong decisions when all candidates are equal
+        -- modulo eta but differ in their unsolved instance metas.
+        -- So we cut the search short here.
+        Right (Just v) -> return $ Right $ singleton $
+          Candidate LocalCandidate v instTy Overlaps -- not sure about "Overlaps" but this might not matter
+        _ -> do
+          reportSDoc "tc.instance.cands" 30 $ "Found instance type head: " <+> prettyTCM n
+          runBlocked do
+            local  <- getContextCands (Just n)
+            global <- getScopeDefs n
+            lift $ tickCandidates n $ length local + length global
+            pure $ local <> global
   where
     -- Ticky profiling for statistics about a class.
     tickCandidates n size = whenProfile Profile.Instances do

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -898,7 +898,11 @@ debugCandidateTerm = debugCandidate' False True
 checkCandidates :: MetaId -> Type -> [Candidate] -> TCM (Maybe ([(Candidate, TCErr)], [(Candidate, Term)]))
 checkCandidates m t cands =
   verboseBracket "tc.instance.candidates" 20 ("checkCandidates " ++! prettyShow m) $
-  ifM (anyMetaTypes cands) (return Nothing) $ Just <$> do
+  -- Andreas, 2026-05-07: Ulf, 2015-10-31 commit 711bc27
+  -- If there are candidates of meta type we won't be able to solve the constraint
+  -- anyway and trying can be very expensive since checking a candidate might
+  -- lead to further instance problems (exponential in depth).
+  ifM (anyM (isMetaV . candidateType) cands) (return Nothing) $ Just <$> do
     reportSDoc "tc.instance.candidates" 20 $ nest 2 $ "target:" <+> prettyTCM t
     reportSDoc "tc.instance.candidates" 20 $ nest 2 $ vcat
       [ "candidates", vcat (map' debugCandidate cands) ]
@@ -913,13 +917,8 @@ checkCandidates m t cands =
 
     return cands'
   where
-    anyMetaTypes :: [Candidate] -> TCM Bool
-    anyMetaTypes [] = return False
-    anyMetaTypes (Candidate _ _ a _ : cands) = do
-      a <- instantiate a
-      case unEl a of
-        MetaV{} -> return True
-        _       -> anyMetaTypes cands
+    isMetaV :: Type -> TCM Bool
+    isMetaV a = isJust . isMeta <$> instantiate a
 
     checkDepth :: Term -> Type -> TCM YesNo -> TCM YesNo
     checkDepth c a k = locallyTC eInstanceDepth succ $ do
@@ -980,7 +979,7 @@ checkCandidates m t cands =
             stealConstraints pid
             let
               blocking = foldMap (allBlockingMetas . constraintUnblocker) cons
-              !ok = getAll $! flip allMetas t (All . not . flip Set.member blocking)
+              !ok = getAll $! allMetas (All . not . flip Set.member blocking) t
             pure (cons, ok)
           debugConstraints
 

--- a/test/Fail/Issue6627.agda
+++ b/test/Fail/Issue6627.agda
@@ -1,9 +1,21 @@
+-- CheckArguments call exposes dummy checkArguments return type
 module Issue6627 where
 
-record Foo : Set where
+record Foo : Set₁ where
+  field foo : Set
 record Bar ⦃ _ : Foo ⦄ : Set where
 postulate
   i : Foo
   b : Bar ⦃ i ⦄
 
 open Bar b
+
+-- Error was:
+-- No instance of type Foo was found in scope.
+-- when checking that b is a valid argument to a function of type
+-- ⦃ _ = z : Foo ⦄ → .Bar → "dummyType: __DUMMY_TYPE__, called at ..."
+
+-- Expected error: [InstanceNoCandidate]
+-- No instance of type Foo was found in scope.
+-- when checking that b is a valid argument to a function accepting
+-- arguments of type ⦃ _ = z : Foo ⦄ (r : Bar)

--- a/test/Fail/Issue6627.err
+++ b/test/Fail/Issue6627.err
@@ -1,4 +1,4 @@
-Issue6627.agda:9.6-9: error: [InstanceNoCandidate]
+Issue6627.agda:11.6-9: error: [InstanceNoCandidate]
 No instance of type Foo was found in scope.
 when checking that b is a valid argument to a function accepting
 arguments of type ⦃ _ = z : Foo ⦄ (r : Bar)

--- a/test/Succeed/EraseRecordParameters.agda
+++ b/test/Succeed/EraseRecordParameters.agda
@@ -20,6 +20,7 @@ module ErasedDefinition where
   record R (x : A) : Set where
     y : A
     y = a
+    field foo : A
 
   f : (@0 x : A) → R x → A
   f x r = R.y {x} r

--- a/test/Succeed/Issue8553.agda
+++ b/test/Succeed/Issue8553.agda
@@ -1,0 +1,47 @@
+-- Andreas, 2026-05-07, issue #8553
+-- Report and test case by Carlos Tome
+
+module Issue8553 where
+
+it : {A : Set} ⦃ _ : A ⦄ → A
+it ⦃ a ⦄ = a
+
+-- A singleton type:
+record C : Set where
+
+record Q : Set where
+  field
+    -- This instance projection conflicts with the instance for C defined later
+    instance
+      ⦃ q ⦄ : C
+
+instance
+  iC : C
+  iC = record {}
+
+open Q ⦃...⦄ public
+-- This brings the instance projection into scope unqualified.
+
+c-C : C
+c-C = it
+
+-- There are several way to solve the instance meta of type C here.
+-- They are all definitionally equal, due to eta.
+-- The bug was that Agda dropped the good one (iC) and then failed
+-- to proceed with the bad one (q) since there is no instance for Q.
+
+-- Now instance search succeeds trivially since C is a singleton type.
+
+
+-- We can also solve instance metas of singleton types
+-- even without any instance terms around.
+
+record E : Set where
+
+e : E
+e = it
+
+-- This is rejected as instance search in general
+-- rejects search in explicit function spaces.
+-- f : E → E
+-- f = it {A = E → E}


### PR DESCRIPTION
This PR changes the Agda language in the respect that instance metas of singleton types are attempted to be solved by eta-expansion.
This fixes #8553 with the test cases it has been reported with.
- #8553

I suspect the practical inpact of this change will be small, as cases where one defines instances of unit records mostly arise from shrinking larger counterexamples---and shrinking too much, one could argue, but removing the last field from a record.
To preserve the behavior of our testsuites, I added fields to some empty records there.

Commits:

- **[refactor] use anyM instead of hand-rolled loop**
  
- **Issue #8553: solve instances for singleton type by eta-expansion**
  
TODO:
- [ ] Changelog
- [ ] Docs