### PR TITLE
Place -WShouldBeEtaRecordPattern under --exact-split.

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -855,6 +855,12 @@ Pattern matching and equality
      definitional equalities unless marked ``CATCHALL`` (see
      :ref:`case-trees`).
 
+     Turns on the following warnings:
+
+     * :option:`CoverageNoExactSplit`
+     * :option:`InlineNoExactSplit`
+     * :option:`ShouldBeEtaRecordPattern`
+
      Default: ``--no-exact-split``.
 
 .. option:: --hidden-argument-puns, --no-hidden-argument-puns
@@ -1997,6 +2003,8 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
      .. versionadded:: 2.9.0
 
      Irrefutable record pattern without eta.
+
+     Off by default, enabled with :option:`--exact-split`.
 
 .. option:: TooManyArgumentsToSort
 

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -234,6 +234,7 @@ exactSplitWarnings :: Set WarningName
 exactSplitWarnings = Set.fromList
   [ CoverageNoExactSplit_
   , InlineNoExactSplit_
+  , ShouldBeEtaRecordPattern_
   ]
 
 -- | Both of these warnings are disabled by @-WnoUnusedImports@.

--- a/test/Fail/LetPatternEta.agda
+++ b/test/Fail/LetPatternEta.agda
@@ -1,6 +1,8 @@
 -- Andreas, 2023-10-07, issue #6825, test case by Amy
 -- Andreas, 2026-04-14, updated to warning
 
+{-# OPTIONS --exact-split #-}
+
 module LetPatternEta where
 
 open import Agda.Builtin.Equality

--- a/test/Fail/LetPatternEta.err
+++ b/test/Fail/LetPatternEta.err
@@ -1,9 +1,9 @@
-LetPatternEta.agda:13.14-20: warning: -W[no]ShouldBeEtaRecordPattern
+LetPatternEta.agda:15.14-20: warning: -W[no]ShouldBeEtaRecordPattern
 Irrefutable matching on non-eta record constructor
 when checking that the expression
 λ w @ (wrap a) → refl {x = wrap a} has type (w : Wrap A) → w ≡ w
 
-LetPatternEta.agda:13.24-41: error: [UnequalTerms]
+LetPatternEta.agda:15.24-41: error: [UnequalTerms]
 The terms
   wrap a
 and

--- a/test/Fail/TelescopePatternEta.agda
+++ b/test/Fail/TelescopePatternEta.agda
@@ -1,5 +1,7 @@
 -- Andreas, 2023-10-07, issue #6825, test case by Amy
 
+{-# OPTIONS --exact-split #-}
+
 module TelescopePatternEta where
 
 open import Agda.Builtin.Equality

--- a/test/Fail/TelescopePatternEta.err
+++ b/test/Fail/TelescopePatternEta.err
@@ -1,8 +1,8 @@
-TelescopePatternEta.agda:11.18-24: warning: -W[no]ShouldBeEtaRecordPattern
+TelescopePatternEta.agda:13.18-24: warning: -W[no]ShouldBeEtaRecordPattern
 Irrefutable matching on non-eta record constructor
 when checking the parameters of module _
 
-TelescopePatternEta.agda:14.7-11: error: [UnequalTerms]
+TelescopePatternEta.agda:16.7-11: error: [UnequalTerms]
 The terms
   w
 and


### PR DESCRIPTION
Closes #6825.
Closes #8592.

Rendered docs: https://agda--8617.org.readthedocs.build/en/8617/tools/command-line-options.html#pattern-matching-and-equality