### PR TITLE
[wasm] Bump ghc-wasm in nix flake containing nixpkgs-26.05-darwin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1764532453,
-        "narHash": "sha256-83PtOfCHZhby/isbpHiEG61BkoPK42zCi0lr3JTRStw=",
+        "lastModified": 1783919537,
+        "narHash": "sha256-YBXYe6BXFmwhQ4cJXwsknv3SCsNWUs8iGE2bUaaS9J8=",
         "ref": "refs/heads/master",
-        "rev": "01679cb5e8c6ed1c80218ce09f2d10766c1a5b1d",
-        "revCount": 450,
+        "rev": "1da639656e710abae174e7f736507461d1b5bca5",
+        "revCount": 566,
         "type": "git",
         "url": "https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta.git"
       },
@@ -57,16 +57,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759326671,
-        "narHash": "sha256-h9jyjb62WDgKs0MBUDFhSlV3F4n+64ygJeo3ijhEF80=",
+        "lastModified": 1783549019,
+        "narHash": "sha256-0XnckG4ZhBmAsYa9mLuEIFowBG0fDGPLHduQGsbMS4A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "840e8405978644a20844b54e70a09b518f5c7709",
+        "rev": "74cc63f702f7d60a557e152a57b40fb1fd0f72ac",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixpkgs-26.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }


### PR DESCRIPTION
It has been a while since the setup of GitHub Actions compiling Agda to WebAssembly. I think it is a good time to bump the lock file so that we can test with up-to-date ghc-wasm. Notably, its nixpkg [had been bumped to nixpkgs-26.05-darwin](https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta/-/commit/9f85abc81117a1f10199b430409a4c3365ac2a0a).