### PR TITLE
Fix #8587

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -76,6 +76,7 @@ import Agda.Syntax.Concrete.Generic
 import Agda.Syntax.Abstract.Name
 import Agda.Syntax.Common
 import Agda.Syntax.Common.Pretty hiding (Mode)
+import Agda.Syntax.Common.Pretty qualified as Pretty
 import Agda.Syntax.Parser
 import Agda.Syntax.Position
 import Agda.Syntax.Scope.Base
@@ -738,12 +739,13 @@ importPrimitiveModules = whenM (optLoadPrimitives <$> pragmaOptions) $ do
       (Strict.Just . Trie.insert [] 0 . Strict.fromMaybe Trie.empty)
 
     -- We don't want to generate highlighting information for Agda.Primitive.
-    withHighlightingLevel None $
-      forM_ (map (filePath libdirPrim </>) $ Set.toList primitiveModules) \ f -> do
-        sf <- srcFromPath (mkAbsolute f)
-        primSource <- parseSource sf
-        checkModuleName' (srcModuleName primSource) (srcOrigin primSource)
-        void $ getNonMainInterface (srcModuleName primSource) (Just primSource)
+    withHighlightingLevel None $ do
+      locallyTC eImplPrimitiveImporting (\_ -> True) $ do
+        forM_ (map (filePath libdirPrim </>) $ Set.toList primitiveModules) \ f -> do
+          sf <- srcFromPath (mkAbsolute f)
+          primSource <- parseSource sf
+          checkModuleName' (srcModuleName primSource) (srcOrigin primSource)
+          void $ getNonMainInterface (srcModuleName primSource) (Just primSource)
 
   reportSLn "import.main" 10 $ "Done importing the primitive modules."
 
@@ -880,14 +882,13 @@ getInterface x isMain msrc = locallyTC eImportStack (x :) do
   where
     addOptionsCompatibilityWarnings :: PragmaOptions -> ModuleInfo -> TCM ModuleInfo
     addOptionsCompatibilityWarnings currentOptions
-      mi@ModuleInfo{ miInterface = i, miPrimitive = isPrim, miWarnings = ws } = do
+      mi@ModuleInfo{ miInterface = i, miIsBuiltin = isBuiltin, miWarnings = ws } = do
 
       -- Andreas, 2026-02-03, issue #8361, debug printing by @nad.
       -- For testing whether 'isBuiltinModule' is thread-safe.
       reportSDoc "import.iface.builtin" 25 do
-        isBuiltin <- isJust <$> isBuiltinModule (srcFileId (miSourceFile mi))
         P.hsep [ "The module", prettyTCM (iTopLevelModuleName i), "is"
-               , if isBuiltin then "primitive." else "not primitive."
+               , if maybe False isPrimitiveModule isBuiltin then "primitive." else "not primitive."
                ]
 
       -- Check that imported options are compatible with current ones (issue #2487),
@@ -940,20 +941,37 @@ getOptionsCompatibilityWarnings ::
   -> PragmaOptions
   -> ModuleInfo
   -> TCM (Maybe (Set TCWarning))
-getOptionsCompatibilityWarnings isMain currentOptions = \case
-  ModuleInfo{ miPrimitive = False, miInterface = Interface{ iOptionsUsed, iTopLevelModuleName = m }, miSourceFile } -> do
+getOptionsCompatibilityWarnings isMain currentOptions info =
 
-    -- Add range to name of imported module.
-    m' <- if not $ null $ getRange m then pure m else do
-      path <- srcFilePath miSourceFile
-      pure $ setRange (rangeFromAbsolutePath path) m
+  -- are we importing a primitive module implicitly?
+  viewTC eImplPrimitiveImporting >>= \case
+    True -> pure Nothing
+    False -> case info of
+      ModuleInfo{ miIsBuiltin = isBuiltin
+                , miInterface = Interface{ iOptionsUsed, iTopLevelModuleName = m }
+                , miSourceFile } -> do
 
-    ifM (checkOptionsCompatible currentOptions iOptionsUsed m')
-      {-then-} (return Nothing) -- No warnings to collect because options were compatible.
-      {-else-} (Just <$> getAllWarnings' isMain ErrorWarnings)
+        -- Add range to name of imported module.
+        m' <- if not $ null $ getRange m then pure m else do
+          path <- srcFilePath miSourceFile
+          pure $ setRange (rangeFromAbsolutePath path) m
 
-  -- Options consistency checking is disabled for always-available primitive modules.
-  _ -> return Nothing
+        case isBuiltin of
+          Just IsAgdaPrimitive ->
+            pure Nothing
+          Just IsAgdaPrimitiveCubical ->
+            case _optCubical currentOptions of
+              Nothing -> do
+                warning $ CoInfectiveImport $
+                  Pretty.fsep $
+                  Pretty.pwords "Module imports the cubical primitive module" ++
+                  Pretty.pwords "but does not enable a --cubical[={full,erased,no-glue}] option."
+                Just <$> getAllWarnings' isMain ErrorWarnings
+              Just _  -> pure Nothing
+          _ ->
+            ifM (checkOptionsCompatible currentOptions iOptionsUsed m')
+              {-then-} (pure Nothing) -- No warnings to collect because options were compatible.
+              {-else-} (Just <$> getAllWarnings' isMain ErrorWarnings)
 
 -- | Try to get the interface from interface file or cache.
 
@@ -1032,7 +1050,7 @@ getStoredInterface x file@(SourceFile fi) msrc = do
           path <- srcFilePath file
           lift $ typeError $ OverlappingProjects path topLevelName x
 
-        isPrimitiveMod <- isPrimitiveModule fi
+        isBuiltinMod <- isBuiltinModule fi
 
         lift $ chaseMsg "Loading " x $ Just ifp
         -- print imported warnings
@@ -1041,7 +1059,7 @@ getStoredInterface x file@(SourceFile fi) msrc = do
         loadDecodedModule file $ ModuleInfo
           { miInterface = i
           , miWarnings = empty
-          , miPrimitive = isPrimitiveMod
+          , miIsBuiltin = isBuiltinMod
           , miMode = ModuleTypeChecked
           , miSourceFile = file
           }
@@ -1570,12 +1588,12 @@ createInterface mname sf@(SourceFile sfi) isMain msrc = do
     lensAccumStatistics `modifyTCLens'` (<>) localStatistics
     reportSLn "import.iface" 25 $ prettyShow mname ++ ": Added statistics to the accumulated statistics."
 
-    isPrimitiveMod <- isPrimitiveModule sfi
+    isBuiltinMod <- isBuiltinModule sfi
 
     return ModuleInfo
       { miInterface = finalIface
       , miWarnings = mallWarnings
-      , miPrimitive = isPrimitiveMod
+      , miIsBuiltin = isBuiltinMod
       , miMode = moduleCheckMode isMain
       , miSourceFile = sf
       }

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -160,11 +160,14 @@ agdaBuiltin = ("Agda" </>) . ("Builtin" </>)
 
 -- | The very magical, auto-imported modules.
 
+agdaPrimitive :: FilePath
+agdaPrimitive = "Agda" </> "Primitive.agda"
+
+agdaPrimitiveCubical :: FilePath
+agdaPrimitiveCubical = "Agda" </> "Primitive" </> "Cubical.agda"
+
 primitiveModules :: Set FilePath
-primitiveModules = Set.fromList
-  [ "Agda" </> "Primitive.agda"
-  , "Agda" </> "Primitive" </> "Cubical.agda"
-  ]
+primitiveModules = Set.fromList [agdaPrimitive, agdaPrimitiveCubical]
 
 -- | These builtins may use postulates, and are still considered @--safe@.
 
@@ -231,8 +234,9 @@ classifyBuiltinModule_ primLibDir fp = do
   f <- relativizeAbsolutePath fp primLibDir
   guard $ f `Set.member` builtinModules
   if f `Set.member` builtinModulesWithUnsafePostulates then return IsBuiltinModule
-  else if f `Set.member` primitiveModules then return IsPrimitiveModule
-  else return IsBuiltinModuleWithSafePostulates
+  else if f == agdaPrimitive then pure IsAgdaPrimitive
+  else if f == agdaPrimitiveCubical then pure IsAgdaPrimitiveCubical
+  else pure IsBuiltinModuleWithSafePostulates
 
 ------------------------------------------------------------------------
 -- * Get the libraries for the current project

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1486,7 +1486,7 @@ data ModuleInfo = ModuleInfo
     --   These might include warnings not stored in the interface itself,
     --   specifically unsolved interaction metas.
     --   See "Agda.Interaction.Imports"
-  , miPrimitive  :: Bool
+  , miIsBuiltin  :: !(Maybe IsBuiltinModule)
     -- ^ 'True' if the module is a primitive module, which should always
     -- be importable.
   , miMode       :: ModuleCheckMode
@@ -4489,6 +4489,11 @@ envWorkingOnTypes = mkFlag 16
 envPureConversion :: Lens' Flags64 Bool
 envPureConversion = mkFlag 17
 
+-- | Are we doing implicit importing of primitive modules?
+{-# INLINE envImplPrimitiveImporting #-}
+envImplPrimitiveImporting :: Lens' Flags64 Bool
+envImplPrimitiveImporting = mkFlag 18
+
 -- | Choose between behavior in pure conversion and impure conversion.
 --   The first branch is the impure case.
 ifImpureConv :: TCM a -> TCM a -> TCM a
@@ -4519,6 +4524,7 @@ initEnvFlags = Flags64 0
   & envFoldLetBindings       .~ True
   & envMakeCase              .~ False
   & envPureConversion        .~ False
+  & envImplPrimitiveImporting    .~ False
 
 initTCContext :: TCContext
 initTCContext = TCContext {
@@ -4875,6 +4881,10 @@ eWorkingOnTypes = mkEnvFlag 16
 {-# INLINE ePureConversion #-}
 ePureConversion :: Lens' TCEnv Bool
 ePureConversion = mkEnvFlag 17
+
+{-# INLINE eImplPrimitiveImporting #-}
+eImplPrimitiveImporting :: Lens' TCEnv Bool
+eImplPrimitiveImporting = mkEnvFlag 18
 
 
 ----------------------------------------------------------------------------------------------------

--- a/src/full/Agda/TypeChecking/Monad/Base/Types.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base/Types.hs
@@ -160,17 +160,24 @@ data HighlightingMethod
 ---------------------------------------------------------------------------
 
 -- | Discern Agda's primitive modules from other file modules.
---   @IsPrimitiveModule `implies` IsBuiltinModuleWithSafePostulate `implies` isBuiltinModule.
-
+--   @isPrimitiveModule `implies` IsBuiltinModuleWithSafePostulate `implies` isBuiltinModule@.
 --   Keep constructors in this order!
 data IsBuiltinModule
-  = IsPrimitiveModule
-      -- ^ Very magical module, e.g. @Agda.Primitive@.
+  = IsAgdaPrimitive
+      -- ^ @Agda.Primitive@.
+  | IsAgdaPrimitiveCubical
+      -- ^ @Agda.Primitive.Cubical@.
   | IsBuiltinModuleWithSafePostulates
       -- ^ Safe module, e.g. @Agda.Builtin.Equality@.
   | IsBuiltinModule
       -- ^ Any builtin module.
   deriving (Eq, Ord, Show, Generic)
+
+isPrimitiveModule :: IsBuiltinModule -> Bool
+isPrimitiveModule = \case
+  IsAgdaPrimitive        -> True
+  IsAgdaPrimitiveCubical -> True
+  _                      -> False
 
 -- | Collection of 'FileId's of primitive modules.
 

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -422,19 +422,8 @@ isBuiltinModuleWithSafePostulates fi = do
     Nothing                                -> False
     Just IsBuiltinModule                   -> False
     Just IsBuiltinModuleWithSafePostulates -> True
-    Just IsPrimitiveModule                 -> True
-
--- | Does the given 'FileId' belong to one of Agda's magical primitive modules?
---
--- Implies 'isBuiltinModuleWithSafePostulates'.
-
-isPrimitiveModule :: ReadTCState m => FileId -> m Bool
-isPrimitiveModule  fi = do
-  isBuiltinModule fi <&> \case
-    Nothing                                -> False
-    Just IsBuiltinModule                   -> False
-    Just IsBuiltinModuleWithSafePostulates -> False
-    Just IsPrimitiveModule                 -> True
+    Just IsAgdaPrimitive                   -> True
+    Just IsAgdaPrimitiveCubical            -> True
 
 ---------------------------------------------------------------------------
 -- * Top level module

--- a/test/Fail/CubicalPrimitiveNotFullyApplied.agda
+++ b/test/Fail/CubicalPrimitiveNotFullyApplied.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --cubical #-}
+
 module CubicalPrimitiveNotFullyApplied where
 
 open import Agda.Primitive.Cubical

--- a/test/Fail/CubicalPrimitiveNotFullyApplied.err
+++ b/test/Fail/CubicalPrimitiveNotFullyApplied.err
@@ -1,3 +1,3 @@
-CubicalPrimitiveNotFullyApplied.agda:6.8-15: error: [CubicalPrimitiveNotFullyApplied]
+CubicalPrimitiveNotFullyApplied.agda:8.8-15: error: [CubicalPrimitiveNotFullyApplied]
 primPOr must be fully applied
 when checking that the expression primPOr has type Set

--- a/test/Fail/FaceConstraintDisjunction.agda
+++ b/test/Fail/FaceConstraintDisjunction.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --cubical #-}
+
 open import Agda.Primitive.Cubical renaming (primIMax to _∨_)
 
 data S : Set where

--- a/test/Fail/FaceConstraintDisjunction.err
+++ b/test/Fail/FaceConstraintDisjunction.err
@@ -1,3 +1,3 @@
-FaceConstraintDisjunction.agda:7.10-20: error: [FaceConstraintDisjunction]
+FaceConstraintDisjunction.agda:9.10-20: error: [FaceConstraintDisjunction]
 Cannot have disjunctions in a face constraint
 when checking that the pattern (i ∨ j = i1) has type IsOne (i ∨ j)

--- a/test/Fail/FaceConstraintUnsatisfiable.agda
+++ b/test/Fail/FaceConstraintUnsatisfiable.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --cubical #-}
+
 open import Agda.Primitive.Cubical
 
 data S : Set where

--- a/test/Fail/FaceConstraintUnsatisfiable.err
+++ b/test/Fail/FaceConstraintUnsatisfiable.err
@@ -1,3 +1,3 @@
-FaceConstraintUnsatisfiable.agda:7.6-13: error: [FaceConstraintUnsatisfiable]
+FaceConstraintUnsatisfiable.agda:9.6-13: error: [FaceConstraintUnsatisfiable]
 The face constraint is unsatisfiable
 when checking that the pattern (i0 = i1) has type IsOne i0

--- a/test/Fail/IUnivData.agda
+++ b/test/Fail/IUnivData.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --cubical #-}
+
 open import Agda.Primitive.Cubical
 
 data BadData : IUniv where

--- a/test/Fail/IUnivData.err
+++ b/test/Fail/IUnivData.err
@@ -1,4 +1,4 @@
-IUnivData.agda:3.6-13: error: [SortDoesNotAdmitDataDefinitions]
+IUnivData.agda:5.6-13: error: [SortDoesNotAdmitDataDefinitions]
 The universe IUniv of BadData
 does not admit data or record declarations
 when checking the definition of BadData

--- a/test/Fail/IUnivNoHComp.agda
+++ b/test/Fail/IUnivNoHComp.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --cubical #-}
+
 open import Agda.Primitive.Cubical
 
 test : (J : IUniv) → J → J

--- a/test/Fail/IUnivNoHComp.err
+++ b/test/Fail/IUnivNoHComp.err
@@ -1,4 +1,4 @@
-IUnivNoHComp.agda:4.12-21: error: [UnequalTypes]
+IUnivNoHComp.agda:6.12-21: error: [UnequalTypes]
 The types
   IUniv
 and

--- a/test/Fail/IUnivNotFibrant.agda
+++ b/test/Fail/IUnivNotFibrant.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --cubical #-}
+
 open import Agda.Primitive
 open import Agda.Primitive.Cubical
 

--- a/test/Fail/IUnivNotFibrant.err
+++ b/test/Fail/IUnivNotFibrant.err
@@ -1,4 +1,4 @@
-IUnivNotFibrant.agda:4.8-12: error: [ConstructorDoesNotFitInData]
+IUnivNotFibrant.agda:6.8-12: error: [ConstructorDoesNotFitInData]
 Constructor Wrap.constructor
 of inferred sort SSet₁
 does not fit into record type of sort Set₁.

--- a/test/Fail/IUnivRecord.agda
+++ b/test/Fail/IUnivRecord.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --cubical #-}
+
 open import Agda.Primitive.Cubical
 
 record Bad : IUniv where

--- a/test/Fail/IUnivRecord.err
+++ b/test/Fail/IUnivRecord.err
@@ -1,4 +1,4 @@
-IUnivRecord.agda:3.8-11: error: [SortDoesNotAdmitDataDefinitions]
+IUnivRecord.agda:5.8-11: error: [SortDoesNotAdmitDataDefinitions]
 The universe IUniv of Bad
 does not admit data or record declarations
 when checking the definition of Bad

--- a/test/Fail/Issue2446.agda
+++ b/test/Fail/Issue2446.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --cubical #-}
+
 module _ where
 
 import Agda.Primitive.Cubical as C

--- a/test/Fail/Issue2446.err
+++ b/test/Fail/Issue2446.err
@@ -1,3 +1,3 @@
-Issue2446.agda:7.1-13: error: [TriedToCopyConstrainedPrim]
+Issue2446.agda:9.1-13: error: [TriedToCopyConstrainedPrim]
 Cannot create a module containing a copy of C.primPOr
 when checking the module application module M = C

--- a/test/Fail/Issue4768.agda
+++ b/test/Fail/Issue4768.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --cubical #-}
+
 -- Andreas, 2020-06-21, issue #4768
 -- Problem was: @0 appearing in "Not a finite domain" message.
 

--- a/test/Fail/Issue4768.err
+++ b/test/Fail/Issue4768.err
@@ -1,4 +1,4 @@
-Issue4768.agda:8.6-13: error: [SplitOnPartial]
+Issue4768.agda:10.6-13: error: [SplitOnPartial]
 Splitting on partial elements is only allowed at the type Partial, but the domain here is
   IsOne i
 when checking that the pattern (i0 = i1) has type IsOne i

--- a/test/Fail/Issue5891DataInIUniv.agda
+++ b/test/Fail/Issue5891DataInIUniv.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --cubical #-}
+
 -- Andreas, Ulf, 2022-05-06, AIM XXXV
 -- Make sure you cannot trick Agda into admitting data types in IUniv.
 -- The previous check let this exploit through.

--- a/test/Fail/Issue5891DataInIUniv.err
+++ b/test/Fail/Issue5891DataInIUniv.err
@@ -1,4 +1,4 @@
-Issue5891DataInIUniv.agda:10.8-13: error: [SortDoesNotAdmitDataDefinitions]
+Issue5891DataInIUniv.agda:12.8-13: error: [SortDoesNotAdmitDataDefinitions]
 The universe IUniv of False
 does not admit data or record declarations
 when checking the definition of False

--- a/test/Fail/Issue8587.agda
+++ b/test/Fail/Issue8587.agda
@@ -1,0 +1,14 @@
+{-# OPTIONS --safe #-}
+
+module Issue8587 where
+
+open import Agda.Primitive.Cubical public
+open import Agda.Builtin.Unit
+
+bad-path : ∀ {ℓ A} (x y : A) → PathP {ℓ} _ x y
+bad-path x y i = y
+
+data ⊥ : Set where
+
+⊥-intro : ⊥
+⊥-intro = primTransp (λ i → bad-path ⊤ ⊥ i) i0 tt

--- a/test/Fail/Issue8587.err
+++ b/test/Fail/Issue8587.err
@@ -1,5 +1,5 @@
-Issue2788c.agda:3.1-50: error: [CoInfectiveImport]
+Issue8587.agda:5.1-42: error: [CoInfectiveImport]
 Module imports the cubical primitive module but does not enable a
 --cubical[={full,erased,no-glue}] option.
 when scope checking the declaration
-  open import Agda.Primitive.Cubical hiding (PathP)
+  open import Agda.Primitive.Cubical public

--- a/test/Fail/ReifyPartialP.agda
+++ b/test/Fail/ReifyPartialP.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --cubical #-}
+
 module ReifyPartialP where
 
 open import Agda.Primitive

--- a/test/Fail/ReifyPartialP.err
+++ b/test/Fail/ReifyPartialP.err
@@ -1,4 +1,4 @@
-ReifyPartialP.agda:12.13-14: error: [UnequalTypes]
+ReifyPartialP.agda:14.13-14: error: [UnequalTypes]
 The type
   PartialP φ (λ .p → (λ { (φ = i1) → B (a _) }) p)
 is not a subtype of

--- a/test/Succeed/FunSortOmega.agda
+++ b/test/Succeed/FunSortOmega.agda
@@ -4,6 +4,7 @@
 
 {-# OPTIONS --two-level #-}
 {-# OPTIONS --prop #-}
+{-# OPTIONS --cubical #-}
 
 module _ where
 

--- a/test/Succeed/FunSortOmegaNoProp.agda
+++ b/test/Succeed/FunSortOmegaNoProp.agda
@@ -3,6 +3,7 @@
 -- In absence of Prop, determine even domain from smaller codomain.
 
 {-# OPTIONS --two-level #-}
+{-# OPTIONS --cubical #-}
 
 module _ where
 

--- a/test/Succeed/FunSortPropIUniv.agda
+++ b/test/Succeed/FunSortPropIUniv.agda
@@ -3,6 +3,7 @@
 
 {-# OPTIONS --two-level #-}
 {-# OPTIONS --prop #-}
+{-# OPTIONS --cubical #-}
 
 open Agda.Primitive
 open import Agda.Primitive.Cubical

--- a/test/Succeed/Issue2845.agda
+++ b/test/Succeed/Issue2845.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --cubical #-}
+
 module Issue2845 where
 
 open import Agda.Builtin.Nat

--- a/test/Succeed/Issue4769.agda
+++ b/test/Succeed/Issue4769.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --cubical #-}
+
 -- Andreas, 2020-06-21, issue #4769
 -- Name and hiding ignored in subsequent face constraint patterns.
 -- Instead, we should throw a warning.

--- a/test/Succeed/Issue4769.warn
+++ b/test/Succeed/Issue4769.warn
@@ -1,11 +1,12 @@
-Issue4769.agda:11.20-42: warning: -W[no]FaceConstraintCannotBeNamed
+
+Issue4769.agda:13.20-42: warning: -W[no]FaceConstraintCannotBeNamed
 Ignoring name 'agdaDoesNotSeeThisName' given to face constraint
 pattern
 when scope checking the left-hand side
 foo i j ((i = i0)) ⦃ agdaDoesNotSeeThisName = ((j = i1)) ⦄ in the
 definition of foo
 
-Issue4769.agda:11.46-52: warning: -W[no]FaceConstraintCannotBeHidden
+Issue4769.agda:13.46-52: warning: -W[no]FaceConstraintCannotBeHidden
 Face constraint patterns cannot be instance arguments
 when scope checking the left-hand side
 foo i j ((i = i0)) ⦃ agdaDoesNotSeeThisName = ((j = i1)) ⦄ in the
@@ -13,14 +14,14 @@ definition of foo
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue4769.agda:11.20-42: warning: -W[no]FaceConstraintCannotBeNamed
+Issue4769.agda:13.20-42: warning: -W[no]FaceConstraintCannotBeNamed
 Ignoring name 'agdaDoesNotSeeThisName' given to face constraint
 pattern
 when scope checking the left-hand side
 foo i j ((i = i0)) ⦃ agdaDoesNotSeeThisName = ((j = i1)) ⦄ in the
 definition of foo
 
-Issue4769.agda:11.46-52: warning: -W[no]FaceConstraintCannotBeHidden
+Issue4769.agda:13.46-52: warning: -W[no]FaceConstraintCannotBeHidden
 Face constraint patterns cannot be instance arguments
 when scope checking the left-hand side
 foo i j ((i = i0)) ⦃ agdaDoesNotSeeThisName = ((j = i1)) ⦄ in the

--- a/test/Succeed/QuoteSet.agda
+++ b/test/Succeed/QuoteSet.agda
@@ -1,4 +1,5 @@
 {-# OPTIONS --sized-types #-}
+{-# OPTIONS --cubical #-}
 
 -- Andreas, 2024-09-27, issue #7514
 


### PR DESCRIPTION
Users could previously import `Agda.Cubical.Primitive` from a module without a cubical flag
because (co)infectivity checking was turned off for primitive modules. The reason for not having
those checks was that primitive modules are implicitly imported (but not loaded into user
scope!). However, cubical primops without a cubical option are inconsistent.

Change:
  - Implicit primitive imports are distinguished from normal imports, using an extra TCEnv flag.
  - (co)infectivity checks are turned off for implicit primitive imports.
  - Checks are still turned off for a normal user import of `Agda.Primitive`.
  - For a user import of `Agda.Primitive.Cubical`, there's an extra hardwired check for a cubical
    option (full or erased or no-glue) in the importer module.