### PR TITLE
Fix #8583: (Co)InfectiveError: report imported module with range

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -893,7 +893,7 @@ getInterface x isMain msrc = locallyTC eImportStack (x :) do
       -- Check that imported options are compatible with current ones (issue #2487),
       -- but give primitive modules a pass.
       -- Compute updated warnings if needed.
-      ws' <- fromMaybe ws <$> getOptionsCompatibilityWarnings isMain isPrim currentOptions i
+      ws' <- fromMaybe ws <$> getOptionsCompatibilityWarnings isMain currentOptions mi
       return mi{ miWarnings = ws' }
 
 -- | If checking produced non-benign warnings, error out.
@@ -937,16 +937,23 @@ checkOptionsCompatible current imported importedModule = flip execStateT True $ 
 
 getOptionsCompatibilityWarnings ::
      MainInterface
-  -> Bool           -- ^ Are we looking at a primitvie module?
   -> PragmaOptions
-  -> Interface
+  -> ModuleInfo
   -> TCM (Maybe (Set TCWarning))
-getOptionsCompatibilityWarnings isMain False currentOptions Interface{ iOptionsUsed, iTopLevelModuleName } = do
-  ifM (checkOptionsCompatible currentOptions iOptionsUsed iTopLevelModuleName)
-    {-then-} (return Nothing) -- No warnings to collect because options were compatible.
-    {-else-} (Just <$> getAllWarnings' isMain ErrorWarnings)
--- Options consistency checking is disabled for always-available primitive modules.
-getOptionsCompatibilityWarnings _ True _ _ = return Nothing
+getOptionsCompatibilityWarnings isMain currentOptions = \case
+  ModuleInfo{ miPrimitive = False, miInterface = Interface{ iOptionsUsed, iTopLevelModuleName = m }, miSourceFile } -> do
+
+    -- Add range to name of imported module.
+    m' <- if not $ null $ getRange m then pure m else do
+      path <- srcFilePath miSourceFile
+      pure $ setRange (rangeFromAbsolutePath path) m
+
+    ifM (checkOptionsCompatible currentOptions iOptionsUsed m')
+      {-then-} (return Nothing) -- No warnings to collect because options were compatible.
+      {-else-} (Just <$> getAllWarnings' isMain ErrorWarnings)
+
+  -- Options consistency checking is disabled for always-available primitive modules.
+  _ -> return Nothing
 
 -- | Try to get the interface from interface file or cache.
 

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -230,6 +230,7 @@ import Agda.Interaction.Options.Warnings
 import Agda.Syntax.Concrete.Glyph ( unsafeSetUnicodeOrAscii, UnicodeOrAscii(..) )
 import Agda.Syntax.Common (Cubical(..))
 import Agda.Syntax.Common.Pretty
+import Agda.Syntax.Position (PrintRange(PrintRange))
 import Agda.Syntax.TopLevelModuleName (TopLevelModuleName)
 
 import qualified Agda.Setup.EmacsMode as EmacsMode
@@ -898,7 +899,7 @@ infectiveOption opt s = ICOption
   , icOptionOK          = \current imported ->
                            opt imported <= opt current
   , icOptionWarning     = \m -> fsep $
-      pwords "Importing module" ++ [pretty m] ++ pwords "using the" ++
+      pwords "Importing module" ++ [pretty $ PrintRange m] ++ pwords "using the" ++
       [text s] ++ pwords "flag from a module which does not."
   }
 
@@ -918,7 +919,7 @@ coinfectiveOption opt s = ICOption
   , icOptionOK          = \current imported ->
                            opt current <= opt imported
   , icOptionWarning     = \m -> fsep $
-      pwords "Importing module" ++ [pretty m] ++
+      pwords "Importing module" ++ [pretty $ PrintRange m] ++
       pwords "not using the" ++ [text s] ++
       pwords "flag from a module which does."
   }
@@ -983,7 +984,7 @@ infectiveCoinfectiveOptions =
             (Just CWithoutGlue, Just CErased) -> False
             _ -> True
       , icOptionWarning = \m -> fsep $
-          pwords "Importing module" ++ [pretty m] ++
+          pwords "Importing module" ++ [pretty $ PrintRange m] ++
           pwords "which might contain glue to a module with the option" ++
           pwords (flagName ++ ".")
       }

--- a/test/Fail/CubicalWithoutGlueCannotImportGlue.err
+++ b/test/Fail/CubicalWithoutGlueCannotImportGlue.err
@@ -1,5 +1,7 @@
 CubicalWithoutGlueCannotImportGlue.agda:3.1-38: error: [InfectiveImport]
-Importing module Agda.Builtin.Cubical.Glue which might contain glue
-to a module with the option --cubical=no-glue.
+Importing module
+Agda.Builtin.Cubical.Glue (at agda-default-include-path/Agda/Builtin/Cubical/Glue.agda:1.1)
+which might contain glue to a module with the option
+--cubical=no-glue.
 when scope checking the declaration
   open import Agda.Builtin.Cubical.Glue

--- a/test/Fail/CubicalWithoutGlueIsInfective.err
+++ b/test/Fail/CubicalWithoutGlueIsInfective.err
@@ -1,6 +1,7 @@
 CubicalWithoutGlueIsInfective.agda:3.1-53: error: [InfectiveImport]
-Importing module Cubical-without-glue-Import.Without-glue using the
---cubical[={full,erased,no-glue}] flag from a module which does
-not.
+Importing module
+Cubical-without-glue-Import.Without-glue (at Cubical-without-glue-Import/Without-glue.agda:1.1)
+using the --cubical[={full,erased,no-glue}] flag from a module
+which does not.
 when scope checking the declaration
   open import Cubical-without-glue-Import.Without-glue

--- a/test/Fail/Issue1209-4.err
+++ b/test/Fail/Issue1209-4.err
@@ -1,11 +1,13 @@
 Issue1209-4.agda:3.1-30: error: [CoInfectiveImport]
-Importing module Agda.Builtin.Size not using the --safe flag from a
-module which does.
+Importing module
+Agda.Builtin.Size (at agda-default-include-path/Agda/Builtin/Size.agda:1.1)
+not using the --safe flag from a module which does.
 when scope checking the declaration
   open import Agda.Builtin.Size
 
 Issue1209-4.agda:3.1-30: error: [InfectiveImport]
-Importing module Agda.Builtin.Size using the --sized-types flag
-from a module which does not.
+Importing module
+Agda.Builtin.Size (at agda-default-include-path/Agda/Builtin/Size.agda:1.1)
+using the --sized-types flag from a module which does not.
 when scope checking the declaration
   open import Agda.Builtin.Size

--- a/test/Fail/Issue202.err
+++ b/test/Fail/Issue202.err
@@ -1,5 +1,7 @@
 Issue202.agda:6.1-25: error: [CoInfectiveImport]
-Importing module Imports.Test not using the
---no-universe-polymorphism flag from a module which does.
+Importing module
+Imports.Test (at Imports/Test.agda:1.1)
+not using the --no-universe-polymorphism flag from a module which
+does.
 when scope checking the declaration
   open import Imports.Test

--- a/test/Fail/Issue2487.err
+++ b/test/Fail/Issue2487.err
@@ -1,12 +1,14 @@
 Issue2487/b.agda:5.1-24: error: [CoInfectiveImport]
-Importing module Issue2487.c not using the --safe flag from a
-module which does.
+Importing module
+Issue2487.c (at Issue2487/c.agda:1.1)
+not using the --safe flag from a module which does.
 when scope checking the declaration
   open import Issue2487.c
 
 Issue2487/b.agda:5.1-24: error: [InfectiveImport]
-Importing module Issue2487.c using the
---cubical[={full,erased,no-glue}] flag from a module which does
-not.
+Importing module
+Issue2487.c (at Issue2487/c.agda:1.1)
+using the --cubical[={full,erased,no-glue}] flag from a module
+which does not.
 when scope checking the declaration
   open import Issue2487.c

--- a/test/Fail/Issue3451-2.err
+++ b/test/Fail/Issue3451-2.err
@@ -1,5 +1,6 @@
 Issue3451-2.agda:5.1-24: error: [InfectiveImport]
-Importing module Common.Size using the --sized-types flag from a
-module which does not.
+Importing module
+Common.Size (at Size.agda:1.1) using
+the --sized-types flag from a module which does not.
 when scope checking the declaration
   open import Common.Size

--- a/test/Fail/Issue3517.err
+++ b/test/Fail/Issue3517.err
@@ -5,7 +5,8 @@ when scope checking the declaration
   import Issue3517.S
 
 Issue3517/S.agda:5.1-37: error: [CoInfectiveImport]
-Importing module Agda.Builtin.Size not using the --safe flag from a
-module which does.
+Importing module
+Agda.Builtin.Size (at agda-default-include-path/Agda/Builtin/Size.agda:1.1)
+not using the --safe flag from a module which does.
 when scope checking the declaration
   open import Agda.Builtin.Size public

--- a/test/Fail/Issue8326.err
+++ b/test/Fail/Issue8326.err
@@ -1,6 +1,7 @@
 Issue8326.agda:6.1-33: error: [InfectiveImport]
-Importing module Agda.Builtin.Cubical.Glue using the
---cubical[={full,erased,no-glue}] flag from a module which does
-not.
+Importing module
+Agda.Builtin.Cubical.Glue (at agda-default-include-path/Agda/Builtin/Cubical/Glue.agda:1.1)
+using the --cubical[={full,erased,no-glue}] flag from a module
+which does not.
 when scope checking the declaration
   import Agda.Builtin.Cubical.Glue

--- a/test/Fail/NoSizedTypes.err
+++ b/test/Fail/NoSizedTypes.err
@@ -1,5 +1,6 @@
 NoSizedTypes.agda:3.1-44: error: [InfectiveImport]
-Importing module Common.Size using the --sized-types flag from a
-module which does not.
+Importing module
+Common.Size (at Size.agda:1.1) using
+the --sized-types flag from a module which does not.
 when scope checking the declaration
   open import Common.Size renaming (↑_ to _^)

--- a/test/Fail/SafeFlagPrimTrustMe-2.err
+++ b/test/Fail/SafeFlagPrimTrustMe-2.err
@@ -1,5 +1,6 @@
 SafeFlagPrimTrustMe-2.agda:5.1-33: error: [CoInfectiveImport]
-Importing module Agda.Builtin.TrustMe not using the --safe flag
-from a module which does.
+Importing module
+Agda.Builtin.TrustMe (at agda-default-include-path/Agda/Builtin/TrustMe.agda:1.1)
+not using the --safe flag from a module which does.
 when scope checking the declaration
   open import Agda.Builtin.TrustMe

--- a/test/interaction/Issue2487-2.out
+++ b/test/interaction/Issue2487-2.out
@@ -2,5 +2,6 @@ Checking Issue2487.A (Issue2487/A.agda).
 Checking Issue2487-2 (Issue2487-2.agda).
 Checking Issue2487.A (Issue2487/A.agda).
 Issue2487-2.agda:4.8-19: error: [CoInfectiveImport]
-Importing module Issue2487.A not using the --safe flag from a
-module which does.
+Importing module
+Issue2487.A (at Issue2487/A.agda:1.1)
+not using the --safe flag from a module which does.

--- a/test/interaction/Issue2487-3.out
+++ b/test/interaction/Issue2487-3.out
@@ -1,7 +1,7 @@
 (agda2-status-action "")
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
-(agda2-info-action "*Error*" "Issue2487/B.agda:4.1-19: error: [CoInfectiveImport] Importing module Issue2487.A not using the --safe flag from a module which does. when scope checking the declaration import Issue2487.A" nil)
+(agda2-info-action "*Error*" "Issue2487/B.agda:4.1-19: error: [CoInfectiveImport] Importing module Issue2487.A (at Issue2487/A.agda:1.1) not using the --safe flag from a module which does. when scope checking the declaration import Issue2487.A" nil)
 ((last . 3) . (agda2-maybe-goto '("Issue2487/B.agda" . 50)))
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")


### PR DESCRIPTION
(Co)infective error now reports the imported module with its range (beginning of file) so that we can jump to it by clicking.
To this end a range is constructed from its filename.