### PR TITLE
Fix #8577: Normalise under varTel in Unify.hs

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -903,6 +903,7 @@ solutionStep retry s
       case solveVar (m - 1 - i) p s of
         Nothing | retry == RetryNormalised -> do
           s <- lensVarTel normalise s
+          -- #8577: Need to normalise 'u' under 'varTel'
           u <- addContext (varTel s) $ normalise u
           solutionStep DontRetryNormalised s step{ solutionTerm = u }
         Nothing ->

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -902,8 +902,8 @@ solutionStep retry s
     Right True | usable ->
       case solveVar (m - 1 - i) p s of
         Nothing | retry == RetryNormalised -> do
-          u <- normalise u
           s <- lensVarTel normalise s
+          u <- addContext (varTel s) $ normalise u
           solutionStep DontRetryNormalised s step{ solutionTerm = u }
         Nothing ->
           return $! UnifyStuck [UnifyRecursiveEq (varTel s) a i u]

--- a/test/Fail/LocalRewriteUnifyCycle.agda
+++ b/test/Fail/LocalRewriteUnifyCycle.agda
@@ -8,3 +8,24 @@ module _ (f : Nat → Nat → Nat) (n m : Nat) (@rewrite p : n ≡ 0) where
   foo : f n m ≡ m → Nat
   foo refl = 0
 
+{-
+Was:
+
+> An internal error has occurred. Please report this as a bug.
+> Location of the error: __IMPOSSIBLE_VERBOSE__, called at
+> src/full/Agda/TypeChecking/Monad/Context.hs:783:9 in
+> Agda-2.9.0-inplace:Agda.TypeChecking.Monad.Context
+
+Now:
+
+> LocalRewriteUnifyCycle.agda:9.7-11: error: [SplitError.UnificationStuck]
+> I'm not sure if there should be a case for the constructor refl,
+> because I get stuck when trying to solve the following unification
+> problems (inferred index ≟ expected index):
+>   f n m ≟ m
+> Possible reason why unification failed:
+>   Cannot solve variable m of type Nat with solution f 0 m because the
+>   variable occurs in the solution, or in the type of one of the
+>   variables in the solution.
+> when checking that the pattern refl has type f n m ≡ m
+-}

--- a/test/Fail/LocalRewriteUnifyCycle.agda
+++ b/test/Fail/LocalRewriteUnifyCycle.agda
@@ -1,0 +1,10 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module _ (f : Nat → Nat → Nat) (n m : Nat) (@rewrite p : n ≡ 0) where
+  foo : f n m ≡ m → Nat
+  foo refl = 0
+

--- a/test/Fail/LocalRewriteUnifyCycle.err
+++ b/test/Fail/LocalRewriteUnifyCycle.err
@@ -1,0 +1,10 @@
+LocalRewriteUnifyCycle.agda:9.7-11: error: [SplitError.UnificationStuck]
+I'm not sure if there should be a case for the constructor refl,
+because I get stuck when trying to solve the following unification
+problems (inferred index ≟ expected index):
+  f n m ≟ m
+Possible reason why unification failed:
+  Cannot solve variable m of type Nat with solution f 0 m because the
+  variable occurs in the solution, or in the type of one of the
+  variables in the solution.
+when checking that the pattern refl has type f n m ≡ m


### PR DESCRIPTION
Fixes #8577

Also normalise the `varTel` before normalising the term (I don't think it really matters but I think this might sometimes be more efficient?)