### PR TITLE
Cabal CI: Windows: drop cluster-counting (ICU)

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -152,7 +152,9 @@ jobs:
         - description: macOS
           ghc-ver: 9.14.1
           os: macos-26
-        - description: Windows
+        - cabal-flags: --enable-tests --flags=use-xdg-data-home --flags=debug --flags=debug-serialisation
+            --flags=debug-parsing
+          description: Windows
           ghc-ver: 9.14.1
           os: windows-2025
         os:

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -101,6 +101,13 @@ jobs:
           - os: windows-2025
             description: Windows
             ghc-ver: '9.14.1'
+            cabal-flags: >-
+              --enable-tests
+              --flags=use-xdg-data-home
+              --flags=debug
+              --flags=debug-serialisation
+              --flags=debug-parsing
+            # --flags=enable-cluster-counting
 
     # Default values
     env:


### PR DESCRIPTION
Linking the ICU library broke upstream, so disabling this for now.

The symptom we have been seeing seems easy to reproduce, but I didn't find out how to fix it:
```
ghc-9.14.1.exe: Could not load `libicuuc78.dll'. Reason: addDLL: libicuuc78.dll or dependencies not loaded. (Win32 error 127)

<no location info>: error:
    loadArchive "C:\\msys64\\mingw64\\lib\\libicuuc.dll.a": failed
```
https://github.com/agda/agda/actions/runs/26329801687/job/77513830611#step:11:216