### PR TITLE
Fixes #8626: treat lazy split pattern as dot pattern when there is nothing left to split in `compile`

### DIFF
--- a/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
@@ -177,6 +177,9 @@ compile (c:cs) = case nextSplit c cs of
     xs = map' (fmap name) ps
     name (VarP _ x) = x
     name (DotP _ _) = underscore
+    name (ConP _ cpi _) | conPLazy cpi = underscore
+    -- Issue #8626: forcing analysis can create lazy split, which appears
+    -- as lazy `ConP` patterns instead of `DotP` patterns.
     name ConP{}  = __IMPOSSIBLE__
     name DefP{}  = __IMPOSSIBLE__
     name LitP{}  = __IMPOSSIBLE__

--- a/test/Succeed/Issue8626.agda
+++ b/test/Succeed/Issue8626.agda
@@ -1,0 +1,92 @@
+{-# OPTIONS --without-K --safe #-}
+
+module _ where
+
+record Unit : Set where constructor tt
+
+data Relevance : Set where
+  ! % : Relevance
+
+data Term : Set where
+  zero : Term
+  suc  : Term → Term
+
+data Prp : Term → Set where
+  ps : (n : Term) → Prp (suc n)
+  pz : Prp zero
+
+data Jdg : Set where
+  N : (n : Term) (prop : Prp n) → Jdg
+
+natrec-congTerm : {rF : Relevance} → Jdg → Jdg → Unit
+natrec-congTerm {rF = !} v            w        = tt
+natrec-congTerm          (N i (ps m)) (N j pz) = tt
+natrec-congTerm          q            (N h pz) = tt
+natrec-congTerm          (N k (ps m)) l        = tt
+natrec-congTerm          b            c        = tt
+
+-- Checking Issue8626
+-- An internal error has occurred. Please report this as a bug.
+-- Location of the error: __IMPOSSIBLE__, called at src/full/Agda/TypeChecking/CompiledClause/Compile.hs:180:20 in Agda-2.9.0-4LTCrYcgM18IOO7aOFG0rT:Agda.TypeChecking.CompiledClause.Compile%
+--
+-- Split tree:
+--    split at {0}
+--    |
+--    +- M.Relevance.! -> done, 2 bindings
+--    |
+--    `- M.Relevance.% -> split at 0
+--       |
+--       `- M.Jdg.N -> split at 1
+--          |
+--          +- M.Prp.ps -> lazy split at 0
+--          |  |
+--          |  `- M.Term.suc -> split at 2
+--          |     |
+--          |     `- M.Jdg.N -> split at 3
+--          |        |
+--          |        +- M.Prp.ps -> lazy split at 2
+--          |        |  |
+--          |        |  `- M.Term.suc -> done, 2 bindings
+--          |        |
+--          |        `- M.Prp.pz -> done, 1 bindings
+--          |
+--          `- M.Prp.pz -> split at 1
+--             |
+--             `- M.Jdg.N -> split at 2
+--                |
+--                +- M.Prp.ps -> lazy split at 1
+--                |  |
+--                |  `- M.Term.suc -> done, 1 bindings
+--                |
+--                `- M.Prp.pz -> done, 0 bindings
+--
+--    covering patterns for M.natrec-congTerm
+--      [{rF = !}, v, w]
+--      [{rF = %}, N (suc m) (ps m), N (suc l) (ps n)]
+--      [{rF = %}, N (suc m) (ps m), N j pz]
+--      [{rF = %}, N n pz, N (suc c) (ps n)]
+--      [{rF = %}, N n pz, N h pz]
+--
+-- Compiled case trees:
+--    compiled clauses of  natrec-congTerm  (still containing record splits)
+--      case {0} of
+--        M.Relevance.! -> done 0?Rec: [v, w] M.tt
+--        _ -> case 1 of
+--               M.Jdg.N ->
+--                 case 2 of
+--                   M.Prp.ps ->
+--                     case 3 of
+--                       M.Jdg.N -> case 4 of M.Prp.pz -> done 1?Rec: [{_}, _, _, _] M.tt
+--
+--                                  Note: after this `case 4 of M.Prop.pz` split, the clauses are
+--                                      M.Prp.pz ->
+--                                        [1: [{_}, ~M.Term.suc m, .@2, .M.Term.zero] -> M.tt,
+--                                         2: [{_}, _, _, .M.Term.zero] -> M.tt]
+--
+--
+--                       _ -> case 1 of ~ M.Term.suc -> done 3?Rec: [{_}, m, _, l] M.tt
+--                   _ -> case 3 of
+--                          M.Jdg.N -> case 4 of M.Prp.pz -> done 2?Rec: [{_}, _, _, _] M.tt
+--               _ -> case 2 of
+--                      M.Jdg.N -> case 3 of M.Prp.pz -> done 2?Rec: [{_}, q, _] M.tt
+--                      _ -> done 4?Rec: [{_}, b, c] M.tt

--- a/test/Succeed/Issue8626.agda
+++ b/test/Succeed/Issue8626.agda
@@ -1,6 +1,7 @@
 {-# OPTIONS --without-K --safe #-}
+-- {-# OPTIONS -v tc.cover:10 #-}
 
-module _ where
+module Issue8626 where
 
 record Unit : Set where constructor tt
 
@@ -25,42 +26,42 @@ natrec-congTerm          q            (N h pz) = tt
 natrec-congTerm          (N k (ps m)) l        = tt
 natrec-congTerm          b            c        = tt
 
--- Checking Issue8626
+-- Error was:
 -- An internal error has occurred. Please report this as a bug.
--- Location of the error: __IMPOSSIBLE__, called at src/full/Agda/TypeChecking/CompiledClause/Compile.hs:180:20 in Agda-2.9.0-4LTCrYcgM18IOO7aOFG0rT:Agda.TypeChecking.CompiledClause.Compile%
+-- Location of the error: __IMPOSSIBLE__, called at src/full/Agda/TypeChecking/CompiledClause/Compile.hs:180:20
 --
 -- Split tree:
 --    split at {0}
 --    |
---    +- M.Relevance.! -> done, 2 bindings
+--    +- Relevance.! -> done, 2 bindings
 --    |
---    `- M.Relevance.% -> split at 0
+--    `- Relevance.% -> split at 0
 --       |
---       `- M.Jdg.N -> split at 1
+--       `- Jdg.N -> split at 1
 --          |
---          +- M.Prp.ps -> lazy split at 0
+--          +- Prp.ps -> lazy split at 0
 --          |  |
---          |  `- M.Term.suc -> split at 2
+--          |  `- Term.suc -> split at 2
 --          |     |
---          |     `- M.Jdg.N -> split at 3
+--          |     `- Jdg.N -> split at 3
 --          |        |
---          |        +- M.Prp.ps -> lazy split at 2
+--          |        +- Prp.ps -> lazy split at 2
 --          |        |  |
---          |        |  `- M.Term.suc -> done, 2 bindings
+--          |        |  `- Term.suc -> done, 2 bindings
 --          |        |
---          |        `- M.Prp.pz -> done, 1 bindings
+--          |        `- Prp.pz -> done, 1 bindings
 --          |
---          `- M.Prp.pz -> split at 1
+--          `- Prp.pz -> split at 1
 --             |
---             `- M.Jdg.N -> split at 2
+--             `- Jdg.N -> split at 2
 --                |
---                +- M.Prp.ps -> lazy split at 1
+--                +- Prp.ps -> lazy split at 1
 --                |  |
---                |  `- M.Term.suc -> done, 1 bindings
+--                |  `- Term.suc -> done, 1 bindings
 --                |
---                `- M.Prp.pz -> done, 0 bindings
+--                `- Prp.pz -> done, 0 bindings
 --
---    covering patterns for M.natrec-congTerm
+--    covering patterns for natrec-congTerm
 --      [{rF = !}, v, w]
 --      [{rF = %}, N (suc m) (ps m), N (suc l) (ps n)]
 --      [{rF = %}, N (suc m) (ps m), N j pz]
@@ -70,23 +71,23 @@ natrec-congTerm          b            c        = tt
 -- Compiled case trees:
 --    compiled clauses of  natrec-congTerm  (still containing record splits)
 --      case {0} of
---        M.Relevance.! -> done 0?Rec: [v, w] M.tt
+--        Relevance.! -> done 0?Rec: [v, w] tt
 --        _ -> case 1 of
---               M.Jdg.N ->
+--               Jdg.N ->
 --                 case 2 of
---                   M.Prp.ps ->
+--                   Prp.ps ->
 --                     case 3 of
---                       M.Jdg.N -> case 4 of M.Prp.pz -> done 1?Rec: [{_}, _, _, _] M.tt
+--                       Jdg.N -> case 4 of Prp.pz -> done 1?Rec: [{_}, _, _, _] tt
 --
---                                  Note: after this `case 4 of M.Prop.pz` split, the clauses are
---                                      M.Prp.pz ->
---                                        [1: [{_}, ~M.Term.suc m, .@2, .M.Term.zero] -> M.tt,
---                                         2: [{_}, _, _, .M.Term.zero] -> M.tt]
+--                                  Note: after this `case 4 of Prop.pz` split, the clauses are
+--                                      Prp.pz ->
+--                                        [1: [{_}, ~Term.suc m, .@2, .Term.zero] -> tt,
+--                                         2: [{_}, _, _, .Term.zero] -> tt]
 --
 --
---                       _ -> case 1 of ~ M.Term.suc -> done 3?Rec: [{_}, m, _, l] M.tt
+--                       _ -> case 1 of ~ Term.suc -> done 3?Rec: [{_}, m, _, l] tt
 --                   _ -> case 3 of
---                          M.Jdg.N -> case 4 of M.Prp.pz -> done 2?Rec: [{_}, _, _, _] M.tt
+--                          Jdg.N -> case 4 of Prp.pz -> done 2?Rec: [{_}, _, _, _] tt
 --               _ -> case 2 of
---                      M.Jdg.N -> case 3 of M.Prp.pz -> done 2?Rec: [{_}, q, _] M.tt
---                      _ -> done 4?Rec: [{_}, b, c] M.tt
+--                      Jdg.N -> case 3 of Prp.pz -> done 2?Rec: [{_}, q, _] tt
+--                      _ -> done 4?Rec: [{_}, b, c] tt


### PR DESCRIPTION
Fixes #8626 where `__IMPOSSIBLE__` at `Agda/TypeChecking/CompiledClause/Compile.hs:180:20` is evaluated.

I added the additional line in `compile` by comparing the execution traces of `compileWithSplitTree` and `compile` in the presence of the flags `--force` and `--no-force`. In both cases, Agda reaches L169 with almost identical inputs:

https://github.com/agda/agda/blob/6a5169a469d506ee848ad99ef574c3df8e329a02/src/full/Agda/TypeChecking/CompiledClause/Compile.hs#L165-L181

In `--no-force` (in which case there is no error), the input to `compile` at the end was

```agda
compile $         -- from splitOn False 4 (c:cs)
    M.Prp.pz ->
      [1: [{_}, .(M.Term.suc @1), m, .M.Term.zero] -> M.tt,
       2: [{_}, _, _, .M.Term.zero] -> M.tt]
```

However, for `--force`, the input became a lazy split:

```agda
compile $         -- from splitOn False 4 (c:cs)
    M.Prp.pz ->
      [1: [{_}, ~M.Term.suc m, .@2, .M.Term.zero] -> M.tt,
       2: [{_}, _, _, .M.Term.zero] -> M.tt]
```

The `~M.Term.suc m` pattern triggerred `__IMPOSSIBLE__` at L180.