### PR TITLE
Make AGDA_BIN_SUFFIX overridable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ include ./mk/pretty.mk
 # Or set it in ./mk/config.mk, which is .gitignored
 PARALLEL_TESTS ?= $(shell getconf _NPROCESSORS_ONLN)
 
-AGDA_BIN_SUFFIX = -$(VERSION)
+AGDA_BIN_SUFFIX ?= -$(VERSION)
 AGDA_TESTS_OPTIONS ?=-i -j$(PARALLEL_TESTS)
 
 # A cabal/stack dictionary


### PR DESCRIPTION
This makes it easier for users to install multiple versions of agda with distinct names, e.g.:

  make install-bin AGDA_BIN_SUFFIX=-featurebranch
  make install-bin AGDA_BIN_SUFFIX=-master

This change follows the existing convention for user-overridable variables (AGDA_BIN, BUILD_DIR, PARALLEL_TESTS).