### PR TITLE
Fix #8580: internal error with _ in pattern synonym definition

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Name.hs
+++ b/src/full/Agda/Syntax/Concrete/Name.hs
@@ -64,6 +64,7 @@ instance Underscore Name where
   underscore = NoName noRange __IMPOSSIBLE__
   isUnderscore NoName{} = True
   isUnderscore (Name {nameNameParts = Id x :| []}) = isUnderscore x
+  isUnderscore (Name {nameNameParts = Hole :| []}) = True
   isUnderscore _ = False
 
 instance Null Name where

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2216,6 +2216,7 @@ instance ToAbstract NiceDeclaration where
 
     NicePatternSyn r a n as p -> do
       reportSLn "scope.pat" 30 $ "found nice pattern syn: " ++ prettyShow n
+      reportSLn "scope.pat" 40 $ "arguments: " ++ prettyShow as
       (as, p) <- withLocalVars $ do
          -- Expand puns if optHiddenArgumentPuns is True.
          p <- parsePatternSyn =<< expandPunsOpt p
@@ -2240,9 +2241,9 @@ instance ToAbstract NiceDeclaration where
       return $ singleton $ A.PatternSynDef y (map (fmap BindName) as) p   -- only for highlighting, so use unexpanded version
       where
         checkPatSynParam :: WithHiding C.Name -> ScopeM (WithHiding A.Name)
-        checkPatSynParam (WithHiding h x) = do
-          let err = setCurrentRange x . typeError
-          resolveName (C.QName x) >>= \case
+        checkPatSynParam (WithHiding h x)
+          | isUnderscore x = err $ UnusedVariableInPatternSynonym x
+          | otherwise = resolveName (C.QName x) >>= \case
             VarName a (PatternBound h')
               | isInstance h, not (isInstance h') -> err $ IllegalInstanceVariableInPatternSynonym x
               | otherwise -> return $ WithHiding h a
@@ -2251,6 +2252,8 @@ instance ToAbstract NiceDeclaration where
             UnknownName -> err $ UnusedVariableInPatternSynonym x
             -- Other cases are impossible because parsing the pattern syn rhs would have failed.
             _ -> __IMPOSSIBLE__
+          where
+            err = setCurrentRange x . typeError
 
     d@NiceLoneConstructor{} -> [] <$ do
       declarationWarning $ InvalidConstructorBlock $ getRange d

--- a/test/Fail/Issue8580.agda
+++ b/test/Fail/Issue8580.agda
@@ -1,0 +1,13 @@
+-- Andreas, 2026-06-04, issue #8580, reported and test by DrpontAgon
+-- Pattern synonym checking crashed if argument was _.
+
+-- {-# OPTIONS -v scope.pat:40 #-}
+
+pattern S _ = Set
+
+-- WAS: internal error
+--
+-- Expected error: [UnusedVariableInPatternSynonym]
+-- Unused variable in pattern synonym: _
+-- when scope checking the declaration
+--   pattern S _ = Set

--- a/test/Fail/Issue8580.err
+++ b/test/Fail/Issue8580.err
@@ -1,0 +1,4 @@
+Issue8580.agda:6.11-12: error: [UnusedVariableInPatternSynonym]
+Unused variable in pattern synonym: _
+when scope checking the declaration
+  pattern S _ = Set


### PR DESCRIPTION
Fix #8580 by checking that arguments to pattern synonym are not underscores.