### PR TITLE
Fix #3054 by introducing MatchPrio for constructor patterns

### DIFF
--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -639,6 +639,9 @@ data PatternInfo = PatternInfo
   , patAsNames :: [Name]
   } deriving (Show, Eq, Generic)
 
+instance Null PatternInfo where
+  empty = defaultPatternInfo
+
 defaultPatternInfo :: PatternInfo
 defaultPatternInfo = PatternInfo PatOSystem []
 
@@ -670,7 +673,7 @@ data Pattern' x
   | ConP ConHead ConPatternInfo [NamedArg (Pattern' x)]
     -- ^ @c ps@
     --   The subpatterns do not contain any projection copatterns.
-  | LitP PatternInfo Literal
+  | LitP LitPatternInfo Literal
     -- ^ E.g. @5@, @"hello"@.
   | ProjP ProjOrigin QName
     -- ^ Projection copattern.  Can only appear by itself.
@@ -690,7 +693,7 @@ dotP :: Term -> Pattern' a
 dotP = DotP defaultPatternInfo
 
 litP :: Literal -> Pattern' a
-litP = LitP defaultPatternInfo
+litP = LitP empty
 
 -- | Type used when numbering pattern variables.
 data DBPatVar = DBPatVar
@@ -710,6 +713,41 @@ namedDBVarP m = (fmap . fmap) (\x -> DBPatVar x m) . namedVarP
 -- | Make an absurd pattern with the given de Bruijn index.
 absurdP :: Int -> DeBruijnPattern
 absurdP = VarP (PatternInfo PatOAbsurd []) . DBPatVar absurdPatternName
+
+-- | For the sake of reducing clauses before they have compiled,
+-- we keep a match priority in the constructors (and literals)
+-- of patterns that is computed during lhs checking and
+-- decides whether a mismatch should be treated as a hard 'No'.
+-- Matches that get available earlier have a lower priority.
+-- Lower priority wins, meaning that if we combine a
+-- 'DontKnow' with a 'No' we take the one with the lower priority.
+newtype MatchPrio = MatchPrio { theMatchPrio :: Int }
+  deriving (Eq, Ord, Show, Enum, KillRange, NFData)
+
+instance Null MatchPrio where
+  empty = MatchPrio 0
+
+instance Semigroup MatchPrio where
+  MatchPrio p <> MatchPrio p' = MatchPrio $ min p p'
+
+instance Monoid MatchPrio where
+  mempty = empty
+
+-- | Extra information attached to a 'LitP'.
+data LitPatternInfo = LitPatternInfo
+  { litPInfo :: PatternInfo
+      -- ^ Information on the origin of the pattern.
+  , litPPrio :: MatchPrio
+      -- ^ Time when this pattern was constructed during LHS checking.
+      --   This field is used during pattern matching with the non-compiled clauses.
+  }
+  deriving (Eq, Show, Generic)
+
+instance Null LitPatternInfo where
+  empty = LitPatternInfo empty empty
+
+instance KillRange LitPatternInfo where
+  killRange (LitPatternInfo a b) = killRangeN LitPatternInfo a b
 
 -- | The @ConPatternInfo@ states whether the constructor belongs to
 --   a record type (@True@) or data type (@False@).
@@ -742,11 +780,14 @@ data ConPatternInfo = ConPatternInfo
     --   ('Agda.TypeChecking.CompiledClause.Compile.compileClauses') when the
     --   variables they bind are unused. The GHC backend compiles lazy matches
     --   to lazy patterns in Haskell (TODO: not yet).
+  , conPPrio :: !MatchPrio
+    -- ^ Time when this pattern was constructed during LHS checking.
+    --   This field is used during pattern matching with the non-compiled clauses.
   }
   deriving (Show, Generic)
 
 noConPatternInfo :: ConPatternInfo
-noConPatternInfo = ConPatternInfo defaultPatternInfo False False Nothing False
+noConPatternInfo = ConPatternInfo defaultPatternInfo False False Nothing False empty
 
 -- | Build partial 'ConPatternInfo' from 'ConInfo'
 toConPatternInfo :: ConInfo -> ConPatternInfo
@@ -803,7 +844,7 @@ instance PatternVars a => PatternVars [a] where
 patternInfo :: Pattern' x -> Maybe PatternInfo
 patternInfo (VarP i _)        = Just i
 patternInfo (DotP i _)        = Just i
-patternInfo (LitP i _)        = Just i
+patternInfo (LitP i _)        = Just $ litPInfo i
 patternInfo (ConP _ ci _)     = Just $ conPInfo ci
 patternInfo ProjP{}           = Nothing
 patternInfo (IApplyP i _ _ _) = Just i
@@ -1636,7 +1677,7 @@ instance KillRange PatternInfo where
   killRange (PatternInfo o xs) = killRangeN PatternInfo o xs
 
 instance KillRange ConPatternInfo where
-  killRange (ConPatternInfo i mr b mt lz) = killRangeN (ConPatternInfo i mr b) mt lz
+  killRange (ConPatternInfo i mr b mt lz prio) = killRangeN (ConPatternInfo i mr b) mt lz prio
 
 instance KillRange DBPatVar where
   killRange (DBPatVar x i) = killRangeN DBPatVar x i
@@ -1927,6 +1968,7 @@ instance NFData PatOrigin
 instance NFData x => NFData (Pattern' x)
 instance NFData DBPatVar
 instance NFData ConPatternInfo
+instance NFData LitPatternInfo
 instance NFData a => NFData (Substitution' a)
 instance NFData DefSing
 instance NFData NLPat

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -409,7 +409,7 @@ instance NamesIn PatternSynDefn where
   namesAndMetasIn' sg (PatternSynDefn _args p) = namesAndMetasIn' sg p
 
 instance NamesIn ConPatternInfo where
-  namesAndMetasIn' sg (ConPatternInfo _ _ _ ty _) = namesAndMetasIn' sg ty
+  namesAndMetasIn' sg (ConPatternInfo _ _ _ ty _ _) = namesAndMetasIn' sg ty
 
 instance NamesIn (A.Pattern' a) where
   namesAndMetasIn' sg = \case

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1360,7 +1360,7 @@ reifyPatterns = mapM $ (stripNameFromExplicit . stripHidingFromPostfixProj) <.>
           else
             reifyDotP keepVars o v
         o -> reifyDotP keepVars o v
-      I.LitP i l  -> addAsBindings (patAsNames i) $ return $ A.LitP empty l
+      I.LitP i l  -> addAsBindings (patAsNames (litPInfo i)) $ return $ A.LitP empty l
       I.ProjP o d -> return $! A.ProjP patNoRange o $ unambiguous d
       I.ConP c cpi ps | conPRecord cpi -> addAsBindings (patAsNames $ conPInfo cpi) $
         case patOrigin (conPInfo cpi) of

--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -358,7 +358,7 @@ unDotP (DotP o v) = reduce v >>= \case
   Con c _ vs -> do
     let ps = map' (fmap $ unnamed . DotP o) $ mustAllApplyElims vs
     return $ ConP c noConPatternInfo ps
-  Lit l -> return $ LitP (PatternInfo PatODot []) l
+  Lit l -> return $ LitP (LitPatternInfo (PatternInfo PatODot []) empty) l
   v     -> return $ dotP v
 unDotP p = return p
 
@@ -386,12 +386,12 @@ isLitP _ = return Nothing
 
 {-# SPECIALIZE unLitP :: Pattern' a -> TCM (Pattern' a) #-}
 unLitP :: HasBuiltins m => Pattern' a -> m (Pattern' a)
-unLitP (LitP info l@(LitNat n)) | n >= 0 = do
+unLitP (LitP lpi@(LitPatternInfo info prio) l@(LitNat n)) | n >= 0 = do
  constructorForm (Lit l) >>= \case
   Con c ci es -> do
-    let toP (Apply (Arg i (Lit l))) = Arg i (LitP info l)
+    let toP (Apply (Arg i (Lit l))) = Arg i (LitP lpi l)
         toP _ = __IMPOSSIBLE__
-        cpi   = noConPatternInfo { conPInfo = info }
+        cpi   = noConPatternInfo { conPInfo = info, conPPrio = prio }
     return $ ConP c cpi $ map' (fmap unnamed . toP) es
   _ -> __IMPOSSIBLE__
 unLitP p = return p

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -34,12 +34,17 @@ import Agda.Utils.Tuple
 
 import Agda.Utils.Impossible
 
--- | If matching is inconclusive (@DontKnow@) we want to know whether it is on a
---   lazy pattern and whether it is due to a particular meta variable.
-data Match a = Yes Simplification (IntMap (Arg a))
-             | No
-             | DontKnow OnlyLazy (Blocked ())
-  deriving Functor
+-- | Result of matching a pattern against a term.
+data Match a
+  = Yes Simplification (IntMap (Arg a))
+      -- ^ Matches with the given substitution for the pattern variables.
+  | No MatchPrio
+      -- ^ Mismatch where the constructor/literal pattern has the given priority.
+  | DontKnow MatchPrio OnlyLazy (Blocked ())
+      -- ^ Stuck where the constructor/literal pattern has the given priority.
+      -- If matching is inconclusive we also want to know whether it is on a
+      -- lazy pattern and whether it is due to a particular meta variable.
+  deriving (Show, Functor)
 
 instance Null (Match a) where
   empty = Yes empty empty
@@ -61,18 +66,22 @@ buildSubstitution err n vs = foldr cons idS $ matchedArgs' n vs
   where cons Nothing  = strengthenS' err 1
         cons (Just v) = consS (unArg v)
 
-
+-- | Combining match results.
+-- When combining 'No' and 'DontKnow', the lower priority wins!
+-- See issue #3054 / #8559.
 instance Semigroup (Match a) where
+  m <> m' = case (m, m') of
     -- @NotBlocked (StuckOn e)@ means blocked by a variable.
     -- In this case, no instantiation of meta-variables will make progress.
-    DontKnow l b <> DontKnow l' b' = DontKnow (l <> l') (b <> b')
-    DontKnow l m <> _              = DontKnow l m
-    _            <> DontKnow l m   = DontKnow l m
-    -- One could imagine DontKnow _ _ <> No = No, but would break the
-    -- equivalence to case-trees (Issue 2964).
-    No         <> _                = No
-    _          <> No               = No
-    Yes s us   <> Yes s' vs        = Yes (s <> s') (us <> vs)
+    (DontKnow p l b , DontKnow p' l' b' ) -> DontKnow (p <> p') (l <> l') (b <> b')
+    (DontKnow{}     , Yes{}             ) -> m
+    (DontKnow p _ _ , No p'             ) -> if p < p' then m else m'
+    (Yes{}          , DontKnow{}        ) -> m'
+    (No p           , DontKnow p' _ _   ) -> if p' < p then m' else m
+    (No p           , No p'             ) -> No (p <> p')
+    (No{}           , Yes{}             ) -> m
+    (Yes{}          , No{}              ) -> m'
+    (Yes s us       , Yes s' vs         ) -> Yes (s <> s') (us <> vs)
 
 instance Monoid (Match a) where
     mempty = empty
@@ -80,6 +89,7 @@ instance Monoid (Match a) where
 
 -- | Whether the inconclusive matches are only on lazy patterns.
 data OnlyLazy = OnlyLazy | NonLazy
+  deriving (Show)
 
 instance Semigroup OnlyLazy where
   NonLazy  <> _        = NonLazy
@@ -120,8 +130,8 @@ foldMatch match = loop where
       (p : ps, v : vs) -> do
         (r, v') <- match p v
         case r of
-          No | Just{} <- isProjP p -> return (No, v' : vs)
-          No -> do
+          No prio | Just{} <- isProjP p -> return (No prio, v' : vs)
+          No _ -> do
             -- Issue 2964: Even when the first pattern doesn't match we should
             -- continue to the next patterns (and potentially block on them)
             -- because the splitting order in the case tree may not be
@@ -131,10 +141,10 @@ foldMatch match = loop where
             -- contain ill-typed terms due to eta-expansion at wrong
             -- type.
             return (r <> r', v' : vs)
-          DontKnow OnlyLazy _ -> do
+          DontKnow _ OnlyLazy _ -> do
             (r', _vs') <- loop ps vs
             return (r <> r', v' : vs)
-          DontKnow NonLazy m -> return (DontKnow NonLazy m, v' : vs)
+          DontKnow prio NonLazy m -> return (DontKnow prio NonLazy m, v' : vs)
           Yes{} -> do
             (r', vs') <- loop ps vs
             return (r <> r', v' : vs')
@@ -190,10 +200,10 @@ matchCopattern pat@ProjP{} elim@(Proj _ q) = do
          _         -> __IMPOSSIBLE__
   q       <- getOriginalProjection q
   return $ if p == q then (Yes YesSimplification empty, elim)
-                     else (No,                          elim)
+                     else (No empty,                    elim)
 -- The following two cases are not impossible, see #2964
-matchCopattern ProjP{} elim@Apply{}   = return (No , elim)
-matchCopattern _       elim@Proj{}    = return (No , elim)
+matchCopattern ProjP{} elim@Apply{}   = return (No empty, elim)
+matchCopattern _       elim@Proj{}    = return (No empty, elim)
 matchCopattern p       (Apply v) = second Apply <$> matchPattern p v
 matchCopattern p       e@(IApply x y r) = second (mergeElim e) <$> matchPattern p (defaultArg r)
 
@@ -224,30 +234,31 @@ matchPattern :: MonadMatch m
              => DeBruijnPattern
              -> Arg Term
              -> m (Match Term, Arg Term)
-matchPattern p u = case (p, u) of
+matchPattern p u = debugMatchPattern $ case (p, u) of
   (ProjP{}, _            ) -> __IMPOSSIBLE__
   (IApplyP _ _ _ x , arg ) -> return (Yes NoSimplification entry, arg)
     where entry = singleton (dbPatVarIndex x, arg)
   (VarP _ x , arg          ) -> return (Yes NoSimplification entry, arg)
     where entry = singleton (dbPatVarIndex x, arg)
   (DotP _ _ , arg@(Arg _ v)) -> return (Yes NoSimplification empty, arg)
-  (LitP _ l , arg@(Arg _ v)) -> do
+  (LitP LitPatternInfo{ litPPrio = prio } l , arg@(Arg _ v)) -> do
     w <- reduceB v
     let arg' = arg $> ignoreBlocking w
     case w of
       NotBlocked _ (Lit l')
-          | l == l'            -> return (Yes YesSimplification empty , arg')
-          | otherwise          -> return (No                          , arg')
-      Blocked b _              -> return (DontKnow NonLazy $ Blocked b ()     , arg')
-      NotBlocked r t           -> return (DontKnow NonLazy $ NotBlocked r' () , arg')
+          | l == l'   -> return (Yes YesSimplification empty , arg')
+          | otherwise -> return (No prio                     , arg')
+      Blocked b _     -> return (DontKnow prio NonLazy $ Blocked b ()     , arg')
+      NotBlocked r t  -> return (DontKnow prio NonLazy $ NotBlocked r' () , arg')
         where r' = stuckOn (Apply arg') r
 
   -- Case constructor pattern.
   (ConP c cpi ps, Arg info v) -> do
+    let prio = conPPrio cpi
     let lazy = if conPLazy cpi then OnlyLazy else NonLazy
-    if not (conPRecord cpi) then fallback c lazy ps (Arg info v) else do
+    if not (conPRecord cpi) then fallback c prio lazy ps (Arg info v) else do
     isEtaRecordConstructor (conName c) >>= \case
-      Nothing -> fallback c lazy ps (Arg info v)
+      Nothing -> fallback c prio lazy ps (Arg info v)
       -- Case: Eta record constructor.
       -- This case is necessary if we want to use the clauses before
       -- record pattern translation (e.g., in type-checking definitions by copatterns).
@@ -262,7 +273,7 @@ matchPattern p u = case (p, u) of
         -- `v` might be an application of a *different* constructor.
         -- In that case we certainly have no match.
         case v of
-          Con c' _ _ | c /= c' -> return (No, u)
+          Con c' _ _ | c /= c' -> return (No prio, u)
           _ -> do
             let fs = map argFromDom $ _recFields def
             unless (size fs == size ps) __IMPOSSIBLE__
@@ -271,15 +282,31 @@ matchPattern p u = case (p, u) of
   (DefP o q ps, v) -> do
     let f (Def q' vs) | q == q' = Just (Def q, vs)
         f _                     = Nothing
-    fallback' f NonLazy ps v
+    fallback' f empty NonLazy ps v
  where
+  debugMatchPattern go = do
+    reportSDoc "tc.match" 20 $
+       vcat [ "matchPattern"
+            , nest 2 $ "p =" <+> prettyTCM p
+            , nest 2 $ "u =" <+> prettyTCM u
+            ]
+    reportSDoc "tc.match" 60 $
+       vcat [ nest 2 $ "p (raw) =" <+> (text . show) p
+            ]
+    (m, t) <- go
+    reportSDoc "tc.match" 50 $
+      vcat [ nest 2 $ "result = " <+> (text . show) m ]
+    -- reportSDoc "tc.match" 20 $
+    --   vcat [ nest 2 $ "result = " <+> prettyTCM m ]
+    return (m, t)
+
     -- Default: not an eta record constructor.
   fallback :: MonadMatch m
-           => ConHead -> OnlyLazy -> [NamedArg DeBruijnPattern] -> Arg Term -> m (Match Term, Arg Term)
-  fallback c lazy ps v = do
+           => ConHead -> MatchPrio -> OnlyLazy -> [NamedArg DeBruijnPattern] -> Arg Term -> m (Match Term, Arg Term)
+  fallback c prio lazy ps v = do
     let f (Con c' ci' vs) | c == c' = Just (Con c' ci',vs)
         f _                         = Nothing
-    fallback' f lazy ps v
+    fallback' f prio lazy ps v
 
   -- Regardless of blocking, constructors and a properly applied @hcomp@
   -- can be matched on.
@@ -298,11 +325,12 @@ matchPattern p u = case (p, u) of
   -- DefP hcomp and ConP matching.
   fallback' :: MonadMatch m
             => (Term -> Maybe (Elims -> Term , Elims))
+            -> MatchPrio
             -> OnlyLazy
             -> [NamedArg DeBruijnPattern]
             -> Arg Term
             -> m (Match Term, Arg Term)
-  fallback' mtc lazy ps (Arg info v) = do
+  fallback' mtc prio lazy ps (Arg info v) = do
         isMatchable <- isMatchable'
 
         w <- reduceB v
@@ -333,9 +361,9 @@ matchPattern p u = case (p, u) of
                 (m, vs1) <- matchPatterns ps (fromMaybe __IMPOSSIBLE__ $ allApplyElims vs)
                 return (yesSimplification m, Arg info $ bld (mergeElims vs vs1))
               Nothing
-                                    -> return (No                          , arg)
-          Blocked b _               -> return (DontKnow lazy $ Blocked b ()     , arg)
-          NotBlocked r _            -> return (DontKnow lazy $ NotBlocked r' () , arg)
+                                    -> return (No prio                               , arg)
+          Blocked b _               -> return (DontKnow prio lazy $ Blocked b ()     , arg)
+          NotBlocked r _            -> return (DontKnow prio lazy $ NotBlocked r' () , arg)
             where r' = stuckOn (Apply arg) r
 
 yesSimplification :: Match a -> Match a
@@ -369,7 +397,7 @@ matchPatternP p arg@(Arg info q) = do
     ConP c cpi ps ->
       case q of
         ConP c' _ qs | c == c'   -> matchPatternsP ps ((map . fmap) namedThing qs)
-                     | otherwise -> return No
+                     | otherwise -> return $ No (conPPrio cpi)
         LitP{} -> fmap toLitP <$> termMatch
           where toLitP (DotP _ (Lit l)) = litP l   -- All bindings should be to literals
                 toLitP _                = __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs-boot
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs-boot
@@ -11,7 +11,10 @@ import Agda.TypeChecking.Substitute (DeBruijn)
 
 import Agda.Utils.Impossible
 
-data Match a = Yes Simplification (IntMap (Arg a)) | No | DontKnow OnlyLazy (Blocked ())
+data Match a
+  = Yes Simplification (IntMap (Arg a))
+  | No MatchPrio
+  | DontKnow MatchPrio OnlyLazy (Blocked ())
 
 data OnlyLazy = OnlyLazy | NonLazy
 

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1017,15 +1017,15 @@ appDefE'' v cls rewr es = traceSDoc "tc.reduce" 90 ("appDefE' v = " <+> pretty v
             (m, es0) <- matchCopatterns pats es0
             let es = es0 ++! es1
             case m of
-              No               -> goCls cls es
+              No _ -> goCls cls es
               -- Szumi, 2024-03-29, issue #7181:
               -- If a lazy match is stuck and all non-lazy matches are conclusive,
               -- then reduction should not be stuck on the current clause and it
               -- should be fine to continue matching on the next clause.
               -- This assumes it's impossible for a lazy match to be stuck if
               -- all non-lazy matches succeed.
-              DontKnow OnlyLazy _ -> goCls cls es
-              DontKnow NonLazy  b -> rewrite b (applyE v) rewr es
+              DontKnow _ OnlyLazy _ -> goCls cls es
+              DontKnow _ NonLazy  b -> rewrite b (applyE v) rewr es
               Yes simpl vs -- vs is the subst. for the variables bound in body
                 | couldBeRecursive (clauseRecursive cl)
                 , RecursiveReductions `SmallSet.notMember` allowedReductions ->

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -578,7 +578,7 @@ defineCompData d con params names fsT t boundary = do
 
         -- Δ.Φ ⊢ u = Con con ConOSystem $ teleElims fsT boundary : R δ
 --        u = Con con ConOSystem $ teleElims fsT boundary
-        up = ConP con (ConPatternInfo defaultPatternInfo False False Nothing False) $
+        up = ConP con (ConPatternInfo defaultPatternInfo False False Nothing False empty) $
                telePatterns (d0 `applySubst` fsT) (liftS (size fsT) d0 `applySubst` boundary)
 --        gamma' = telFromList $ take' (size gamma - 1) $ telToList gamma
 
@@ -643,7 +643,7 @@ defineProjections dataName con params names fsT t = do
   forM_ (zip3 (downFrom (size fieldTypes)) names fieldTypes) $ \ (i,projName,ty) -> do
     let
       projType = abstract projTel <$> ty
-      cpi    = ConPatternInfo defaultPatternInfo False False (Just $ argN $ raise (size fsT) t) False
+      cpi    = ConPatternInfo defaultPatternInfo False False (Just $ argN $ raise (size fsT) t) False empty
       conp   = defaultNamedArg $ ConP con cpi $ teleNamedArgs fsT
       sigma  = Con con ConOSystem (map' Apply $ teleArgs fsT) `consS` raiseS (size fsT)
       clause = empty

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -459,26 +459,27 @@ transferOrigins ps qs = do
     transfer :: A.Pattern -> DeBruijnPattern -> TCM DeBruijnPattern
     transfer p q = case (asView p , q) of
 
-      ((asB , A.ConP pi _ ps) , ConP c (ConPatternInfo i r ft mb l) qs) -> do
-        let cpi = ConPatternInfo (PatternInfo PatOCon asB) r ft mb l
+      ((asB , A.ConP pi _ ps) , ConP c (ConPatternInfo i r ft mb l prio) qs) -> do
+        let cpi = ConPatternInfo (PatternInfo PatOCon asB) r ft mb l prio
         ConP c cpi <$> transfers ps qs
 
-      ((asB , A.RecP _kwr pi fs) , ConP c (ConPatternInfo i r ft mb l) qs) -> do
+      ((asB , A.RecP _kwr pi fs) , ConP c (ConPatternInfo i r ft mb l prio) qs) -> do
         let Def d _  = unEl $ unArg $ fromMaybe __IMPOSSIBLE__ mb
             axs = map' (nameConcrete . qnameName . unArg) (conFields c) `withArgsFrom` qs
-            cpi = ConPatternInfo (PatternInfo PatORec asB) r ft mb l
+            cpi = ConPatternInfo (PatternInfo PatORec asB) r ft mb l prio
         ps <- insertMissingFieldsFail ConORec d (const $ A.WildP empty) fs axs
         ConP c cpi <$> transfers ps qs
 
-      ((asB , p) , ConP c (ConPatternInfo i r ft mb l) qs) -> do
-        let cpi = ConPatternInfo (PatternInfo (patOrig p) asB) r ft mb l
+      ((asB , p) , ConP c (ConPatternInfo i r ft mb l prio) qs) -> do
+        let cpi = ConPatternInfo (PatternInfo (patOrig p) asB) r ft mb l prio
         return $ ConP c cpi qs
 
       ((asB , p) , VarP _ x) -> return $! VarP (PatternInfo (patOrig p) asB) x
 
       ((asB , p) , DotP _ u) -> return $! DotP (PatternInfo (patOrig p) asB) u
 
-      ((asB , p) , LitP _ l) -> return $! LitP (PatternInfo (patOrig p) asB) l
+      ((asB , p) , LitP (LitPatternInfo _ prio) l) ->
+        return $! LitP (LitPatternInfo (PatternInfo (patOrig p) asB) prio) l
 
       _ -> return q
 
@@ -736,7 +737,7 @@ checkLeftHandSide call lhsRng f ps a withSub' strippedPats =
       eqs0 = zipWith3 ProblemEq (map' namedArg cps) (map' var $ downFrom $ size tel) (flattenTel tel)
 
   let finalChecks :: LHSState a -> TCM a
-      finalChecks (LHSState delta qs0 (Problem eqs rps _) b psplit ixsplit) = do
+      finalChecks (LHSState delta qs0 (Problem eqs rps _) b psplit ixsplit _prio) = do
 
         reportSDoc "tc.lhs.top" 20 $ vcat
           [ "lhs: final checks with remaining equations"
@@ -997,7 +998,7 @@ checkLHS mf = updateModality checkLHS_ where
  {-# INLINE updateModality #-}
     -- If the target type is irrelevant or in Prop,
     -- we need to check the lhs in irr. cxt. (see Issue 939).
- updateModality cont = \st@(LHSState tel ip problem target psplit _) -> do
+ updateModality cont = \st@(LHSState tel ip problem target psplit _ _prio) -> do
       let m = getModality target
       applyModalityToContext m $ do
         cont $ over (lhsTel . listTel)
@@ -1005,7 +1006,7 @@ checkLHS mf = updateModality checkLHS_ where
         -- Andreas, 2018-10-23, issue #3309
         -- the modalities in the clause telescope also need updating.
 
- checkLHS_ st@(LHSState tel ip problem target psplit ixsplit) = do
+ checkLHS_ st@(LHSState tel ip problem target psplit ixsplit prio) = do
   reportSDoc "tc.lhs" 40 $ "tel is" <+> prettyTCM tel
   reportSDoc "tc.lhs" 40 $ "ip is" <+> pretty ip
   reportSDoc "tc.lhs" 40 $ "target is" <+> addContext tel (prettyTCM target)
@@ -1128,7 +1129,7 @@ checkLHS mf = updateModality checkLHS_ where
           ip'      = ip ++! [projP]
           -- drop the projection pattern (already splitted)
           problem' = over problemRestPats (drop 1) problem
-      liftTCM $ updateLHSState (LHSState tel ip' problem' target' psplit ixsplit)
+      liftTCM $ updateLHSState (LHSState tel ip' problem' target' psplit ixsplit prio)
 
 
     -- Split a Partial.
@@ -1281,7 +1282,7 @@ checkLHS mf = updateModality checkLHS_ where
       -- Compute the new state
       let problem' = set problemEqs eqs' problem
       reportSDoc "tc.lhs.split.partial" 60 $ text (show problem')
-      liftTCM $ updateLHSState (LHSState delta' ip' problem' target' (psplit ++! [Just o_n]) ixsplit)
+      liftTCM $ updateLHSState (LHSState delta' ip' problem' target' (psplit ++! [Just o_n]) ixsplit prio)
 
 
     splitLit :: Telescope      -- The types of arguments before the one we split on
@@ -1324,7 +1325,7 @@ checkLHS mf = updateModality checkLHS_ where
 
       -- Compute the new state
       let problem' = set problemEqs eqs' problem
-      liftTCM $ updateLHSState (LHSState delta' ip' problem' target' psplit ixsplit)
+      liftTCM $ updateLHSState (LHSState delta' ip' problem' target' psplit ixsplit prio)
 
 
     splitCon :: Telescope      -- The types of arguments before the one we split on
@@ -1540,7 +1541,9 @@ checkLHS mf = updateModality checkLHS_ where
                                    , conPRecord = isRec
                                    , conPFallThrough = False
                                    , conPType   = Just $ Arg info a'
-                                   , conPLazy   = False } -- Don't mark eta-record matches as lazy (#4254)
+                                   , conPLazy   = False  -- Don't mark eta-record matches as lazy (#4254)
+                                   , conPPrio   = prio
+                                   }
 
           -- compute final context and substitution
           let crho    = ConP c cpi $ applySubst rho0 $ (telePatterns gamma boundary)
@@ -1602,7 +1605,7 @@ checkLHS mf = updateModality checkLHS_ where
 
           -- if rest type reduces,
           -- extend the split problem by previously not considered patterns
-          st' <- liftTCM $ updateLHSState $ LHSState delta' ip' problem' target'' psplit (ixsplit || not (null ixs))
+          st' <- liftTCM $ updateLHSState $ LHSState delta' ip' problem' target'' psplit (ixsplit || not (null ixs)) prio
 
           reportSDoc "tc.lhs.top" 12 $ sep
             [ "new problem from rest"

--- a/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
@@ -237,6 +237,14 @@ data LHSState a = LHSState
     -- ^ have we splitted with a PartialFocus?
   , _lhsIndexedSplit :: !Bool
     -- ^ Have we split on any indexed inductive types?
+  , _lhsMatchPrio :: !MatchPrio
+    -- ^ The match priority attached to the next split.
+    --   The priority approximates causality, i.e. some splits (higher prio value) become available
+    --   only after certain splits (lower prio value) have already been made.
+    --   This information is used in the matcher for the non-compiled clauses
+    --   to determine whether a 'DontKnow' dominates a 'No' (mismatch).
+    --   The lower prio value is dominant in case of conflict.
+    --   See issues #2964 and #3054, #8559.
   }
 
 lhsTel :: Lens' (LHSState a) Telescope
@@ -250,6 +258,9 @@ lhsProblem f p = f (_lhsProblem p) <&> \x -> p {_lhsProblem = x}
 
 lhsTarget :: Lens' (LHSState a) (Arg Type)
 lhsTarget f p = f (_lhsTarget p) <&> \x -> p {_lhsTarget = x}
+
+lhsMatchPrio :: Lens' (LHSState a) MatchPrio
+lhsMatchPrio f p = f (_lhsMatchPrio p) <&> \ x -> p{ _lhsMatchPrio = x }
 
 data PatVarPosition = PVLocal | PVParam
   deriving (Show, Eq)
@@ -419,10 +430,14 @@ instance InstantiateFull AsBinding where
   instantiateFull' (AsB x v a) = AsB x <$> instantiateFull' v <*> instantiateFull' a
 
 instance PrettyTCM (LHSState a) where
-  prettyTCM (LHSState tel outPat (Problem eqs rps _) target _ _) = vcat
+  prettyTCM (LHSState tel outPat (Problem eqs rps _) target _ _ prio) = vcat
     [ "tel             = " <+> prettyTCM tel
     , "outPat          = " <+> addContext tel (prettyTCMPatternList outPat)
     , "problemEqs      = " <+> addContext tel (prettyList_ $ map prettyTCM eqs)
     , "problemRestPats = " <+> prettyList_ (map prettyA rps)
     , "target          = " <+> addContext tel (prettyTCM target)
+    , "matchPrio       = " <+> prettyTCM prio
     ]
+
+instance PrettyTCM MatchPrio where
+  prettyTCM (MatchPrio prio) = (text . show) prio

--- a/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
@@ -2,6 +2,8 @@
 
 module Agda.TypeChecking.Rules.LHS.ProblemRest where
 
+import Prelude hiding (null)
+
 import Control.Monad
 import Control.Monad.Except
 
@@ -21,6 +23,7 @@ import Agda.TypeChecking.Rules.LHS.Problem
 import Agda.TypeChecking.Rules.LHS.Implicit
 
 import Agda.Utils.Functor
+import Agda.Utils.Null
 import Agda.Utils.Size
 
 import Agda.Utils.Impossible
@@ -105,14 +108,14 @@ initLHSState delta eqs ps a ret = do
   let problem = Problem eqs ps ret
       qs0     = teleNamedArgs delta
 
-  updateProblemRest $ LHSState delta qs0 problem (Arg (defaultArgInfo { argInfoModality = unitModality }) a) [] False
+  updateProblemRest $ LHSState delta qs0 problem (Arg (defaultArgInfo { argInfoModality = unitModality }) a) [] False empty
 
 -- | Try to move patterns from the problem rest into the problem.
 --   Possible if type of problem rest has been updated to a function type.
 updateProblemRest
   :: forall m a. (PureTCM m, MonadError TCErr m, MonadTrace m, MonadFresh NameId m)
   => LHSState a -> m (LHSState a)
-updateProblemRest st@(LHSState tel0 qs0 p@(Problem oldEqs ps ret) a psplit ixsplit) = addContext tel0 $ do
+updateProblemRest st@(LHSState tel0 qs0 p@(Problem oldEqs ps ret) a psplit ixsplit prio) = addContext tel0 $ do
   ps <- insertImplicitPatternsT ExpandLast ps $ unArg a
   reportSDoc "tc.lhs.imp" 20 $
     "insertImplicitPatternsT returned" <+> fsep (map prettyA ps)
@@ -164,4 +167,12 @@ updateProblemRest st@(LHSState tel0 qs0 p@(Problem oldEqs ps ret) a psplit ixspl
     , _lhsTarget  = a $> b
     , _lhsPartialSplit = psplit
     , _lhsIndexedSplit = ixsplit
+    , _lhsMatchPrio    = succ prio
+        -- Andreas, 2026-05-09, issue #8559
+        -- We approximate the split causality by simply increasing the prio
+        -- at each call to 'updateProblemRest'.
+        -- This is somewhat crude but sufficient to pass #3054 and #8559 and fail #2964
+        -- as intended.
+        -- Should there be examples where this simply heuristics is not adequate,
+        -- it needs to be refined.
     }

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -548,7 +548,9 @@ checkRecordProjections m r hasNamedCon con tel ftel fs = do
                                     , conPRecord = True
                                     , conPFallThrough = False
                                     , conPType   = Just $ argFromDom $ fmap snd rt
-                                    , conPLazy   = True }
+                                    , conPLazy   = True
+                                    , conPPrio   = empty
+                                    }
             conp   = defaultNamedArg $ ConP con cpi $ teleNamedArgs ftel
             body   = Just $ bodyMod $ var (size ftel2)
             cltel  = ptel `abstract` ftel

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 #include "MachDeps.h"
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20260501 * 10 + 0
+currentInterfaceVersion = 20260509 * 10 + 0
 
 ifaceVersionSize :: Int
 ifaceVersionSize = SIZEOF_WORD64

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -584,9 +584,13 @@ instance EmbPrj I.Clause where
   value = valueN Clause
 
 instance EmbPrj I.ConPatternInfo where
-  icod_ (ConPatternInfo a b c d e) = icodeN' ConPatternInfo a b c d e
+  icod_ (ConPatternInfo a b c d e f) = icodeN' ConPatternInfo a b c d e f
 
   value = valueN ConPatternInfo
+
+instance EmbPrj MatchPrio where
+  icod_ (MatchPrio n) = icodeN' MatchPrio n
+  value = valueN MatchPrio
 
 instance EmbPrj I.DBPatVar where
   icod_ (DBPatVar a b) = icodeN' DBPatVar a b
@@ -597,6 +601,10 @@ instance EmbPrj I.PatternInfo where
   icod_ (PatternInfo a b) = icodeN' PatternInfo a b
 
   value = valueN PatternInfo
+
+instance EmbPrj I.LitPatternInfo where
+  icod_ (LitPatternInfo a b) = icodeN' LitPatternInfo a b
+  value = valueN LitPatternInfo
 
 instance EmbPrj I.PatOrigin where
   icod_ PatOSystem       = icodeN' PatOSystem

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1349,10 +1349,10 @@ usePatternInfo i p = case patternOrigin p of
   Just _          -> case p of
     (VarP _ x) -> VarP i x
     (DotP _ u) -> DotP i u
-    (ConP c (ConPatternInfo _ r ft b l) ps)
-      -> ConP c (ConPatternInfo i r ft b l) ps
+    (ConP c (ConPatternInfo _ r ft b l prio) ps)
+      -> ConP c (ConPatternInfo i r ft b l prio) ps
     DefP _ q ps -> DefP i q ps
-    (LitP _ l) -> LitP i l
+    (LitP (LitPatternInfo _ prio) l) -> LitP (LitPatternInfo i prio) l
     ProjP{} -> __IMPOSSIBLE__
     (IApplyP _ t u x) -> IApplyP i t u x
 

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -412,6 +412,7 @@ expandTelescopeVar gamma k delta c = (tel', rho)
                    = False
       , conPType   = Just $ argFromDom a
       , conPLazy   = True
+      , conPPrio   = MatchPrio 0
       }
     cargs       = map' (setOrigin Inserted) $ teleNamedArgs delta
     cdelta      = ConP c cpi cargs                    -- Γ₁Δ ⊢ c Δ : D pars

--- a/test/Fail/Issue2964.agda
+++ b/test/Fail/Issue2964.agda
@@ -1,3 +1,6 @@
+-- {-# OPTIONS -v tc.lhs.top:90 #-}
+-- {-# OPTIONS -v tc.match:60 #-}
+
 open import Agda.Builtin.Bool
 open import Agda.Builtin.Equality
 
@@ -8,6 +11,23 @@ record R : Set₁ where
 open R
 
 test : R
-fun test .Bool true true refl = true
-fun test _     _    _    _    = false
-rule test x = refl
+test .fun .Bool true true refl = true
+test .fun _     _    _    _    = false
+test .rule x = refl
+
+-- Expected error: [UnequalTerms]
+-- The terms
+--   test .fun Bool false x refl
+-- and
+--   false
+-- are not equal at type Bool
+-- when checking that the expression refl has type
+-- test .fun Bool false x refl ≡ false
+
+-- The equation
+--
+--   test .fun Bool false x refl = false
+--
+-- is not definitional because the generated splittree
+-- happens to split on x before splitting on refl.
+-- (Left to right splitting order when possible.)

--- a/test/Fail/Issue2964.err
+++ b/test/Fail/Issue2964.err
@@ -1,4 +1,4 @@
-Issue2964.agda:13.15-19: error: [UnequalTerms]
+Issue2964.agda:16.16-20: error: [UnequalTerms]
 The terms
   test .fun Bool false x refl
 and

--- a/test/Succeed/Issue3054.agda
+++ b/test/Succeed/Issue3054.agda
@@ -1,0 +1,20 @@
+-- Andreas, 2026-05-09, issue #3054, regression in 2.6.0 introduced by fix of #2964
+-- Reported and test case by Andrea Vezzosi
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.Bool
+
+T : Bool → Set
+T true  = Bool → Bool
+T false = Bool → Bool
+
+foo : Σ (∀ b → T b) (\ f → ∀ x → f false x ≡ true)
+foo .fst true  false = true  -- This split was making clause 3 non-definitional, but not rightfully so.
+foo .fst true  true  = true
+foo .fst false x     = true  -- This clause should be a definitional equality even during lhs checking.
+-- the following should pass.
+-- we can give the "refl", but after reloading it fails.
+foo .snd x           = refl
+
+-- Should succeed

--- a/test/Succeed/Issue8559.agda
+++ b/test/Succeed/Issue8559.agda
@@ -1,0 +1,52 @@
+-- Andreas, 2026-05-09, issue #8559, duplicate of #3054
+-- Report and test case by Nate Soares
+-- Regression introduced in 2.6.0 by fix of #2964
+
+data _≡_ {A : Set} (a : A) : A → Set where
+    refl : a ≡ a
+
+data Bool : Set where
+    false true : Bool
+
+data _≤_ : Bool → Bool → Set where
+    false≤ : ∀ b → false ≤ b
+    true≤ : true ≤ true
+
+id : ∀ b → b ≤ b
+id false = false≤ false
+id true = true≤
+
+record IsSieve (B : Bool → Set) : Set where
+    field
+        sift : ∀ {a b} → a ≤ b → B b → B a
+        sift-id : ∀ a (x : B a) → x ≡ sift (id a) x
+
+data F : Bool → Set where
+    ffalse : F false
+    ftrue : F true
+
+sift-F : ∀ {a b} → a ≤ b → F b → F a
+sift-F {false} {false} _ x = x
+sift-F {false} {true} _ ftrue = ffalse
+sift-F {true} {true} _ x = x
+
+Works : IsSieve F
+Works .IsSieve.sift = sift-F
+Works .IsSieve.sift-id false _ = refl
+Works .IsSieve.sift-id true _ = refl
+
+Breaks : IsSieve F
+Breaks .IsSieve.sift {false} {false} _ x = x
+Breaks .IsSieve.sift {false} {true} _ ftrue = ffalse   -- (2)
+Breaks .IsSieve.sift {true} {true} _ x = x             -- (3)
+Breaks .IsSieve.sift-id false _ = refl
+Breaks .IsSieve.sift-id true _ = refl                  -- (5)
+
+-- WAS: last refl (5) failed because clause (3) did not fire during lhs checking,
+-- only after coverage checking.
+-- Firing (3) was blocked by the match ftrue/x in clause (2) that since the fix of #2964
+-- resulted in a "DontKnow" even though the prior match false/true is a hard "No".
+
+-- NOW: succeeds.
+-- We only turn "No" into "DontKnow" now if the "DontKnow" has a higher priority,
+-- i.e. if in the resulting case tree split it could precede the "No".


### PR DESCRIPTION
In #2964 we discovered that inconclusive matches (`DontKnow`) should dominate mismatches (`No`) in the matcher for non-compiled clauses because the split tree constructed by the coverage checker later could put the inconclusive match before the mismatch (yielding a stuck reduction).

However, not every `DontKnow` should override a `No`, only those that can actually come before in a possible split tree. Some splits are only becoming available by prior splits, and those
should not have the possibility ot override.

We approximate this "split causality" by a new `MatchPrio` field attached to constructor and literal patterns.
Currently, the `MatchPrio` is incremented in the LHS checker at each call of `updateProblemRest`.  This might be too crude but works for the given reproducers.

Closes #3054 closes #8559
