### PR TITLE
Added a missing option to a list in the documentation

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -2589,6 +2589,7 @@ again, the source file is re-typechecked instead:
 * :option:`--no-guardedness`
 * :option:`--no-import-sorts`
 * :option:`--no-load-primitives`
+* :option:`--no-occurrence-analysis`
 * :option:`--no-pattern-matching`
 * :option:`--no-positivity-check`
 * :option:`--no-projection-like`


### PR DESCRIPTION
The following list:

https://github.com/agda/agda/blob/5be79acab9f9fae1e888714dbbc772c817fb978a/doc/user-manual/tools/command-line-options.rst?plain=1#L2552-L2614