### PR TITLE
adding some tests to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,12 @@ test : check-whitespace \
        std-lib-interaction \
        user-manual-test \
        doc-test \
-       size-solver-test
+       size-solver-test \
+	   test-suite-covers-errors \
+	   test-suite-covers-warnings \
+	   user-manual-covers-options \
+	   user-manual-covers-warnings \
+	   build-succeed-test \
 
 .PHONY : test-using-std-lib ## Run all tests which use the standard library.
 test-using-std-lib : std-lib-test \

--- a/Makefile
+++ b/Makefile
@@ -429,6 +429,8 @@ test : check-whitespace \
 	   user-manual-covers-options \
 	   user-manual-covers-warnings \
 	   build-succeed-test \
+	   build-fail-test \
+	   cubical-succeed
 
 .PHONY : test-using-std-lib ## Run all tests which use the standard library.
 test-using-std-lib : std-lib-test \

--- a/Makefile
+++ b/Makefile
@@ -407,10 +407,17 @@ test : check-whitespace \
        succeed \
        fail \
        bugs \
+	   build-succeed-test \
+	   build-fail-test \
        interaction \
+	   test-suite-covers-errors \
+	   test-suite-covers-warnings \
+	   user-manual-covers-options \
+	   user-manual-covers-warnings \
        examples \
        std-lib-test \
        cubical-test \
+	   cubical-succeed \
        interactive \
        latex-html-test \
        api-test \
@@ -423,14 +430,7 @@ test : check-whitespace \
        std-lib-interaction \
        user-manual-test \
        doc-test \
-       size-solver-test \
-	   test-suite-covers-errors \
-	   test-suite-covers-warnings \
-	   user-manual-covers-options \
-	   user-manual-covers-warnings \
-	   build-succeed-test \
-	   build-fail-test \
-	   cubical-succeed
+       size-solver-test
 
 .PHONY : test-using-std-lib ## Run all tests which use the standard library.
 test-using-std-lib : std-lib-test \


### PR DESCRIPTION
https://github.com/agda/agda/issues/8359

addresses the missing `test-suite-covers-errors`. for the others I looked at the GitHub actions file so I'm kinda confident on those but may have overlooked others