### PR TITLE
Fix occurrences in over-applied args, primitives and postulates

### DIFF
--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -688,7 +688,7 @@ mapForcedArguments c xs k = do
 -- | Extract recursive calls from one clause.
 termClause :: Clause -> TerM Calls
 termClause clause = do
-  Clause{ clauseTel = tel, namedClausePats = ps, clauseBody = body } <- etaExpandClause clause
+  Clause{ clauseTel = tel, namedClausePats = ps, clauseBody = body } <- snd <$> etaExpandClause clause
   liftTCM $ reportSDoc "term.check.clause" 25 $ vcat
     [ "termClause"
     , nest 2 $ "tel =" <+> prettyTCM tel

--- a/src/full/Agda/TypeChecking/Functions.hs
+++ b/src/full/Agda/TypeChecking/Functions.hs
@@ -23,11 +23,12 @@ import Agda.Utils.Functor ( ($>) )
 import Agda.Syntax.Common.Pretty ( prettyShow )
 import Agda.Utils.Monad
 import Agda.Utils.Size
+import Agda.Utils.List
 import Agda.Utils.Tuple ( first )
 
-
--- | Expand a clause to the maximal arity, by inserting variable
---   patterns and applying the body to variables.
+{-# SPECIALIZE etaExpandClause :: Clause -> TCM (Int, Clause) #-}
+-- | Expand a clause to the maximal arity, by inserting variable patterns and applying the body to
+--   variables. Return the arity and the expanded clause.
 
 --  Fixes issue #2376.
 --  Replaces 'introHiddenLambdas'.
@@ -36,11 +37,11 @@ import Agda.Utils.Tuple ( first )
 --  This is used instead of special treatment of lambdas
 --  (which was unsound: Issue #121)
 
-etaExpandClause :: PureTCM tcm => Clause -> tcm Clause
+etaExpandClause :: PureTCM tcm => Clause -> tcm (Int, Clause)
 etaExpandClause clause = do
   case clause of
-    Clause _  _  ctel ps _           Nothing  _ _ _ _ _ -> return clause
-    Clause _  _  ctel ps Nothing     (Just t) _ _ _ _ _ -> return clause
+    Clause _  _  ctel ps _           Nothing  _ _ _ _ _ -> let !arity = length ps in pure (arity, clause)
+    Clause _  _  ctel ps Nothing     (Just t) _ _ _ _ _ -> let !arity = length ps in pure (arity, clause)
     Clause rl rf ctel ps (Just body) (Just t) catchall recursive unreachable ell wm -> do
 
       -- Get the telescope to expand the clause with.
@@ -48,14 +49,14 @@ etaExpandClause clause = do
 
       -- If the rhs has lambdas, harvest the names of the bound variables.
       let xs   = peekLambdas body
-      let ltel = useNames xs $ telToList tel0
+      let ltel = useNames xs $! telToList tel0
       let tel  = telFromList ltel
       let n    = size tel
       unless (n == size tel0) __IMPOSSIBLE__  -- useNames should not drop anything
       -- Join with lhs telescope, extend patterns and apply body.
       -- NB: no need to raise ctel!
-      let ctel' = telFromList $ telToList ctel ++ ltel
-          ps'   = raise n ps ++ teleNamedArgs tel
+      let ctel' = telFromList $! telToList ctel ++! ltel
+          ps'   = raise n ps ++! teleNamedArgs tel
           body' = raise n body `apply` teleArgs tel
       reportSDoc "term.clause.expand" 30 $ inTopContext $ vcat
         [ "etaExpandClause"
@@ -63,13 +64,14 @@ etaExpandClause clause = do
         , "  xs      = " <+> text (prettyShow xs)
         , "  new tel = " <+> prettyTCM ctel'
         ]
-      return $ Clause rl rf ctel' ps' (Just body') (Just (t $> t')) catchall recursive unreachable ell wm
+      let !arity = length ps + size tel0
+      pure (arity, Clause rl rf ctel' ps' (Just body') (Just (t $> t')) catchall recursive unreachable ell wm)
   where
     -- Get all initial lambdas of the body.
     peekLambdas :: Term -> [Arg ArgName]
     peekLambdas v =
       case v of
-        Lam info b -> Arg info (absName b) : peekLambdas (unAbs b)
+        Lam info b -> (Arg info (absName b) :) $! peekLambdas (unAbs b)
         _ -> []
 
     -- Use the names of the first argument, and set the Origin all other

--- a/src/full/Agda/TypeChecking/Positivity/OccurrenceAnalysis.hs
+++ b/src/full/Agda/TypeChecking/Positivity/OccurrenceAnalysis.hs
@@ -142,15 +142,16 @@ type NodeMap v = HT.HashTableLL Node v
 lookupNode :: Node -> NodeMap v -> (v -> IO a) -> IO a -> IO a
 lookupNode node map found notfound = HT.lookupCPS node map found notfound
 
-{-# NOINLINE isMutual #-}
-isMutual :: QName -> OccM Bool
-isMutual q = do
-  mutuals <- asks mutuals
-  lift $ lift $ HT.hasKey mutuals q
+{-# INLINE lookupMutual #-}
+lookupMutual :: QName -> (Int -> OccM a) -> OccM a -> OccM a
+lookupMutual q found notfound = ReaderT \e -> TCM \tcs tce ->
+  HT.lookupCPS q (mutuals e)
+    (\x -> unTCM (runReaderT (found x) e) tcs tce)
+    (unTCM (runReaderT notfound e) tcs tce)
 
 {-# NOINLINE insertMutual #-}
-insertMutual :: Mutuals -> QName -> IO ()
-insertMutual muts q = HT.insert muts q ()
+insertMutual :: Mutuals -> QName -> Int -> IO ()
+insertMutual muts q arity = HT.insert muts q arity
 
 {-# NOINLINE insertNode #-}
 insertNode :: Node -> v -> NodeMap v -> IO ()
@@ -296,8 +297,10 @@ keep track of the "path" during traversal that leads from the current position t
 data DefArgInEnv = DefArgInEnv Int [Occurrence]
   deriving Show
 
--- | Set of mutual definition names in the block.
-type Mutuals = HT.HashTableLU QName ()
+-- | Mutual definition names in the block.
+--   Each name is mapped to an arity. It's meaningful for 'FunctionDefn'-s; see 'preprocessMutuals'
+--   for docs. For everything else it's set to @maxBound :: Int@.
+type Mutuals = HT.HashTableLU QName Int
 
 data OccEnv = OccEnv {
     topDef     :: QName         -- ^ The definition we're working under (as n-th definition in the mutual block)
@@ -358,6 +361,13 @@ getOccurrencesFromType a = (optPolarity <$> pragmaOptions) >>= \case
             pure (p:ps)
           _ -> pure []
     liftReduce (go a)
+
+addRawEdge :: Range -> Occurrence -> Node -> Node -> OccM ()
+addRawEdge rng occ src tgt = do
+  path   <- asks path
+  graph  <- asks graph
+  let e = Edge occ (OccursWhere rng path)
+  lift $ lift $ addEdgeToGraph src tgt e graph
 
 addEdge :: Range -> Node -> OccM ()
 addEdge rng src = do
@@ -441,26 +451,37 @@ instance ComputeOccurrences Term where
         _      -> __IMPOSSIBLE__
 
       _ -> do
-        isMut <- isMutual d
-        expand \ret -> case isMut of
+        lookupMutual d
 
           -- it's a mutual definition
-          True -> ret do
-            addEdge (getRange d) (DefNode d)
+          (\arity -> do
+            let range = getRange d
+            addEdge range (DefNode d)
             expand \ret -> case es of
               [] -> ret $ pure ()  -- we skip the mutualDefOcc in this case
               es -> ret do
-                let elims d p i es = expand \ret -> case es of
+                def <- lift $ getConstInfo d
+                let defOcc = mutualDefOcc def
+                let elims d p i arity es = expand \ret -> case es of
                       []   -> ret $ pure ()
-                      e:es -> ret do occurrencesInMutDefArg d p i e
-                                     elims d p (i + 1) es
+                      e:es -> ret $ expand \ret -> case i < arity of
 
-                defOcc <- lift (mutualDefOcc <$> getConstInfo d)
-                elims d defOcc 0 es
+                        True  -> ret do
+                          occurrencesInMutDefArg d p i e
+                          elims d p (i + 1) arity es
+
+                        -- we're over the formal arity of the definition so every arg occurs Mixed
+                        -- in its definition
+                        False -> ret do
+                          addRawEdge range Mixed (ArgNode d i) (DefNode d)
+                          occurrencesInMutDefArg d p i e
+                          elims d p (i + 1) arity es
+                elims d defOcc 0 arity es
+          )
 
           -- it's not a mutual definition, we use existing defArgOccurrences
           -- in each argument in the Elims
-          False -> ret do
+          (do
             def <- lift $ getConstInfo d
             case theDef def of
               Constructor{} -> do
@@ -493,6 +514,7 @@ instance ComputeOccurrences Term where
                 let defOcc = mutualDefOcc def
                 let argOccs = defArgOccurrences def
                 underOcc defOcc $ elims d (defType def) 0 argOccs es
+          )
 
     Con _ _ es -> ret $ occurrences es
     MetaV m es -> ret $ underPathSetOcc MetaArg Mixed (occurrences es)
@@ -593,8 +615,8 @@ instance ComputeOccurrences Int where
   occurrences _ = pure ()
 
 -- | Compute occurrences in a given definition.
-computeDefOccurrences :: QName -> OccM ()
-computeDefOccurrences q = inConcreteOrAbstractMode q \def -> do
+computeDefOccurrences :: QName -> Maybe [Clause] -> OccM ()
+computeDefOccurrences q clauses = inConcreteOrAbstractMode q \def -> do
   reportSDoc "tc.pos" 25 do
     let a = defAbstract def
     m   <- viewTC eAbstractMode
@@ -613,9 +635,13 @@ computeDefOccurrences q = inConcreteOrAbstractMode q \def -> do
   let defOcc = mutualDefOcc def
   underPathOcc (`InDefOf` q) defOcc $ expand \ret -> case theDef def of
 
-    Function{funClauses = cs} -> ret do
+    Function{} -> ret do
+      -- eta-expanded clauses are already computed by
+      -- etaExpandFunctionClauses
+      cs <- case clauses of
+        Just cs -> pure cs
+        Nothing -> __IMPOSSIBLE__
 
-      cs <- lift $ mapM etaExpandClause =<< instantiateFull cs
       performAnalysis <- lift $ optOccurrence <$> pragmaOptions
       if performAnalysis then do
         let clauses i cs = expand \ret -> case cs of
@@ -731,17 +757,51 @@ computeDefOccurrences q = inConcreteOrAbstractMode q \def -> do
     GeneralizableVar{} -> ret mempty
     AbstractDefn{}     -> ret __IMPOSSIBLE__
 
+-- | Pre-pass that eta-expands function clauses and records the "formal arity" of the function in
+--   the signature. Any argument beyond this arity is considered to have 'Mixed' polarity.
+--   The analysis does not compute terms (or types) and cannot see arities that depend on argument values,
+--   it can only look at arities of eta-expanded definition clauses.
+--   See also issue 8564.
+--   We return the original names paired with the eta-expanded clauses.
+--   We also build up 'Mutuals' and record arities for each QName.
+--   A definition that's not a Function gets @maxBound@ for arity.
+preprocessMutuals :: [QName] -> Mutuals -> TCM [(QName, Maybe [Clause])]
+preprocessMutuals qs mutuals = forM qs \q -> inConcreteOrAbstractMode q \def -> case theDef def of
+
+  -- Postulates and primities are taken to be external to the mutual block.
+  -- User-given polarity pragmas may influence occurrence computation
+  -- in their arguments, but that's it.
+  Axiom{}     -> pure (q, Nothing)
+  Primitive{} -> pure (q, Nothing)
+
+  Function {funClauses = cs} -> do
+    cs <- mapM etaExpandClause =<< instantiateFull cs
+    let !arity   = case cs of []       -> 0
+                              (c,_):cs -> foldl' (\acc (arity, _) -> min acc arity) c cs
+    let !clauses = map' snd cs
+    lift $ insertMutual mutuals q arity
+
+    reportSDoc "tc.pos.preprocess" 30 $
+      "added function" <+> prettyTCM q <+> "to mutual block with arity" <+> pretty arity
+    pure (q, Just clauses)
+
+  _ -> do
+    reportSDoc "tc.pos.preprocess" 30 $
+      "added definition" <+> prettyTCM q <+> "to mutual block"
+    lift $ insertMutual mutuals q maxBound
+    pure (q, Nothing)
+
 buildOccurrenceGraph :: [QName] -> TCM (OccGraph, Mutuals)
 buildOccurrenceGraph qs = do
   inf <- maybe Nothing (\x -> Just $! nameOfInf x) <$> coinductionKit
 
   mutuals <- lift HT.empty
-  lift $ forM_ qs $ insertMutual mutuals
+  qs      <- preprocessMutuals qs mutuals
 
   graph <- lift HT.empty
-  TCM \st tce -> forM_ qs \q -> do
+  TCM \st tce -> forM_ qs \(q, clauses) -> do
     let env = OccEnv q [] inf 0 mutuals (DefNode q) Root StrictPos graph
-    unTCM (runReaderT (computeDefOccurrences q) env) st tce
+    unTCM (runReaderT (computeDefOccurrences q clauses) env) st tce
 
   pure (graph, mutuals)
 

--- a/src/full/Agda/TypeChecking/RecordPatterns.hs
+++ b/src/full/Agda/TypeChecking/RecordPatterns.hs
@@ -253,7 +253,7 @@ recordRHSToCopatterns ::
 recordRHSToCopatterns cl0 = do
   reportSLn "tc.inline.con" 40 $ "enter recordRHSToCopatterns"
 
-  etaExpandClause cl0 >>= \case
+  (snd <$> etaExpandClause cl0) >>= \case
 
     -- RHS must be fully applied coinductive constructor/record expression.
     cl@Clause{ namedClausePats = ps

--- a/test/Fail/Issue8564.agda
+++ b/test/Fail/Issue8564.agda
@@ -1,0 +1,36 @@
+--------------------------------------------------------------------------------
+-- Prelude
+
+data ⊥ : Set where
+
+-- Unit sans eta
+data ⊤ : Set where
+  tt : ⊤
+
+⊤-rec : ∀ {ℓ} {A : Set ℓ} → ⊤ → A → A
+⊤-rec tt x = x
+
+--------------------------------------------------------------------------------
+-- False
+
+Negate : (x : ⊤) → ⊤-rec x (Set → Set)
+Negate tt X = (X → ⊥)
+
+mutual
+  -- This tricks the positivity checker, which doesn't add
+  -- an edge from the second argument of P to Negate.
+  P : (x : ⊤) → ⊤-rec x (Set → Set)
+  P = Negate
+
+  -- This in turn breaks positivity checking for FixP
+  data FixP : Set where
+    wrap : P tt FixP → FixP
+
+no-fixp : FixP → ⊥
+no-fixp (wrap x) = x (wrap x)
+
+yet-fixp : FixP
+yet-fixp = wrap no-fixp
+
+bang : ⊥
+bang = no-fixp yet-fixp

--- a/test/Fail/Issue8564.err
+++ b/test/Fail/Issue8564.err
@@ -1,0 +1,7 @@
+Issue8564.agda:19.1-27.28: error: [NotStrictlyPositive]
+FixP is not strictly positive, because it occurs
+in the second argument of P
+(in the type of the constructor wrap
+ in the definition of FixP), which occurs
+                           in the type of the constructor wrap
+                           in the definition of FixP.

--- a/test/Fail/Issue8565.agda
+++ b/test/Fail/Issue8565.agda
@@ -1,0 +1,28 @@
+open import Agda.Builtin.Equality
+open import Agda.Builtin.String
+open import Agda.Builtin.Nat
+
+data ⊥ : Set where
+data Unit : Set where
+  tt* : Unit
+
+data Int : Set where
+  pos    : (n : Nat) → Int
+  negsuc : (n : Nat) → Int
+
+{-# BUILTIN INTEGER       Int    #-}
+{-# BUILTIN INTEGERPOS    pos    #-}
+{-# BUILTIN INTEGERNEGSUC negsuc #-}
+
+mutual
+  foo : Unit → Int → String
+  foo tt* x = primShowInteger x
+
+  primitive
+    primShowInteger : Int → String
+
+wuh : ∀ b x y → foo b x ≡ foo b y
+wuh b x y = refl
+
+lol : ⊥
+lol with () ← wuh tt* (pos 0) (pos 1)

--- a/test/Fail/Issue8565.err
+++ b/test/Fail/Issue8565.err
@@ -1,0 +1,7 @@
+Issue8565.agda:25.13-17: error: [UnequalTerms]
+The terms
+  x
+and
+  y
+are not equal at type Int
+when checking that the expression refl has type foo b x ≡ foo b y


### PR DESCRIPTION
Fix #8564 and #8565.

Function definitions could be previously applied to args beyond the arity visible to occurrence analysis, and all such applications were interpreted as Unused. Now all such applications are Mixed instead.

Also, primitives and postulates are now taken to be external to mutual blocks, meaning that they don't get any graph nodes and the occurrences of their arguments are only affected by user-given polarity pragmas.