### PR TITLE
Fix #8596: termination checker respects copatterns

### DIFF
--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -15,6 +15,10 @@ import Control.Monad.Except   ( MonadError(..) )
 
 import Data.DList ( DList )
 import Data.DList qualified as DL
+import Data.IntMap.Strict ( IntMap )
+import Data.IntMap.Strict qualified as IntMap
+import Data.Map.Strict ( Map )
+import Data.Map.Strict qualified as Map
 import Data.Set   ( Set )
 import Data.Set   qualified as Set
 
@@ -131,6 +135,13 @@ data TerEnv = TerEnv
     --   (See issue #1015).
   , terUsableVars :: !VarSet
     -- ^ Pattern variables that can be compared to argument variables using SIZELT.
+  , terProjectedNameToNode :: !(Map (QName, [QName]) CallGraph.Node)
+    -- ^ Map from (name, [projection]) to call-graph node.
+    --   (See issue #8596 for why projected names merit distinct nodes).
+  , terNodeToName :: !(IntMap QName)
+    -- ^ Map from call-graph node back to function names.
+  , terNameToProjections :: !(Map QName [[QName]])
+    -- ^ Map from function names to the list of all available projection paths.
   }
 
 -- | An empty termination environment.
@@ -161,6 +172,9 @@ defaultTerEnv = TerEnv
   , terGuarded                  = le -- not initially guarded
   , terUseSizeLt                = False -- initially, not under data constructor
   , terUsableVars               = empty
+  , terProjectedNameToNode      = Map.empty
+  , terNodeToName               = IntMap.empty
+  , terNameToProjections        = Map.empty
   }
 
 -- | Termination monad service class.
@@ -337,6 +351,24 @@ terModifyUsableVars f = terLocal $ \ e -> e { terUsableVars = f $ terUsableVars 
 
 terSetUsableVars :: VarSet -> TerM a -> TerM a
 terSetUsableVars = terModifyUsableVars . const
+
+terGetProjectedNameToNode :: TerM (Map (QName, [QName]) CallGraph.Node)
+terGetProjectedNameToNode = terAsks terProjectedNameToNode
+
+terSetProjectedNameToNode :: Map (QName, [QName]) CallGraph.Node -> TerM a -> TerM a
+terSetProjectedNameToNode fwd = terLocal $ \ e -> e { terProjectedNameToNode = fwd }
+
+terGetNodeToName :: TerM (IntMap QName)
+terGetNodeToName = terAsks terNodeToName
+
+terSetNodeToName :: IntMap QName -> TerM a -> TerM a
+terSetNodeToName bwd = terLocal $ \ e -> e { terNodeToName = bwd }
+
+terGetNameToProjections :: TerM (Map QName [[QName]])
+terGetNameToProjections = terAsks terNameToProjections
+
+terSetNameToProjections :: Map QName [[QName]] -> TerM a -> TerM a
+terSetNameToProjections modes = terLocal $ \ e -> e { terNameToProjections = modes }
 
 -- | Lens for 'terUseSizeLt'.
 

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -19,9 +19,10 @@ import Prelude hiding ( null, zip, zipWith )
 
 import Control.Applicative  ( liftA2 )
 import Control.Monad        ( (<=<), filterM, forM, forM_, zipWithM )
-
 import Data.Foldable (toList)
+import qualified Data.IntMap.Strict as IntMap
 import qualified Data.List as List
+import qualified Data.Map.Strict as Map
 import Data.Monoid hiding ((<>))
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -214,11 +215,16 @@ termMutual names0 = ifNotM (optTerminationCheck <$> pragmaOptions) (return mempt
            { terMutual    = allNames
            , terUserNames = namesSCC
            }
-         runTerm cont = runTerDefault $ do
+     -- Pre-compute the copattern projection lists and assign node ids, per issue #8596.
+     (projectedNameToNode, nodeToName, nameToProjections) <- buildNodeAndProjectionMaps allNames
+     let runTerm cont = runTerDefault $ do
            cutoff <- terGetCutOff
            reportSLn "term.top" 10 $ "Termination checking " ++ prettyShow namesSCC ++
              " with cutoff=" ++ show cutoff ++ "..."
-           terLocal setNames cont
+           terSetProjectedNameToNode projectedNameToNode $
+             terSetNodeToName nodeToName $
+             terSetNameToProjections nameToProjections $
+             terLocal setNames cont
 
      -- New check currently only makes a difference for copatterns and record types.
      -- Since it is slow, only invoke it if
@@ -231,13 +237,19 @@ termMutual names0 = ifNotM (optTerminationCheck <$> pragmaOptions) (return mempt
 
 -- | Run the termination checker.
 runTerminationCheck ::
-     (Node -> Bool)
+     Maybe QName
   -> TerM Calls
   -> TerM (Terminates CallPath)
-runTerminationCheck filt collect = do
+runTerminationCheck mname collect = do
     -- Use full precision when extracting calls
     let ?cutoff = DontCutOff
     calls <- collect
+
+    nodeToName <- terGetNodeToName
+    let filt :: Node -> Bool
+        filt = case mname of
+          Nothing -> const True
+          Just f  -> \ n -> IntMap.lookup n nodeToName == Just f
 
     useGuardedness <- liftTCM guardednessOption
     maxcutoff <- terGetCutOff
@@ -277,7 +289,7 @@ termMutual' = do
   let collect :: TerM Calls
       collect = forM' allNames termDef
 
-  r <- runTerminationCheck (const True) collect
+  r <- runTerminationCheck Nothing collect
 
   -- @names@ is taken from the 'Abstract' syntax, so it contains only
   -- the names the user has declared.  This is for error reporting.
@@ -373,12 +385,6 @@ reportCalls cutoff filt calls = do
 termFunction :: QName -> TerM Result
 termFunction name = inConcreteOrAbstractMode name $ \ def -> do
 
-  -- Function @name@ is henceforth referred to by its @index@
-  -- in the list of @allNames@ of the mutual block.
-
-  allNames <- terGetMutual
-  let index = fromMaybe __IMPOSSIBLE__ $ Set.lookupIndex name allNames
-
   -- Retrieve the target type of the function to check.
   -- #4256: Don't use typeOfConst (which instantiates type with module params), since termination
   -- checking is running in the empty context, but with the current module unchanged.
@@ -399,23 +405,27 @@ termFunction name = inConcreteOrAbstractMode name $ \ def -> do
     let
       collect :: TerM Calls
       collect = -- strengthenLoopDiagonals <$> do  -- bad heuristics, see https://github.com/agda/agda/pull/8184#issuecomment-3487147737
-        (`trampolineM` (Set.singleton index, mempty, mempty)) $ \ (todo, done, calls) -> do
+        (`trampolineM` (Set.singleton name, mempty, mempty)) $ \ (todo, done, calls) -> do
           if null todo then return $ Left calls else do
-            -- Extract calls originating from indices in @todo@.
-            new <- forM' todo $ \ i ->
-              termDef $
-              if i < 0 || i >= Set.size allNames
-              then __IMPOSSIBLE__
-              else Set.elemAt i allNames
+            -- Extract calls originating from functions in @todo@.
+            new <- forM' todo termDef
+            -- call-graph nodes correspond to @(name, [projection])@ pairs, so we
+            -- need to do a step of processing to translate node numbers into the
+            -- corresponding function name (see #8596).
+            nodeToName <- terGetNodeToName
+            let newNames = Set.fromList
+                  [ q | n <- Set.toList (CallGraph.targetNodes new)
+                      , Just q <- [IntMap.lookup n nodeToName]
+                      ]
             -- Mark those functions as processed and add the calls to the result.
             let done'  = done `mappend` todo
                 calls' = new  `mappend` calls
             -- Compute the new todo list:
-                todo' = CallGraph.targetNodes new Set.\\ done'
+                todo' = newNames Set.\\ done'
             -- Jump the trampoline.
             return $ Right (todo', done', calls')
 
-    r <- runTerminationCheck (== index) collect
+    r <- runTerminationCheck (Just name) collect
 
     names <- terGetUserNames
     case r of
@@ -853,7 +863,7 @@ function g es0 = do
        Nothing   -> return calls
 
        -- call is to one of the mutally recursive functions/record
-       Just gInd -> do
+       Just{} -> do
          cutoff <- terGetCutOff
          let ?cutoff = cutoff
 
@@ -938,9 +948,13 @@ function g es0 = do
            -- Andreas, 2017-01-05, issue #2376
            -- Remove arguments inserted by etaExpandClause.
 
-         let src  = fromMaybe __IMPOSSIBLE__ $ Set.lookupIndex f names
-             tgt  = gInd
-             cm   = makeCM ncols nrows matrix'
+         -- Issue #8596: stratify the call-graph nodes by copattern projection
+         -- list.  The source node is the caller's (name, [projection]) tuple;
+         -- the target fans out to every real callee mode this call can reach
+         -- (those whose projection path is prefix-comparable to the call's).
+         srcNode  <- projNode f =<< clauseProjPath
+         tgtNodes <- callTargetNodes g es0
+         let cm   = makeCM ncols nrows matrix'
              info = CallPath { callPathStart = f, callPathSteps = singleton $
                     CallInfo
                       { callInfoTarget = g
@@ -955,7 +969,70 @@ function g es0 = do
              , nest 2 $ "call matrix (with guardedness): "
              , nest 2 $ pretty cm
              ]
-         return $ CallGraph.insert src tgt cm info calls
+         return $ List.foldl' (\ cs t -> CallGraph.insert srcNode t cm info cs) calls tgtNodes
+
+-- | The canonical leading copattern projection path of the clause currently
+--   being checked.
+clauseProjPath :: TerM [QName]
+clauseProjPath = do
+  pats <- terGetPatterns
+  mapM getOriginalProjection $
+    mapMaybe (fmap (headAmbQ . snd) . isProjP . getMasked) pats
+
+-- | Look up the call-graph node for a @(function, projection path)@ pair.
+--   The pair must have been registered by 'buildNodeAndProjectionMaps'.
+projNode :: QName -> [QName] -> TerM Node
+projNode f path = fromMaybe __IMPOSSIBLE__ . Map.lookup (f, path) <$> terGetProjectedNameToNode
+
+-- | Pre-compute the copattern-mode node maps for a mutual SCC.
+--
+--   For each function in the SCC we collect the canonical leading copattern
+--   projection path of every clause, deduplicate, and assign a fresh 'Node'
+--   integer to each @(function, [projection])@ pair.  The resulting maps
+--   are stored in 'TerEnv' before call extraction begins.  The reverse map
+--   is split into an @IntMap QName@ and a @Map QName [[QName]]@ because
+--   'termFunction' walks per-function, and thus only needs the names.
+buildNodeAndProjectionMaps
+  :: Set QName
+  -> TCM (Map.Map (QName, [QName]) Node, IntMap.IntMap QName, Map.Map QName [[QName]])
+buildNodeAndProjectionMaps allNames = do
+  pairs <- forM (Set.toList allNames) $ \ g -> do
+    cls <- defClauses <$> ignoreAbstractMode (getConstInfo g)
+    ms <- forM cls $ \ cl ->
+      mapM getOriginalProjection $
+        mapMaybe (fmap (headAmbQ . snd) . isProjP . namedArg) $ namedClausePats cl
+    return (g, List.nub ms)
+  let projectionsOf (g, ps) = if null ps then [(g, [])] else map (g,) ps
+      allProjectionLists = concatMap projectionsOf pairs
+      projectedNameToNode = Map.fromList $ zip allProjectionLists [0..]
+      nodeToName = IntMap.fromList $ zip [0..] $ map fst allProjectionLists
+      nameToProjections = Map.fromList [ (g, if null ms then [[]] else ms) | (g, ms) <- pairs ]
+  return (projectedNameToNode, nodeToName, nameToProjections)
+
+-- | Two projection paths are comparable if one is a prefix of the other.
+comparableProjPath :: [QName] -> [QName] -> Bool
+comparableProjPath xs ys = xs `List.isPrefixOf` ys || ys `List.isPrefixOf` xs
+
+-- | The callee nodes that a recursive call should connect to. It is not as easy
+--   as just looking up the node corresponding to a name, because in the case of
+--   definitions by copatterns, a call to @x .foo@ also counts as routing through
+--   @x .foo .bar@, for the purpose of termination checking. So the call must be
+--   "fanned out" to every callee with a comparable projection list.
+callTargetNodes :: QName -> Elims -> TerM [Node]
+callTargetNodes g es = do
+  givenProjList <- mapM getOriginalProjection [ d | Proj _ d <- es ]
+  knownProjLists <- Map.findWithDefault [[]] g <$> terGetNameToProjections
+  let comparable = filter (comparableProjPath givenProjList) knownProjLists
+      leaves
+        | null comparable = knownProjLists  -- incomparable: conservatively connect to all
+        | otherwise       = comparable
+  unless (leaves == [givenProjList]) $
+    reportSLn "term.copattern.modes" 30 $ unwords
+      [ "call to", prettyShow g
+      , "at projection path", show (map prettyShow givenProjList)
+      , "connects to modes", show (map (map prettyShow) leaves)
+      ]
+  mapM (projNode g) leaves
 
 -- We have to reduce constructors in case they're reexported.
 -- Andreas, Issue 1530: constructors have to be reduced deep inside terms,

--- a/test/Fail/CopatternNonterminating.err
+++ b/test/Fail/CopatternNonterminating.err
@@ -2,5 +2,5 @@ CopatternNonterminating.agda:16.1-18.38: error: [TerminationIssue]
 Termination checking failed for the following function:
   illdefined
 Problematic call:
-  Stream.tail illdefined
-    (at CopatternNonterminating.agda:18.28-38)
+  Stream.head illdefined
+    (at CopatternNonterminating.agda:17.28-38)

--- a/test/Fail/Issue5819.err
+++ b/test/Fail/Issue5819.err
@@ -4,31 +4,6 @@ Issue5819.agda:108.36-53: warning: -W[no]RewritesNothing
 when checking that the clause
 invˡ {dl″ (cons′ a l) p} rewrite invˡ {dl″ l ?} = ? has type
 {x = x₁ : DList″} → f dl-iso (f⁻¹ dl-iso x₁) ≡ x₁
-Issue5819.agda:72.1-120.45: error: [TerminationIssue]
-Termination checking failed for the following functions:
-  dl-iso Fresh→Fresh′ Fresh→AllFresh
-Problematic calls:
-  Fresh→Fresh′ eq p | l″ | sym eq
-  Fresh→AllFresh eq p | l″ | sym eq
-  f dl-iso (dcons a₁ l x)
-    (at Issue5819.agda:78.19-25)
-  f dl-iso (dcons a l x)
-    (at Issue5819.agda:83.21-27)
-  f⁻¹ dl-iso (dl″ l′ (proj₂ p))
-    (at Issue5819.agda:88.19-25)
-  Fresh→Fresh′ refl p
-    (at Issue5819.agda:95.11-23)
-  Fresh→AllFresh refl p
-    (at Issue5819.agda:96.11-25)
-  Issue5819.invˡ
-    (at Issue5819.agda:104.20-24)
-  f dl-iso (f⁻¹ dl-iso (dl″ l (?0 (x = x) (a = a) (l = l) (p = p))))
-    (at Issue5819.agda:106.19-25)
-  f dl-iso l
-    (at Issue5819.agda:112.37-43)
-  f dl-iso l
-    (at Issue5819.agda:116.84-90)
-
 Issue5819.agda:108.48-120.45: error: [UnsolvedInteractionMetas]
 Unsolved interaction metas at the following locations:
   Issue5819.agda:108.48-52

--- a/test/Fail/Issue8596a.agda
+++ b/test/Fail/Issue8596a.agda
@@ -1,0 +1,12 @@
+module Issue8596a where
+
+open import Agda.Builtin.Nat
+
+record P : Set where
+  field fst snd : Nat
+open P
+
+p : P
+p .fst = p .snd
+p .snd = p .fst
+-- should not termination-check

--- a/test/Fail/Issue8596a.err
+++ b/test/Fail/Issue8596a.err
@@ -1,0 +1,8 @@
+Issue8596a.agda:9.1-11.16: error: [TerminationIssue]
+Termination checking failed for the following function:
+  p
+Problematic calls:
+  p .snd
+    (at Issue8596a.agda:10.10-11)
+  p .fst
+    (at Issue8596a.agda:11.10-11)

--- a/test/Fail/Issue8596b.agda
+++ b/test/Fail/Issue8596b.agda
@@ -1,0 +1,14 @@
+module Issue8596b where
+
+open import Agda.Builtin.Nat
+
+record R : Set where
+  field fst : Nat
+open R
+
+mutual
+  use : R → Nat
+  use x = x .fst
+
+  r : R
+  r .fst = use r

--- a/test/Fail/Issue8596b.err
+++ b/test/Fail/Issue8596b.err
@@ -1,0 +1,5 @@
+Issue8596b.agda:9.1-14.17: error: [TerminationIssue]
+Termination checking failed for the following function:
+  r
+Problematic call:
+  r (at Issue8596b.agda:14.16-17)

--- a/test/Succeed/Issue3218.agda
+++ b/test/Succeed/Issue3218.agda
@@ -1,0 +1,30 @@
+module Issue3218 where
+
+postulate
+  A   : Set
+  _≤_ : A → A → Set
+  _•_ : ∀ {a b c} → a ≤ b → b ≤ c → a ≤ c
+
+data Tree : Set where
+  node : Tree → Tree
+
+data _⊑_ : Tree → Tree → Set where
+  trans : ∀ {a b c} → a ⊑ b → b ⊑ c → a ⊑ c
+
+record Fun : Set where
+  field ap  : Tree → A
+  field map : ∀ {T U} → T ⊑ U → ap T ≤ ap U
+open Fun
+
+-- Accepted
+get : Tree → A
+get (node T) = get T
+
+Get : Fun
+ap  Get = get
+map Get (trans T≤U U≤V) = map Get T≤U • map Get U≤V
+
+-- Previously rejected
+NoGet : Fun
+ap  NoGet (node T)        = ap  NoGet T
+map NoGet (trans T≤U U≤V) = map NoGet T≤U • map NoGet U≤V

--- a/test/Succeed/Issue8596.agda
+++ b/test/Succeed/Issue8596.agda
@@ -1,0 +1,60 @@
+module Issue8596 where
+
+infix 1 _≡_
+data _≡_ {A : Set} (a : A) : A -> Set where
+    refl : a ≡ a
+
+ap : ∀ {A B : Set} (f : A -> B) {a b : A} -> a ≡ b -> f a ≡ f b
+ap f refl = refl
+
+infixr 9 _▪_
+_▪_ : ∀ {A : Set} {a1 a2 a3 : A} -> a1 ≡ a2 -> a2 ≡ a3 -> a1 ≡ a3
+refl ▪ q = q
+
+record ⊤ : Set where
+    constructor tt
+
+data Bit : Set where
+    lo hi : Bit
+
+record Semicat : Set1 where
+    field
+        Obj : Set
+        Arr : Obj -> Obj -> Set
+        _*_ : ∀ {a1 a2 a3} -> Arr a1 a2 -> Arr a2 a3 -> Arr a1 a3
+open Semicat
+
+record Pump (A : Semicat) : Set where
+    field pump : ∀ {a1 a2 : A .Obj} -> (A .Arr a1 a2) -> (A .Arr a1 a2)
+open Pump
+
+record Pump= {A : Semicat} (F G : Pump A) : Set where
+    field pump= : ∀ {a1 a2 : A .Obj} (a12 : A .Arr a1 a2) -> F .pump a12 ≡ G .pump a12
+open Pump=
+
+record SemicatWithIdempotentPump : Set1 where
+    field
+        Carrier : ⊤ -> Semicat
+        run : Pump (Carrier tt)
+        run-idem : ∀ {_ _ _ _ : ⊤} -> Pump= record{pump = \ x -> run .pump (run .pump x)} run
+            -- When callgraph nodes were not stratified by copattern projections,
+            -- termination checking would fail so long as run-idem had 2 or 4
+            -- spurious ⊤ arguments.
+open SemicatWithIdempotentPump
+
+record Portal : Set1 where
+    field port : ⊤ -> Bit -> Bit
+open Portal
+
+data Chain (P : Portal) (b1 b2 : Bit) : Set where
+    cons : (b1 ≡ P .port tt lo) -> Chain P (P .port tt lo) b2 -> Chain P b1 b2
+
+portal : Portal
+portal .port _ b = b
+
+SWIP : SemicatWithIdempotentPump
+SWIP .Carrier a .Semicat.Obj = Bit
+SWIP .Carrier a .Semicat.Arr = Chain portal
+SWIP .Carrier a .Semicat._*_ (cons e1 c1) p = cons e1 (SWIP .Carrier a .Semicat._*_ c1 p)
+SWIP .run .pump (cons e c) = cons e (SWIP .run .pump c)
+SWIP .run-idem .pump= (cons refl c) = ap (cons refl) (SWIP .run-idem .pump= c)

--- a/test/Succeed/Issue8596.agda
+++ b/test/Succeed/Issue8596.agda
@@ -1,60 +1,133 @@
 module Issue8596 where
+open import Agda.Builtin.Bool
 
-infix 1 _≡_
-data _≡_ {A : Set} (a : A) : A -> Set where
+module AvoidSpuriousMatrixCollission where
+  infix 1 _≡_
+  data _≡_ {A : Set} (a : A) : A -> Set where
     refl : a ≡ a
 
-ap : ∀ {A B : Set} (f : A -> B) {a b : A} -> a ≡ b -> f a ≡ f b
-ap f refl = refl
+  cong : ∀ {A B : Set} (f : A -> B) {a b : A} -> a ≡ b -> f a ≡ f b
+  cong f refl = refl
 
-infixr 9 _▪_
-_▪_ : ∀ {A : Set} {a1 a2 a3 : A} -> a1 ≡ a2 -> a2 ≡ a3 -> a1 ≡ a3
-refl ▪ q = q
+  infixr 9 _▪_
+  _▪_ : ∀ {A : Set} {a1 a2 a3 : A} -> a1 ≡ a2 -> a2 ≡ a3 -> a1 ≡ a3
+  refl ▪ q = q
 
-record ⊤ : Set where
+  record ⊤ : Set where
     constructor tt
 
-data Bit : Set where
+  data Bit : Set where
     lo hi : Bit
 
-record Semicat : Set1 where
+  record Semicat : Set1 where
     field
-        Obj : Set
-        Arr : Obj -> Obj -> Set
-        _*_ : ∀ {a1 a2 a3} -> Arr a1 a2 -> Arr a2 a3 -> Arr a1 a3
-open Semicat
+      Obj : Set
+      Arr : Obj -> Obj -> Set
+      _*_ : ∀ {a1 a2 a3} -> Arr a1 a2 -> Arr a2 a3 -> Arr a1 a3
+  open Semicat
 
-record Pump (A : Semicat) : Set where
+  record Pump (A : Semicat) : Set where
     field pump : ∀ {a1 a2 : A .Obj} -> (A .Arr a1 a2) -> (A .Arr a1 a2)
-open Pump
+  open Pump
 
-record Pump= {A : Semicat} (F G : Pump A) : Set where
+  record Pump= {A : Semicat} (F G : Pump A) : Set where
     field pump= : ∀ {a1 a2 : A .Obj} (a12 : A .Arr a1 a2) -> F .pump a12 ≡ G .pump a12
-open Pump=
+  open Pump=
 
-record SemicatWithIdempotentPump : Set1 where
+  record SemicatWithIdempotentPump : Set1 where
     field
-        Carrier : ⊤ -> Semicat
-        run : Pump (Carrier tt)
-        run-idem : ∀ {_ _ _ _ : ⊤} -> Pump= record{pump = \ x -> run .pump (run .pump x)} run
-            -- When callgraph nodes were not stratified by copattern projections,
-            -- termination checking would fail so long as run-idem had 2 or 4
-            -- spurious ⊤ arguments.
-open SemicatWithIdempotentPump
+      Carrier : ⊤ -> Semicat
+      run : Pump (Carrier tt)
+      run-idem : ∀ {_ _ _ _ : ⊤} -> Pump= record{pump = \ x -> run .pump (run .pump x)} run
+        -- When callgraph nodes were not stratified by copattern projections,
+        -- termination checking would fail so long as run-idem had 2 or 4
+        -- spurious ⊤ arguments.
+  open SemicatWithIdempotentPump
 
-record Portal : Set1 where
+  record Portal : Set1 where
     field port : ⊤ -> Bit -> Bit
-open Portal
+  open Portal
 
-data Chain (P : Portal) (b1 b2 : Bit) : Set where
+  data Chain (P : Portal) (b1 b2 : Bit) : Set where
     cons : (b1 ≡ P .port tt lo) -> Chain P (P .port tt lo) b2 -> Chain P b1 b2
 
-portal : Portal
-portal .port _ b = b
+  portal : Portal
+  portal .port _ b = b
 
-SWIP : SemicatWithIdempotentPump
-SWIP .Carrier a .Semicat.Obj = Bit
-SWIP .Carrier a .Semicat.Arr = Chain portal
-SWIP .Carrier a .Semicat._*_ (cons e1 c1) p = cons e1 (SWIP .Carrier a .Semicat._*_ c1 p)
-SWIP .run .pump (cons e c) = cons e (SWIP .run .pump c)
-SWIP .run-idem .pump= (cons refl c) = ap (cons refl) (SWIP .run-idem .pump= c)
+  SWIP : SemicatWithIdempotentPump
+  SWIP .Carrier a .Semicat.Obj = Bit
+  SWIP .Carrier a .Semicat.Arr = Chain portal
+  SWIP .Carrier a .Semicat._*_ (cons e1 c1) p = cons e1 (SWIP .Carrier a .Semicat._*_ c1 p)
+  SWIP .run .pump (cons e c) = cons e (SWIP .run .pump c)
+  SWIP .run-idem .pump= (cons refl c) = cong (cons refl) (SWIP .run-idem .pump= c)
+
+module RegularSplitFirst where
+
+  postulate
+    A   : Set
+    _≤_ : A → A → Set
+    _·_ : ∀ {a b c} → a ≤ b → b ≤ c → a ≤ c
+
+  data Tree : Set where
+    node : Tree → Tree
+
+  data _⊑_ : Tree → Tree → Set where
+    trans : ∀ {a b c} → a ⊑ b → b ⊑ c → a ⊑ c
+
+  record Fun : Set where
+    field
+      ap  : Tree → A
+      map : ∀ {T U} → T ⊑ U → ap T ≤ ap U
+  open Fun
+
+  sel : Bool → Fun
+  sel true .ap (node T) = sel true .ap T
+  sel true .map (trans T U) = sel true .map T · sel true .map U
+  sel false .ap (node T) = sel false .ap T
+  sel false .map (trans T U) = sel false .map T · sel false .map U
+
+module DependentSplit where
+
+  postulate
+    A   : Set
+    a₀  : A
+    _≤_ : A → A → Set
+    _·_ : ∀ {a b c} → a ≤ b → b ≤ c → a ≤ c
+
+  data Tree : Set where
+    node : Tree → Tree
+
+  data _⊑_ : Tree → Tree → Set where
+    trans : ∀ {a b c} → a ⊑ b → b ⊑ c → a ⊑ c
+
+  record Fun : Set where
+    field
+      ap  : Tree → A
+      map : ∀ {T U} → T ⊑ U → ap T ≤ ap U
+  open Fun
+
+  Ty : Bool → Set
+  Ty true  = Fun
+  Ty false = A
+
+  g : (b : Bool) → Ty b
+  g true .ap  (node T) = g true .ap T
+  g true .map (trans T U) = g true .map T · g true .map U
+  g false = a₀
+
+module NestedProjection where
+  open import Agda.Builtin.Nat
+
+  record R2 : Set where
+    field g h : Nat
+  open R2
+
+  record R1 : Set where
+    field f : Bool → R2
+  open R1
+
+  x : Nat → R1
+  x zero .f b .g = zero
+  x (suc n) .f b .g = x n .f b .g
+  x zero .f b .h = zero
+  x (suc n) .f b .h = x n .f b .h


### PR DESCRIPTION
Implementation follows Andreas' suggestion here:
https://github.com/agda/agda/issues/8596#issuecomment-4706840512. The TerM environment is augmented with maps to link (name, [projection]) pairs to call-graph nodes. I use a triplet of maps instead of a single bimap, because one consumer of the maps (`termFunction`) only cares about the name component and not the projection component. This doesn't really matter and I could switch to a bimap if that's preferred.

I'd appreciate a careful check o my logic in `callTargetNodes`. Out of an abundance of caution, I make a conservative choice where definitions that don't exist yet are assumed to call into every possible projection; so e.g. if `x .fst = x .snd + 1` and `x .snd` hasn't been defined yet, the termination checker will complain. This is *probably* overly conservative and should *probably* be relaxed, but I don't feel sufficiently confident that I understand all the edge-case invocations and I don't want to introduce a `False` so I went with the conservative choice out of an abundance of caution.

This change also fixes #3218.

This change affects two Fail tests:
* CopatternNonterminating now reports the head self-loop rather than the tail one. I'm not sure why, and assume it doesn't matter.
* Issue5819 tests for failure in the case of unsolved interaction metas. It also happens to produce a spurious termination issue that this fix has resolved. The unsolved interaction metas still cause it to fail, but the termination issue is cleared up and has been removed from the output.

I refrained from adding a changelog entry on account of this being a bugfix. (The changelog has a 'bugfix' section that is empty afaict, and one of my theories is that it's autogenerated.)