### PR TITLE
Small tweaks to NotBlocked

### DIFF
--- a/src/full/Agda/Syntax/Internal/Blockers.hs
+++ b/src/full/Agda/Syntax/Internal/Blockers.hs
@@ -43,13 +43,20 @@ data NotBlocked' t
 
 -- | 'ReallyNotBlocked' is the unit.
 --   'MissingClauses' is dominant.
---   @'StuckOn'{}@ should be propagated, if tied, we take the left.
+--   'Underapplied' should be prioritised over 'StuckOn' in order to reliably
+--   determine non-neutral terms ('Underapplied' terms may reduce after further
+--   applications)
+--   If tied, we take the left.
 instance Semigroup (NotBlocked' t) where
   ReallyNotBlocked <> b = b
+  b <> ReallyNotBlocked = b
   -- MissingClauses is dominant (absorptive)
   b@MissingClauses{} <> _ = b
   _ <> b@MissingClauses{} = b
-  -- StuckOn is second strongest
+  -- Underapplied is second strongest
+  Underapplied <> _ = Underapplied
+  _ <> Underapplied = Underapplied
+  -- StuckOn is third strongest
   b@StuckOn{}      <> _ = b
   _ <> b@StuckOn{}      = b
   b <> _                = b

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -549,14 +549,11 @@ rewrite block hd rules es = do
         , "blocking tag" <+> text (show block)
         ]) $ do
       return $ NoReduction $ block $> hd es
-    loop block t (rew:rews) es
-     | let n = rewArity rew, length es >= n = do
-          let (es1, es2) = List.genericSplitAt n es
-          result <- rewriteWith t hd rew es1
-          case result of
-            Left (Blocked m u)    -> loop (block `mappend` Blocked m ()) t rews es
-            Left (NotBlocked _ _) -> loop block t rews es
-            Right w               -> return $ YesReduction YesSimplification $ w `applyE` es2
-     | otherwise = loop (block `mappend` NotBlocked Underapplied ()) t rews es
+    loop block t (rew:rews) es = do
+      let (es1, es2) = List.genericSplitAt (rewArity rew) es
+      result <- rewriteWith t hd rew es1
+      case result of
+        Left  b -> loop (block `mappend` (b $> ())) t rews es
+        Right w -> return $ YesReduction YesSimplification $ w `applyE` es2
 
     rewArity = length . rewPats

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -154,8 +154,11 @@ instance Match a b => Match (Arg a) (Arg b) where
 
 instance Match [Elim' NLPat] Elims where
   match r gamma k (t, hd) [] [] = return ()
+  -- This case should be impossible coming from 'rewrite' because of the
+  -- 'genericSplitAt', but apparently the confluence checker can still reach
+  -- here
   match r gamma k (t, hd) [] _  = matchingBlocked $ NotBlocked ReallyNotBlocked ()
-  match r gamma k (t, hd) _  [] = matchingBlocked $ NotBlocked ReallyNotBlocked ()
+  match r gamma k (t, hd) _  [] = matchingBlocked $ NotBlocked Underapplied ()
   match r gamma k (t, hd) (p:ps) (v:vs) =
    traceSDoc "rewriting.match" 50 (sep
      [ "matching elimination " <+> addContext gamma (addContext k $ prettyTCM p)

--- a/test/Succeed/Issue3594Rewrite.agda
+++ b/test/Succeed/Issue3594Rewrite.agda
@@ -1,0 +1,35 @@
+{-# OPTIONS --rewriting --allow-unsolved-metas #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Nat
+
+-- Adapted example from https://github.com/agda/agda/issues/3594
+-- To avoid throwing an occurs error here, we need to correctly return
+-- 'Underapplied' from the rewrite rule matching and prioritise 'Underapplied'
+-- over 'StuckOn'
+
+record Wrap (A : Set) : Set where
+  constructor wrap
+  field
+    unwrap : A
+
+open Wrap
+
+postulate
+  P : Wrap Nat → Set
+
+f : ∀ (y : Nat) → Wrap Nat
+f 0       = wrap 0
+f (suc _) = wrap 0
+
+postulate
+  f-unwrap : ∀ {y} → f y .unwrap ≡ 0
+{-# REWRITE f-unwrap #-}
+
+postulate
+  q : ∀ y → P (f y)
+  g : ∀ (A : Set) → (∀ (y : Nat) → A) → Nat
+
+-- Can fill with 'P (wrap 0)'
+test = g ? (\ y → q y)


### PR DESCRIPTION
The main motivation for these changes is `--smart-with` (so I am happy for this to be looked at after 2.9.0). `--smart-with` relies on being able to check if a term is neutral. Underapplied definitions cannot be considered neutral because they might reduce after being applied to more arguments.

Unfortunately, the `NotBlocked` reason returned by reduction is sometimes imprecise:

- The `Semigroup` instance for `NotBlocked` prioritises `StuckOn` over `Underapplied`. This was seemingly done intentionally, but, looking through the codebase, I cannot figure out why. All tests pass if we just prioritise `Underapplied` over `StuckOn`. If anyone thinks there was a good reason for this specific `Semigroup` instance, please let me know!
- Rewrite rule matching is very eager to return `Underapplied` (whenever the number of `Elims` is smaller than the LHS of the rewrite rule, even if e.g. we were really `StuckOn` some earlier argument, or there is a mismatch between projections).

This PR fixes both of these problems. As a side effect, we no longer over-eagerly throw an occurs error in the below code (adapted from https://github.com/agda/agda/issues/3594#issuecomment-469406142):
```agda
{-# OPTIONS --rewriting #-}

open import Agda.Builtin.Equality
open import Agda.Builtin.Equality.Rewrite
open import Agda.Builtin.Nat

record Wrap (A : Set) : Set where
  constructor wrap
  field
    unwrap : A

open Wrap

postulate
  P : Wrap Nat → Set

f : ∀ (y : Nat) → Wrap Nat
f 0       = wrap 0
f (suc _) = wrap 0

postulate
  f-unwrap : ∀ {y} → f y .unwrap ≡ 0
{-# REWRITE f-unwrap #-}

postulate
  q : ∀ y → P (f y)
  g : ∀ (A : Set) → (∀ (y : Nat) → A) → Nat

-- Can fill with 'P (wrap 0)'
test = g ? (\ y → q y)

```
So that is hopefully some extra justification that these changes are a good idea.

I suppose no longer skipping rewrite rule matching when the number of `Elims` is too low might have a small performance impact.