### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,9 +131,29 @@ else
 endif
 	agda --setup --emacs-mode compile --emacs-mode setup
 
+.PHONY: build ## Build Agda and test suite in place (with debug printing, like the test suite expects)
+build:
+ifdef HAS_STACK
+	$(STACK_SLOW) build Agda $(STACK_OPT_NO_DOCS) $(STACK_OPT_TESTS) --flag Agda:debug
+else
+	$(CABAL) build -fdebug exe:agda exe:agda-tests
+endif
+
+.PHONY: fast-build ## Build Agda and test suite with -O0 for faster iteration
+fast-build:
+ifdef HAS_STACK
+	$(STACK_FAST) build Agda $(STACK_OPT_NO_DOCS) $(STACK_OPT_TESTS) $(STACK_OPT_FAST)
+else
+	$(CABAL) build --builddir=$(FAST_BUILD_DIR) $(CABAL_OPT_FAST) exe:agda exe:agda-tests
+endif
+
 .PHONY: setup-agda
 setup-agda:
 	$(AGDA_BIN) --setup
+
+.PHONY: fast-setup-agda
+fast-setup-agda:
+	$(AGDA_FAST_BIN) --setup
 
 # GHC doesn't realise that the Template Haskell changes in the VersionCommit module
 # even if the source code does not. Simply touching the source is not enough to force
@@ -443,6 +463,9 @@ test-using-std-lib : std-lib-test \
 .PHONY : test-quick ## Run successful and failing tests.
 test-quick : common succeed fail
 
+.PHONY : fast-test-quick ## Run successful and failing tests (using agda-fast).
+fast-test-quick : fast-common fast-succeed fast-fail
+
 .PHONY : check-encoding ## Make sure that Parser.y is ASCII. [Issue #5465]
 check-encoding :
 	@$(call decorate, "Check that Parser.y is ASCII", \
@@ -459,63 +482,79 @@ check-mdo :
           test/check-mdo.sh)
 
 .PHONY : bugs ##
-bugs :
+bugs : setup-agda
 	@$(call decorate, "Suite of tests for bugs", \
 	  AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Bugs)
 
 .PHONY : internal-tests ##
-internal-tests :
+internal-tests : setup-agda
 	@$(call decorate, "Internal test suite", \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Internal )
 
 .PHONY : fast-internal-tests ##
-fast-internal-tests :
+fast-internal-tests : fast-setup-agda
 	@$(call decorate, "Internal test suite (using agda-fast)", \
 		AGDA_BIN=$(AGDA_FAST_BIN) $(AGDA_FAST_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Internal )
 
 .PHONY : common ##
-common :
+common : setup-agda
 	@$(call decorate, "Suite of successful tests: mini-library Common", \
 		$(MAKE) -C test/Common )
 
+.PHONY : fast-common ##
+fast-common : fast-setup-agda
+	@$(call decorate, "Suite of successful tests: mini-library Common (using agda-fast)", \
+		$(MAKE) -C test/Common AGDA_BIN=$(AGDA_FAST_BIN) )
+
 .PHONY : succeed ##
-succeed :
+succeed : setup-agda
 	@$(call decorate, "Suite of successful tests", \
 		echo $(shell command -v $(AGDA_BIN)) > test/helpers/exec-tc/executables && \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Succeed ; \
 		rm test/helpers/exec-tc/executables )
 
 .PHONY : fast-succeed ##
-fast-succeed :
+fast-succeed : fast-setup-agda
 	@$(call decorate, "Suite of successful tests (using agda-fast)", \
 		echo $(shell command -v $(AGDA_FAST_BIN)) > test/helpers/exec-tc/executables && \
 		AGDA_BIN=$(AGDA_FAST_BIN) $(AGDA_FAST_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Succeed ; \
 		rm test/helpers/exec-tc/executables )
 
 .PHONY : fail ##
-fail :
+fail : setup-agda
 	@$(call decorate, "Suite of failing tests", \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Fail)
 
 .PHONY : fast-fail ##
-fast-fail :
+fast-fail : fast-setup-agda
 	@$(call decorate, "Suite of failing tests (using agda-fast)", \
 		AGDA_BIN=$(AGDA_FAST_BIN) $(AGDA_FAST_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Fail)
 
 .PHONY: build-fail-test ##
-build-fail-test :
+build-fail-test : setup-agda
 	@$(call decorate, "Suite of failing --build-library tests", \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/BuildFail)
 
 .PHONY: build-succeed-test ##
-build-succeed-test :
+build-succeed-test : setup-agda
 	@$(call decorate, "Suite of successful --build-library tests", \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/BuildSucceed)
 
+.PHONY: build-test ##
+build-test : build-fail-test build-succeed-test
+
+.PHONY : fast-build-fail-test ##
+fast-build-fail-test : fast-setup-agda
+	@$(call decorate, "Suite of failing --build-library tests (using agda-fast)", \
+		AGDA_BIN=$(AGDA_FAST_BIN) $(AGDA_FAST_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/BuildFail)
+
 .PHONY : fast-build-succeed-test ##
-fast-build-succeed-test :
+fast-build-succeed-test : fast-setup-agda
 	@$(call decorate, "Suite of successful --build-library tests (using agda-fast)", \
 		AGDA_BIN=$(AGDA_FAST_BIN) $(AGDA_FAST_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/BuildSucceed)
+
+.PHONY : fast-build-test ##
+fast-build-test : fast-build-fail-test fast-build-succeed-test
 
 .PHONY : interaction ##
 interaction :

--- a/Makefile
+++ b/Makefile
@@ -131,13 +131,14 @@ else
 endif
 	agda --setup --emacs-mode compile --emacs-mode setup
 
-.PHONY: build ## Build Agda and test suite in place (with debug printing, like the test suite expects)
+.PHONY: build ## Build Agda and test suite in place (with debug printing, like the test suite expects), then regenerate primitives
 build:
 ifdef HAS_STACK
 	$(STACK_SLOW) build Agda $(STACK_OPT_NO_DOCS) $(STACK_OPT_TESTS) --flag Agda:debug
 else
 	$(CABAL) build -fdebug exe:agda exe:agda-tests
 endif
+	$(MAKE) setup-agda
 
 .PHONY: fast-build ## Build Agda and test suite with -O0 for faster iteration
 fast-build:
@@ -146,14 +147,11 @@ ifdef HAS_STACK
 else
 	$(CABAL) build --builddir=$(FAST_BUILD_DIR) $(CABAL_OPT_FAST) exe:agda exe:agda-tests
 endif
+	$(AGDA_FAST_BIN) --setup
 
 .PHONY: setup-agda
 setup-agda:
 	$(AGDA_BIN) --setup
-
-.PHONY: fast-setup-agda
-fast-setup-agda:
-	$(AGDA_FAST_BIN) --setup
 
 # GHC doesn't realise that the Template Haskell changes in the VersionCommit module
 # even if the source code does not. Simply touching the source is not enough to force
@@ -499,61 +497,61 @@ check-mdo :
           test/check-mdo.sh)
 
 .PHONY : bugs ##
-bugs : setup-agda
+bugs :
 	@$(call decorate, "Suite of tests for bugs", \
 	  AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Bugs)
 
 .PHONY : internal-tests ##
-internal-tests : setup-agda
+internal-tests :
 	@$(call decorate, "Internal test suite", \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Internal )
 
 .PHONY : fast-internal-tests ##
-fast-internal-tests : fast-setup-agda
+fast-internal-tests :
 	@$(call decorate, "Internal test suite (using agda-fast)", \
 		AGDA_BIN=$(AGDA_FAST_BIN) $(AGDA_FAST_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Internal )
 
 .PHONY : common ##
-common : setup-agda
+common :
 	@$(call decorate, "Suite of successful tests: mini-library Common", \
 		$(MAKE) -C test/Common )
 
 .PHONY : fast-common ##
-fast-common : fast-setup-agda
+fast-common :
 	@$(call decorate, "Suite of successful tests: mini-library Common (using agda-fast)", \
 		$(MAKE) -C test/Common AGDA_BIN=$(AGDA_FAST_BIN) )
 
 .PHONY : succeed ##
-succeed : setup-agda
+succeed :
 	@$(call decorate, "Suite of successful tests", \
 		echo $(shell command -v $(AGDA_BIN)) > test/helpers/exec-tc/executables && \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Succeed ; \
 		rm test/helpers/exec-tc/executables )
 
 .PHONY : fast-succeed ##
-fast-succeed : fast-setup-agda
+fast-succeed :
 	@$(call decorate, "Suite of successful tests (using agda-fast)", \
 		echo $(shell command -v $(AGDA_FAST_BIN)) > test/helpers/exec-tc/executables && \
 		AGDA_BIN=$(AGDA_FAST_BIN) $(AGDA_FAST_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Succeed ; \
 		rm test/helpers/exec-tc/executables )
 
 .PHONY : fail ##
-fail : setup-agda
+fail :
 	@$(call decorate, "Suite of failing tests", \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Fail)
 
 .PHONY : fast-fail ##
-fast-fail : fast-setup-agda
+fast-fail :
 	@$(call decorate, "Suite of failing tests (using agda-fast)", \
 		AGDA_BIN=$(AGDA_FAST_BIN) $(AGDA_FAST_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Fail)
 
 .PHONY: build-fail-test ##
-build-fail-test : setup-agda
+build-fail-test :
 	@$(call decorate, "Suite of failing --build-library tests", \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/BuildFail)
 
 .PHONY: build-succeed-test ##
-build-succeed-test : setup-agda
+build-succeed-test :
 	@$(call decorate, "Suite of successful --build-library tests", \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/BuildSucceed)
 
@@ -561,12 +559,12 @@ build-succeed-test : setup-agda
 build-test : build-fail-test build-succeed-test
 
 .PHONY : fast-build-fail-test ##
-fast-build-fail-test : fast-setup-agda
+fast-build-fail-test :
 	@$(call decorate, "Suite of failing --build-library tests (using agda-fast)", \
 		AGDA_BIN=$(AGDA_FAST_BIN) $(AGDA_FAST_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/BuildFail)
 
 .PHONY : fast-build-succeed-test ##
-fast-build-succeed-test : fast-setup-agda
+fast-build-succeed-test :
 	@$(call decorate, "Suite of successful --build-library tests (using agda-fast)", \
 		AGDA_BIN=$(AGDA_FAST_BIN) $(AGDA_FAST_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/BuildSucceed)
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ STACK_OPT_NO_DOCS = --no-haddock
 CABAL_OPT_TESTS   = --enable-tests
 STACK_OPT_TESTS   = --test --no-run-tests
 
-CABAL_OPT_FAST    = --ghc-options=-O0 -fdebug
+CABAL_OPT_FAST    = -O0 -fdebug
 STACK_OPT_FAST    = --fast --flag Agda:debug
 
 CABAL_FLAG_ICU    = -fenable-cluster-counting
@@ -451,6 +451,23 @@ test : check-whitespace \
        user-manual-test \
        doc-test \
        size-solver-test
+
+.PHONY : ci-test ## Build, then run exactly what the CI test workflow (.github/workflows/test.yml) runs.
+ci-test : build
+	@$(call decorate, "CI / whitespace job", \
+	  $(MAKE) check-whitespace check-encoding check-mdo)
+	@$(call decorate, "CI / test job", \
+	  $(MAKE) bugs common succeed fail examples interactive api-test internal-tests compiler-test)
+	@$(call decorate, "CI / interaction-latex-html job", \
+	  $(MAKE) build-succeed-test build-fail-test && \
+	  $(MAKE) DONT_RUN_LATEX=Y latex-html-test && \
+	  $(MAKE) testing-emacs-mode user-manual-test user-manual-covers-options user-manual-covers-warnings \
+	          test-suite-covers-warnings test-suite-covers-errors interaction)
+	@$(call decorate, "CI / cubical job", \
+	  $(MAKE) cubical-test cubical-succeed)
+	@$(call decorate, "CI / stdlib-test job", \
+	  $(MAKE) AGDA_OPTS="-j" std-lib-test && \
+	  $(MAKE) benchmark-without-logs std-lib-compiler-test std-lib-succeed std-lib-interaction)
 
 .PHONY : test-using-std-lib ## Run all tests which use the standard library.
 test-using-std-lib : std-lib-test \

--- a/mk/paths.mk
+++ b/mk/paths.mk
@@ -71,8 +71,8 @@ else
 AGDA_BIN            ?= $(or $(shell $(CABAL) list-bin exe:agda 2>/dev/null),$(BUILD_DIR)/build/agda/agda)
 AGDA_MODE           ?= $(or $(shell $(CABAL) list-bin exe:agda-mode 2>/dev/null),$(BUILD_DIR)/build/agda-mode/agda-mode)
 AGDA_TESTS_BIN      ?= $(or $(shell $(CABAL) list-bin exe:agda-tests 2>/dev/null),$(BUILD_DIR)/build/agda-tests/agda-tests)
-AGDA_FAST_BIN       ?= $(or $(shell $(CABAL) list-bin --builddir=$(FAST_BUILD_DIR) exe:agda 2>/dev/null),$(FAST_BUILD_DIR)/build/agda/agda)
-AGDA_FAST_TESTS_BIN ?= $(or $(shell $(CABAL) list-bin --builddir=$(FAST_BUILD_DIR) exe:agda-tests 2>/dev/null),$(FAST_BUILD_DIR)/build/agda-tests/agda-tests)
+AGDA_FAST_BIN       ?= $(or $(shell $(CABAL) list-bin -O0 --builddir=$(FAST_BUILD_DIR) exe:agda 2>/dev/null),$(FAST_BUILD_DIR)/build/agda/agda)
+AGDA_FAST_TESTS_BIN ?= $(or $(shell $(CABAL) list-bin -O0 --builddir=$(FAST_BUILD_DIR) exe:agda-tests 2>/dev/null),$(FAST_BUILD_DIR)/build/agda-tests/agda-tests)
 endif
 
 AGDA_BIN            := $(abspath $(AGDA_BIN))

--- a/mk/paths.mk
+++ b/mk/paths.mk
@@ -52,22 +52,31 @@ else
   FAST_BUILD_DIR  ?= $(BUILD_DIR)-fast
 endif
 
-# AGDA_BIN can be set in the system environment.
-AGDA_BIN ?= $(BUILD_DIR)/build/agda/agda
-AGDA_BIN := $(abspath $(AGDA_BIN))
-
-# AGDA_MODE can be set in the system environment.
-AGDA_MODE ?= $(BUILD_DIR)/build/agda-mode/agda-mode
-AGDA_MODE := $(abspath $(AGDA_MODE))
-
-# AGDA_TESTS_BIN can be set in the system environment.
-AGDA_TESTS_BIN ?= $(BUILD_DIR)/build/agda-tests/agda-tests
-AGDA_TESTS_BIN := $(abspath $(AGDA_TESTS_BIN))
-
-# Location of the -fast binaries for v1-cabal
-
-AGDA_FAST_BIN ?= $(FAST_BUILD_DIR)/build/agda/agda
-AGDA_FAST_BIN := $(abspath $(AGDA_FAST_BIN))
-
+# AGDA_BIN, AGDA_MODE, AGDA_TESTS_BIN (and their -fast variants) can be set in
+# the system environment.
+#
+# Under Cabal we ask `cabal list-bin` for the binary location (the v2-cabal
+# dist-newstyle layout used by the `build`/`fast-build` targets), falling back
+# to the v1-cabal layout under BUILD_DIR if Cabal cannot report it.  The -fast
+# variants point at FAST_BUILD_DIR; the plain variants use Cabal's default
+# build directory.  Under Stack we use the dist-dir computed above and do not
+# shell out to Cabal at all.
+ifdef HAS_STACK
+AGDA_BIN            ?= $(BUILD_DIR)/build/agda/agda
+AGDA_MODE           ?= $(BUILD_DIR)/build/agda-mode/agda-mode
+AGDA_TESTS_BIN      ?= $(BUILD_DIR)/build/agda-tests/agda-tests
+AGDA_FAST_BIN       ?= $(FAST_BUILD_DIR)/build/agda/agda
 AGDA_FAST_TESTS_BIN ?= $(FAST_BUILD_DIR)/build/agda-tests/agda-tests
+else
+AGDA_BIN            ?= $(or $(shell $(CABAL) list-bin exe:agda 2>/dev/null),$(BUILD_DIR)/build/agda/agda)
+AGDA_MODE           ?= $(or $(shell $(CABAL) list-bin exe:agda-mode 2>/dev/null),$(BUILD_DIR)/build/agda-mode/agda-mode)
+AGDA_TESTS_BIN      ?= $(or $(shell $(CABAL) list-bin exe:agda-tests 2>/dev/null),$(BUILD_DIR)/build/agda-tests/agda-tests)
+AGDA_FAST_BIN       ?= $(or $(shell $(CABAL) list-bin --builddir=$(FAST_BUILD_DIR) exe:agda 2>/dev/null),$(FAST_BUILD_DIR)/build/agda/agda)
+AGDA_FAST_TESTS_BIN ?= $(or $(shell $(CABAL) list-bin --builddir=$(FAST_BUILD_DIR) exe:agda-tests 2>/dev/null),$(FAST_BUILD_DIR)/build/agda-tests/agda-tests)
+endif
+
+AGDA_BIN            := $(abspath $(AGDA_BIN))
+AGDA_MODE           := $(abspath $(AGDA_MODE))
+AGDA_TESTS_BIN      := $(abspath $(AGDA_TESTS_BIN))
+AGDA_FAST_BIN       := $(abspath $(AGDA_FAST_BIN))
 AGDA_FAST_TESTS_BIN := $(abspath $(AGDA_FAST_TESTS_BIN))


### PR DESCRIPTION
* fix binary resolution for cabal v2
* add `build` targets so that one can `make build && make test-quick` and
  have it just work.
* run setup-agda before running test suites so that src/data/lib/prim
  won't be stale and ruin the tests
* add fast-* targets like fast-test-quick and etc., for symmetry with
  existing targets like fast-fail.

I was struggling with the previous makefile on cabal v2; these are some
quick attempts at what look to me like the sensible fixes. It's entirely
possible that I just don't understand the intended workflow and am
somehow stepping on toes.

I could break this into a few separate PRs (stratified by the bullet-points above) if that's easier; for now I'm sticking with the convenience of having all my makefile changes in one place.