### PR TITLE
Add flag for irrelevance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,9 @@ Pragmas and options
   [unguarded records](https://agda.readthedocs.io/en/v2.9.0/language/record-types.html#unguarded-records)
   and [the `ETA_EQUALITY` pragma](https://agda.readthedocs.io/en/v2.9.0/language/coinduction.html#eta-pragma).
 
+* New options `--relevance` (default on) and `--no-irrelevance` to allow or
+  disallow the irrelevance modality.
+
 Errors
 ------
 

--- a/doc/user-manual/language/irrelevance.lagda.rst
+++ b/doc/user-manual/language/irrelevance.lagda.rst
@@ -19,6 +19,9 @@ that anything prepended by a dot (``.``) is marked irrelevant, which means that 
 will only be typechecked but never evaluated or compared for equality.
 Arguments marked as irrelevant are erased by the :ref:`compiler <ghc-backend>`.
 
+Irrelevance annotations are enabled by default. You can use the options
+`--irrelevance`/`--no-irrelevance` to enable/disable them.
+
 .. note::
   This section is about compile-time irrelevance. Agda also supports a weaker
   form of irrelevance called :ref:`runtime-irrelevance` that can be used for

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -725,6 +725,15 @@ Experimental features
 
     Default: ``--require-unique-meta-solutions``
 
+.. option:: --irrelevance, --no-irrelevance
+
+     .. versionadded:: 2.9.0
+
+     Enable or disable declaration and use of irrelevant function spaces, record
+     fields, and declarations (see :ref:`irrelevance <irrelevance>`).
+
+     Default: ``--irrelevance``.
+
 .. option:: --prop, --no-prop
 
      .. versionadded:: 2.6.0

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -49,6 +49,7 @@ module Agda.Interaction.Options.Base
     , lensOptUseUnicode
     , lensOptVerbose
     , lensOptProfiling
+    , lensOptIrrelevance
     , lensOptProp
     , lensOptLevelUniverse
     , lensOptTwoLevel
@@ -118,6 +119,7 @@ module Agda.Interaction.Options.Base
     , optShowImplicit
     , optShowGeneralized
     , optShowIrrelevant
+    , optIrrelevance
     , optProp
     , optLevelUniverse
     , optTwoLevel
@@ -286,6 +288,7 @@ impliedPragmaOptions =
 optShowImplicit              :: PragmaOptions -> Bool
 optShowGeneralized           :: PragmaOptions -> Bool
 optShowIrrelevant            :: PragmaOptions -> Bool
+optIrrelevance               :: PragmaOptions -> Bool
 optProp                      :: PragmaOptions -> Bool
 optLevelUniverse             :: PragmaOptions -> Bool
 optTwoLevel                  :: PragmaOptions -> Bool
@@ -352,6 +355,7 @@ optForcedArgumentRecursion   :: PragmaOptions -> Bool
 optShowImplicit              = collapseDefault . _optShowImplicit
 optShowGeneralized           = collapseDefault . _optShowGeneralized
 optShowIrrelevant            = collapseDefault . _optShowIrrelevant
+optIrrelevance               = collapseDefault . _optIrrelevance
 optProp                      = collapseDefault . _optProp
 optLevelUniverse             = collapseDefault . _optLevelUniverse
 optTwoLevel                  = collapseDefault . _optTwoLevel
@@ -460,6 +464,9 @@ lensOptVerbose f o = f (_optVerbose o) <&> \ i -> o{ _optVerbose = i }
 
 lensOptProfiling :: Lens' PragmaOptions _
 lensOptProfiling f o = f (_optProfiling o) <&> \ i -> o{ _optProfiling = i }
+
+lensOptIrrelevance :: Lens' PragmaOptions _
+lensOptIrrelevance f o = f (_optIrrelevance o) <&> \ i -> o{ _optIrrelevance = i }
 
 lensOptProp :: Lens' PragmaOptions _
 lensOptProp f o = f (_optProp o) <&> \ i -> o{ _optProp = i }
@@ -941,6 +948,7 @@ infectiveCoinfectiveOptions =
   , infectiveOption (isJust . optCubical)     "--cubical[={full,erased,no-glue}]"
   , cubicalWithoutGlue
   , infectiveOption optGuarded                "--guarded"
+  , infectiveOption optIrrelevance            "--irrelevance"
   , infectiveOption optProp                   "--prop"
   , infectiveOption optTwoLevel               "--two-level"
   , infectiveOption optRewriting              "--rewriting"
@@ -1525,6 +1533,9 @@ universePragmaOptions = ("Universes",) $ concat
   , pragmaFlag      "cumulativity" lensOptCumulativity
                     "enable subtyping of universes" "(e.g. Set =< Set₁)"
                     $ Just "disable subtyping of universes"
+  , pragmaFlag      "irrelevance" lensOptIrrelevance
+                    "enable the use of the irrelevance modality" ""
+                    $ Just "disable the use of the irrelevance modality"
   , pragmaFlag      "prop" lensOptProp
                     "enable the use of the Prop universe" ""
                     $ Just "disable the use of the Prop universe"

--- a/src/full/Agda/Interaction/Options/Default.hs
+++ b/src/full/Agda/Interaction/Options/Default.hs
@@ -56,6 +56,7 @@ defaultPragmaOptions = PragmaOptions
   , _optUseUnicode                 = Default -- UnicodeOk
   , _optVerbose                    = empty
   , _optProfiling                  = empty
+  , _optIrrelevance                = Default
   , _optProp                       = Default
   , _optLevelUniverse              = Default
   , _optTwoLevel                   = Default

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -214,6 +214,7 @@ data ErrorName
   | NeedOptionCopatterns_
   | NeedOptionCubical_
   | NeedOptionPatternMatching_
+  | NeedOptionIrrelevance_
   | NeedOptionProp_
   | NeedOptionRewriting_
   | NeedOptionSizedTypes_

--- a/src/full/Agda/Interaction/Options/Types.hs
+++ b/src/full/Agda/Interaction/Options/Types.hs
@@ -111,6 +111,7 @@ data PragmaOptions = PragmaOptions
   , _optUseUnicode                :: WithDefault' UnicodeOrAscii 'True -- Would like to write UnicodeOk instead of True here
   , _optVerbose                   :: !Verbosity
   , _optProfiling                 :: ProfileOptions
+  , _optIrrelevance               :: WithDefault 'True
   , _optProp                      :: WithDefault 'False
   , _optLevelUniverse             :: WithDefault 'False
   , _optTwoLevel                  :: WithDefault 'False

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1340,6 +1340,9 @@ instance PrettyTCM TypeError where
     NeedOptionPatternMatching -> fsep $
       pwords "Pattern matching is disabled (use option --pattern-matching to enable it)"
 
+    NeedOptionIrrelevance -> fsep $
+      pwords "Irrelevance modality is disabled (use options --irrelevance and --no-irrelevance to enable/disable irrelevance)"
+
     NeedOptionProp       -> fsep $
       pwords "Universe Prop is disabled (use options --prop and --no-prop to enable/disable Prop)"
 

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -171,6 +171,7 @@ typeErrorName = \case
   NeedOptionCopatterns                                       {} -> NeedOptionCopatterns_
   NeedOptionCubical                                          {} -> NeedOptionCubical_
   NeedOptionPatternMatching                                  {} -> NeedOptionPatternMatching_
+  NeedOptionIrrelevance                                      {} -> NeedOptionIrrelevance_
   NeedOptionProp                                             {} -> NeedOptionProp_
   NeedOptionRewriting                                        {} -> NeedOptionRewriting_
   NeedOptionSizedTypes                                       {} -> NeedOptionSizedTypes_

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -92,6 +92,14 @@ import Agda.Utils.Monad
 
 import Agda.Utils.Impossible
 
+checkIrrelevanceAllowed :: LensRelevance a => a -> TCM ()
+checkIrrelevanceAllowed x = unlessM isIrrelevanceEnabled $
+  when (isIrrelevant x) $ typeError NeedOptionIrrelevance
+
+checkAllIrrelevanceAllowed :: (Traversable f, LensRelevance a) => f a -> TCM ()
+checkAllIrrelevanceAllowed xs = unlessM isIrrelevanceEnabled $
+  when (any isIrrelevant xs) $ typeError NeedOptionIrrelevance
+
 -- | Check whether something can be used in a position of the given relevance.
 --
 --   This is a substitute for double-checking that only makes sure

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5996,6 +5996,7 @@ data TypeError
         | NeedOptionCubical Cubical String
             -- ^ Flavor of cubical needed for the given reason.
         | NeedOptionPatternMatching
+        | NeedOptionIrrelevance
         | NeedOptionProp
         | NeedOptionRewriting
         | NeedOptionSizedTypes String

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -409,6 +409,10 @@ setIncludeDirs incs root = do
       process keep modFile ms
 
 {-# SPECIALIZE NOINLINE isPropEnabled :: TCM Bool #-}
+isIrrelevanceEnabled :: HasOptions m => m Bool
+isIrrelevanceEnabled = optIrrelevance <$> pragmaOptions
+
+{-# SPECIALIZE NOINLINE isPropEnabled :: TCM Bool #-}
 isPropEnabled :: HasOptions m => m Bool
 isPropEnabled = optProp <$> pragmaOptions
 

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -39,6 +39,7 @@ import Agda.TypeChecking.IApplyConfluence
 import Agda.TypeChecking.Generalize
 import Agda.TypeChecking.Injectivity
 import Agda.TypeChecking.InstanceArguments
+import Agda.TypeChecking.Irrelevance
 import Agda.TypeChecking.Level.Solve
 import Agda.TypeChecking.Positivity
 import Agda.TypeChecking.Positivity.Occurrence
@@ -603,6 +604,8 @@ checkAxiom gentel kind i info0 mp x e = whenAbstractFreezeMetasAfter i $ default
   -- Andreas, 2012-04-18  if we are in irrelevant context, axioms are irrelevant
   -- even if not declared as such (Issue 610).
   rel <- max (getRelevance info0) <$> viewTC eRelevance
+
+  checkIrrelevanceAllowed rel
 
   -- Andrea, 2019-07-16 Cohesion is purely based on left-division, it
   -- does not take envModality into account.

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -310,7 +310,7 @@ checkTelescope' lamOrPi (b : tel) ret =
 
 -- | Check the domain of a function type.
 --   Used in @checkTypedBindings@ and to typecheck @A.Fun@ cases.
-checkDomain :: (LensLock a, LensModality a, LensRewriteAnn a)
+checkDomain :: (LensLock a, LensModality a, LensRewriteAnn a, LensRelevance a)
   => LamOrPi -> Maybe Name -> List1 a -> A.Expr -> TCM (Maybe RewDom, Type)
 checkDomain lamOrPi n xs e = do
     -- Get cohesion and quantity of arguments, as well as if they are local
@@ -324,6 +324,8 @@ checkDomain lamOrPi n xs e = do
 
     let (r :| rs) = fmap (getRewriteAnn) xs
     unless (all (r ==) rs) $ __IMPOSSIBLE__
+
+    checkAllIrrelevanceAllowed xs
 
     -- Also get whether the domain is a local rewrite rule. If it is, and there
     -- are multiple arguments, we warn that this is unnecessary
@@ -373,7 +375,7 @@ checkDomain lamOrPi n xs e = do
         modEnv (LamNotPi _) = workOnTypes
         modEnv PiNotLam     = id
 
-checkPiDomain :: (LensLock a, LensModality a,  LensRewriteAnn a)
+checkPiDomain :: (LensLock a, LensModality a,  LensRewriteAnn a, LensRelevance a)
               => Maybe Name -> List1 a -> A.Expr -> TCM (Maybe RewDom, Type)
 checkPiDomain = checkDomain PiNotLam
 
@@ -539,6 +541,8 @@ checkLambda' cmp r tac xps typ body target = do
   reportSDoc "tc.term.lambda" 60 $ vcat
     [ "info           =" <+> (text . show) info
     ]
+
+  checkAllIrrelevanceAllowed xs
 
   -- Consume @tac@:
   case tac of
@@ -1989,6 +1993,8 @@ checkLetBinding' b@(A.LetBind i info x t e) ret = do
       | getOrigin info == Inserted = checkDontExpandLast
       | otherwise                  = checkExpr'
 
+  checkIrrelevanceAllowed info
+
   t <- workOnTypes $ isType_ t
   v <- applyModalityToContext info $ check CmpLeq e t
 
@@ -1997,6 +2003,8 @@ checkLetBinding' b@(A.LetBind i info x t e) ret = do
 checkLetBinding' b@(A.LetAxiom i info x t) ret = do
   t <- workOnTypes $ isType_ t
   current <- currentModule
+
+  checkIrrelevanceAllowed info
 
   -- Note: if addConstant is called under a nontrivial context then
   -- it'll automatically quantify the type we give it over the context
@@ -2008,6 +2016,9 @@ checkLetBinding' b@(A.LetAxiom i info x t) ret = do
 
 checkLetBinding' b@(A.LetPatBind i ai p e) ret = do
     p <- expandPatternSynonyms p
+
+    checkIrrelevanceAllowed ai
+
     (v, t) <- applyModalityToContext ai $ inferExpr' ExpandLast e
     let -- construct a type  t -> dummy  for use in checkLeftHandSide
         t0 = El (getSort t) $ Pi (defaultArgDom ai t) (NoAbs underscore __DUMMY_TYPE__)

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -524,8 +524,8 @@ instance EmbPrj InfectiveCoinfective where
     valu _      = malformed
 
 instance EmbPrj PragmaOptions where
-  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss ttt uuu vvv) =
-    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss ttt uuu vvv
+  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss ttt uuu vvv www) =
+    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss ttt uuu vvv www
 
   value = valueN PragmaOptions
 

--- a/test/Fail/NoIrrelevance1.agda
+++ b/test/Fail/NoIrrelevance1.agda
@@ -1,0 +1,3 @@
+{-# OPTIONS --no-irrelevance #-}
+
+postulate f : .Set → Set

--- a/test/Fail/NoIrrelevance1.err
+++ b/test/Fail/NoIrrelevance1.err
@@ -1,0 +1,4 @@
+NoIrrelevance1.agda:3.15-25: error: [NeedOptionIrrelevance]
+Irrelevance modality is disabled (use options --irrelevance and
+--no-irrelevance to enable/disable irrelevance)
+when checking that the expression .Set → Set is a type

--- a/test/Fail/NoIrrelevance10.agda
+++ b/test/Fail/NoIrrelevance10.agda
@@ -1,0 +1,4 @@
+{-# OPTIONS --no-irrelevance #-}
+
+.A : Set₁
+A = Set

--- a/test/Fail/NoIrrelevance10.err
+++ b/test/Fail/NoIrrelevance10.err
@@ -1,0 +1,3 @@
+NoIrrelevance10.agda:3.2-3: error: [NeedOptionIrrelevance]
+Irrelevance modality is disabled (use options --irrelevance and
+--no-irrelevance to enable/disable irrelevance)

--- a/test/Fail/NoIrrelevance2.agda
+++ b/test/Fail/NoIrrelevance2.agda
@@ -1,0 +1,3 @@
+{-# OPTIONS --no-irrelevance #-}
+
+postulate f : .(A : Set) → Set

--- a/test/Fail/NoIrrelevance2.err
+++ b/test/Fail/NoIrrelevance2.err
@@ -1,0 +1,4 @@
+NoIrrelevance2.agda:3.16-31: error: [NeedOptionIrrelevance]
+Irrelevance modality is disabled (use options --irrelevance and
+--no-irrelevance to enable/disable irrelevance)
+when checking that the expression .(A : Set) → Set is a type

--- a/test/Fail/NoIrrelevance3.agda
+++ b/test/Fail/NoIrrelevance3.agda
@@ -1,0 +1,3 @@
+{-# OPTIONS --no-irrelevance #-}
+
+f = λ .x → {!   !}

--- a/test/Fail/NoIrrelevance3.err
+++ b/test/Fail/NoIrrelevance3.err
@@ -1,0 +1,4 @@
+NoIrrelevance3.agda:3.5-19: error: [NeedOptionIrrelevance]
+Irrelevance modality is disabled (use options --irrelevance and
+--no-irrelevance to enable/disable irrelevance)
+when checking that the expression λ .x → ? has type _1

--- a/test/Fail/NoIrrelevance4.agda
+++ b/test/Fail/NoIrrelevance4.agda
@@ -1,0 +1,3 @@
+{-# OPTIONS --no-irrelevance #-}
+
+f = let .x = _ in _

--- a/test/Fail/NoIrrelevance4.err
+++ b/test/Fail/NoIrrelevance4.err
@@ -1,0 +1,4 @@
+NoIrrelevance4.agda:3.9-15: error: [NeedOptionIrrelevance]
+Irrelevance modality is disabled (use options --irrelevance and
+--no-irrelevance to enable/disable irrelevance)
+when checking the let binding . x = _

--- a/test/Fail/NoIrrelevance5.agda
+++ b/test/Fail/NoIrrelevance5.agda
@@ -1,0 +1,3 @@
+{-# OPTIONS --no-irrelevance #-}
+
+module _ .(A : Set) where

--- a/test/Fail/NoIrrelevance5.err
+++ b/test/Fail/NoIrrelevance5.err
@@ -1,0 +1,4 @@
+NoIrrelevance5.agda:3.11-20: error: [NeedOptionIrrelevance]
+Irrelevance modality is disabled (use options --irrelevance and
+--no-irrelevance to enable/disable irrelevance)
+when checking the parameters of module NoIrrelevance5

--- a/test/Fail/NoIrrelevance6.agda
+++ b/test/Fail/NoIrrelevance6.agda
@@ -1,0 +1,3 @@
+{-# OPTIONS --no-irrelevance #-}
+
+data D .(A : Set) : Set where

--- a/test/Fail/NoIrrelevance6.err
+++ b/test/Fail/NoIrrelevance6.err
@@ -1,0 +1,3 @@
+NoIrrelevance6.agda:3.6-24: error: [NeedOptionIrrelevance]
+Irrelevance modality is disabled (use options --irrelevance and
+--no-irrelevance to enable/disable irrelevance)

--- a/test/Fail/NoIrrelevance7.agda
+++ b/test/Fail/NoIrrelevance7.agda
@@ -1,0 +1,4 @@
+{-# OPTIONS --no-irrelevance #-}
+
+data D : Set where
+    c : .D → D

--- a/test/Fail/NoIrrelevance7.err
+++ b/test/Fail/NoIrrelevance7.err
@@ -1,0 +1,4 @@
+NoIrrelevance7.agda:4.9-15: error: [NeedOptionIrrelevance]
+Irrelevance modality is disabled (use options --irrelevance and
+--no-irrelevance to enable/disable irrelevance)
+when checking that the expression .D → D is a type

--- a/test/Fail/NoIrrelevance8.agda
+++ b/test/Fail/NoIrrelevance8.agda
@@ -1,0 +1,5 @@
+{-# OPTIONS --no-irrelevance #-}
+
+record R : Set₁ where
+    field
+      .f : Set

--- a/test/Fail/NoIrrelevance8.err
+++ b/test/Fail/NoIrrelevance8.err
@@ -1,0 +1,4 @@
+NoIrrelevance8.agda:5.8-15: error: [NeedOptionIrrelevance]
+Irrelevance modality is disabled (use options --irrelevance and
+--no-irrelevance to enable/disable irrelevance)
+when checking that the expression .(f : Set) → Set is a type

--- a/test/Fail/NoIrrelevance9.agda
+++ b/test/Fail/NoIrrelevance9.agda
@@ -1,0 +1,3 @@
+{-# OPTIONS --no-irrelevance #-}
+
+postulate .A : Set

--- a/test/Fail/NoIrrelevance9.err
+++ b/test/Fail/NoIrrelevance9.err
@@ -1,0 +1,3 @@
+NoIrrelevance9.agda:3.12-19: error: [NeedOptionIrrelevance]
+Irrelevance modality is disabled (use options --irrelevance and
+--no-irrelevance to enable/disable irrelevance)


### PR DESCRIPTION
As requested by @nad in https://github.com/agda/agda/issues/8557#issuecomment-4429776356, there ought to be a flag for turning irrelevance on or off. I decided to implement the checks in the elaborator (in particular `Term.hs` and `Decl.hs`), but not check the flag every time we use irrelevance in the conversion checker. This *ought* to be enough and is much less likely to cause some weird performance regression, but it does come with the risk that I missed another place where something can be irrelevant. So please check the test cases I included and let me know if there are any more I should add.