### PR TITLE
fix(compiler): avoid nested case code explosion

### DIFF
--- a/src/full/Agda/Compiler/Treeless/Simplify.hs
+++ b/src/full/Agda/Compiler/Treeless/Simplify.hs
@@ -125,23 +125,6 @@ simplify FunctionKit{ divAux, modAux, natMinus, true, false } = simpl
         case u of                          -- TODO: also for literals
           _ | Just (c, as)     <- conView u   -> simpl $ matchCon lets c as d bs
             | Just (k, TVar y) <- plusKView u -> simpl . mkLets lets . TCase y t d =<< mapM (matchPlusK y x k) bs
-          TCase y t1 d1 bs1 -> simpl $ mkLets lets $ TCase y t1 (distrDef case1 d1) $
-                                       map (distrCase case1) bs1
-            where
-              -- Γ x Δ -> Γ _ Δ Θ y, where x maps to y and Θ are the lets
-              n     = length lets
-              rho   = liftS (x + n + 1) (raiseS 1)    `composeS`
-                      singletonS (x + n + 1) (TVar 0) `composeS`
-                      raiseS (n + 1)
-              case1 = applySubst rho (TCase x t d bs)
-
-              distrDef v d | isUnreachable d = tUnreachable
-                           | otherwise       = tLet d v
-
-              distrCase v (TACon c a b) = TACon c a $ TLet b $ raiseFrom 1 a v
-              distrCase v (TALit l b)   = TALit l   $ TLet b v
-              distrCase v (TAGuard g b) = TAGuard g $ TLet b v
-
           _ -> do
             d <- simpl d
             tCase x t d bs

--- a/test/Compiler/simple/CaseOnCase.out
+++ b/test/Compiler/simple/CaseOnCase.out
@@ -16,18 +16,32 @@ out >       _ | c >= 1 → CaseOnCase.Cmp.greater
 out >       _ → CaseOnCase.Cmp.less
 out > CaseOnCase._<_ =
 out >   λ a b →
-out >     let c = CaseOnCase._-_ a b in
+out >     let c =
+out >           let d = CaseOnCase._-_ a b in
+out >           case d of
+out >             0 → CaseOnCase.Cmp.equal
+out >             _ | d >= 1 → CaseOnCase.Cmp.greater
+out >             _ → CaseOnCase.Cmp.less in
 out >     case c of
-out >       0 → Agda.Builtin.Bool.Bool.false
-out >       _ | c >= 1 → Agda.Builtin.Bool.Bool.false
-out >       _ → Agda.Builtin.Bool.Bool.true
+out >       CaseOnCase.Cmp.less → Agda.Builtin.Bool.Bool.true
+out >       CaseOnCase.Cmp.equal → Agda.Builtin.Bool.Bool.false
+out >       CaseOnCase.Cmp.greater → Agda.Builtin.Bool.Bool.false
 out > CaseOnCase.cmp =
 out >   λ a b →
-out >     let c = CaseOnCase._-_ a b in
+out >     let c =
+out >           let d =
+out >                 let e = CaseOnCase._-_ a b in
+out >                 case e of
+out >                   0 → CaseOnCase.Cmp.equal
+out >                   _ | e >= 1 → CaseOnCase.Cmp.greater
+out >                   _ → CaseOnCase.Cmp.less in
+out >           case d of
+out >             CaseOnCase.Cmp.less → Agda.Builtin.Bool.Bool.true
+out >             CaseOnCase.Cmp.equal → Agda.Builtin.Bool.Bool.false
+out >             CaseOnCase.Cmp.greater → Agda.Builtin.Bool.Bool.false in
 out >     case c of
-out >       0 → "not less"
-out >       _ | c >= 1 → "not less"
-out >       _ → "less"
+out >       Agda.Builtin.Bool.Bool.false → "not less"
+out >       Agda.Builtin.Bool.Bool.true → "less"
 out > CaseOnCase.fancyCase =
 out >   λ a b →
 out >     let c = a - 1 in

--- a/test/Compiler/simple/CompareNat.out
+++ b/test/Compiler/simple/CompareNat.out
@@ -15,14 +15,48 @@ out >       Agda.Builtin.Bool.Bool.true →
 out >         CompareNat.Comparison.less (CompareNat._<_.diff (b - a - 1) _)
 out > CompareNat.compare-lots =
 out >   λ a b →
-out >     let c = a < b in
+out >     let c =
+out >           let e = a < b in
+out >           case e of
+out >             Agda.Builtin.Bool.Bool.false →
+out >               let f = b < a in
+out >               case f of
+out >                 Agda.Builtin.Bool.Bool.false → CompareNat.Comparison.equal _
+out >                 Agda.Builtin.Bool.Bool.true →
+out >                   CompareNat.Comparison.greater (CompareNat._<_.diff (a - b - 1) _)
+out >             Agda.Builtin.Bool.Bool.true →
+out >               CompareNat.Comparison.less (CompareNat._<_.diff (b - a - 1) _)
+out >         d =
+out >           let e = a < b in
+out >           case e of
+out >             Agda.Builtin.Bool.Bool.false →
+out >               let f = b < a in
+out >               case f of
+out >                 Agda.Builtin.Bool.Bool.false → CompareNat.Comparison.equal _
+out >                 Agda.Builtin.Bool.Bool.true →
+out >                   CompareNat.Comparison.greater (CompareNat._<_.diff (a - b - 1) _)
+out >             Agda.Builtin.Bool.Bool.true →
+out >               CompareNat.Comparison.less (CompareNat._<_.diff (b - a - 1) _) in
 out >     case c of
-out >       Agda.Builtin.Bool.Bool.false →
-out >         let d = b < a in
+out >       CompareNat.Comparison.less e →
+out >         seq
+out >           e
+out >           (case d of
+out >              CompareNat.Comparison.less f → seq f "less-less"
+out >              CompareNat.Comparison.equal _ → "less-equal"
+out >              CompareNat.Comparison.greater f → seq f "less-greater")
+out >       CompareNat.Comparison.equal _ →
 out >         case d of
-out >           Agda.Builtin.Bool.Bool.false → "equal-equal"
-out >           Agda.Builtin.Bool.Bool.true → "greater-greater"
-out >       Agda.Builtin.Bool.Bool.true → "less-less"
+out >           CompareNat.Comparison.less e → seq e "equal-less"
+out >           CompareNat.Comparison.equal _ → "equal-equal"
+out >           CompareNat.Comparison.greater e → seq e "equal-greater"
+out >       CompareNat.Comparison.greater e →
+out >         seq
+out >           e
+out >           (case d of
+out >              CompareNat.Comparison.less f → seq f "greater-less"
+out >              CompareNat.Comparison.equal _ → "greater-equal"
+out >              CompareNat.Comparison.greater f → seq f "greater-greater")
 out > CompareNat.main =
 out >   Common.IO.then
 out >     () () _ _ (Common.IO.putStrLn (CompareNat.compare-lots 1500 2000))

--- a/test/Compiler/simple/CompileNumbers.out
+++ b/test/Compiler/simple/CompileNumbers.out
@@ -32,8 +32,66 @@ out >           Agda.Builtin.Bool.Bool.true →
 out >             CompileNumbers.Diff.greater (a - b - 1)
 out >       Agda.Builtin.Bool.Bool.true → CompileNumbers.Diff.less (b - a - 1)
 out > CompileNumbers.neg = λ a → 0 - a
-out > CompileNumbers._-N_ = λ a b → a - b
-out > CompileNumbers._+Z_ = λ a b → a + b
+out > CompileNumbers._-N_ =
+out >   λ a b →
+out >     let c =
+out >           let d = a < b in
+out >           case d of
+out >             Agda.Builtin.Bool.Bool.false →
+out >               let e = b < a in
+out >               case e of
+out >                 Agda.Builtin.Bool.Bool.false → CompileNumbers.Diff.equal
+out >                 Agda.Builtin.Bool.Bool.true →
+out >                   CompileNumbers.Diff.greater (a - b - 1)
+out >             Agda.Builtin.Bool.Bool.true →
+out >               CompileNumbers.Diff.less (b - a - 1) in
+out >     case c of
+out >       CompileNumbers.Diff.less d → -1 - d
+out >       CompileNumbers.Diff.equal → Agda.Builtin.Nat._-_ a b
+out >       CompileNumbers.Diff.greater d → 1 + d
+out > CompileNumbers._+Z_ =
+out >   λ a b →
+out >     case a of
+out >       _ | a >= 0 →
+out >         case b of
+out >           _ | b >= 0 → a + b
+out >           _ → let c = 0 - b
+out >                   d =
+out >                     let e = 0 - b
+out >                         f = a < 0 - b in
+out >                     case f of
+out >                       Agda.Builtin.Bool.Bool.false →
+out >                         let g = e < a in
+out >                         case g of
+out >                           Agda.Builtin.Bool.Bool.false → CompileNumbers.Diff.equal
+out >                           Agda.Builtin.Bool.Bool.true →
+out >                             CompileNumbers.Diff.greater (a + b - 1)
+out >                       Agda.Builtin.Bool.Bool.true →
+out >                         CompileNumbers.Diff.less (-1 - a - b) in
+out >               case d of
+out >                 CompileNumbers.Diff.less e → -1 - e
+out >                 CompileNumbers.Diff.equal → Agda.Builtin.Nat._-_ a c
+out >                 CompileNumbers.Diff.greater e → 1 + e
+out >       _ → case b of
+out >             _ | b >= 0 →
+out >               let c = 0 - a
+out >                   d =
+out >                     let e = 0 - a
+out >                         f = b < 0 - a in
+out >                     case f of
+out >                       Agda.Builtin.Bool.Bool.false →
+out >                         let g = e < b in
+out >                         case g of
+out >                           Agda.Builtin.Bool.Bool.false → CompileNumbers.Diff.equal
+out >                           Agda.Builtin.Bool.Bool.true →
+out >                             CompileNumbers.Diff.greater (a + b - 1)
+out >                       Agda.Builtin.Bool.Bool.true →
+out >                         CompileNumbers.Diff.less (-1 - a - b) in
+out >               case d of
+out >                 CompileNumbers.Diff.less e → -1 - e
+out >                 CompileNumbers.Diff.equal → Agda.Builtin.Nat._-_ b c
+out >                 CompileNumbers.Diff.greater e → 1 + e
+out >             _ → a + b
 out > CompileNumbers._*Z_ = λ a b → a * b
 out > CompileNumbers.printInt =
 out >   λ a → Common.IO.putStrLn (Common.String.intToString a)

--- a/test/Compiler/simple/Issue7595-semantics.agda
+++ b/test/Compiler/simple/Issue7595-semantics.agda
@@ -1,0 +1,52 @@
+-- Cross-backend semantic coverage for the nested-case simplification in #7595.
+
+open import Agda.Builtin.Maybe
+open import Common.IO
+open import Common.String
+open import Common.Unit
+
+case_of_ : {A B : Set} -> A -> (A -> B) -> B
+case x of f = f x
+
+data Cell : Set where
+  [-] [x] : Cell
+
+data Board : Set where
+  mk-Board : Cell -> Cell -> Board
+
+winner : Board -> Maybe Cell
+winner = \ where
+  (mk-Board [x] [x]) -> just [x]
+  (mk-Board [-]  _ ) -> nothing
+  (mk-Board  _  [-]) -> nothing
+
+b0 : Board
+b0 = mk-Board [-] [-]
+
+bx : Board
+bx = mk-Board [x] [x]
+
+step1 : Board -> Board
+step1 b = case winner b of \ where
+  (just _) -> b
+  nothing  -> b0
+
+step2 : Board -> Board
+step2 b with winner b
+... | just _ = b
+... | nothing = b0
+
+showWinner : Maybe Cell -> String
+showWinner nothing    = "nothing"
+showWinner (just [-]) = "-"
+showWinner (just [x]) = "x"
+
+printWinner : Board -> IO Unit
+printWinner b = putStr (showWinner (winner b)) >>= \ _ -> putStr "\n"
+
+main : IO Unit
+main =
+  printWinner (step1 b0) >>= \ _ ->
+  printWinner (step2 b0) >>= \ _ ->
+  printWinner (step1 bx) >>= \ _ ->
+  printWinner (step2 bx)

--- a/test/Compiler/simple/Issue7595-semantics.options
+++ b/test/Compiler/simple/Issue7595-semantics.options
@@ -1,0 +1,8 @@
+TestOptions
+  { forCompilers =
+      [ (MAlonzo Lazy, CompilerOptions {extraAgdaArgs = []})
+      , (JS NonOptimized, CompilerOptions {extraAgdaArgs = []})
+      ]
+  , runtimeOptions = []
+  , executeProg = True
+  }

--- a/test/Compiler/simple/Issue7595-semantics.out
+++ b/test/Compiler/simple/Issue7595-semantics.out
@@ -1,0 +1,8 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > nothing
+out > nothing
+out > x
+out > x
+out >

--- a/test/Compiler/simple/Issue7595.agda
+++ b/test/Compiler/simple/Issue7595.agda
@@ -1,0 +1,161 @@
+-- Regression test for #7595: nested with must not duplicate the outer case tree.
+
+open import Agda.Builtin.Maybe
+open import Common.IO
+open import Common.Unit
+
+case_of_ : {A B : Set} → A → (A → B) → B
+case x of f = f x
+
+data Cell : Set where
+  [-] [o] [x] : Cell
+
+data Board : Set where
+  mk-Board :
+    (_ _ _
+     _ _ _
+     _ _ _ : Cell) → Board
+
+winner : Board → Maybe Cell
+winner = λ where
+  (mk-Board [x]  _   _
+            [x]  _   _
+            [x]  _   _) → just [x]
+
+  (mk-Board  _  [x]  _
+             _  [x]  _
+             _  [x]  _) → just [x]
+
+  (mk-Board  _   _  [x]
+             _   _  [x]
+             _   _  [x]) → just [x]
+
+  (mk-Board [x] [x] [x]
+             _   _   _
+             _   _   _ ) → just [x]
+
+  (mk-Board  _   _   _
+            [x] [x] [x]
+             _   _   _ ) → just [x]
+
+  (mk-Board  _   _   _
+             _   _   _
+            [x] [x] [x]) → just [x]
+
+  (mk-Board [x]  _   _
+             _  [x]  _
+             _   _  [x]) → just [x]
+
+  (mk-Board  _   _  [x]
+             _  [x]  _
+            [x]  _   _ ) → just [x]
+
+  (mk-Board [o]  _   _
+            [o]  _   _
+            [o]  _   _ ) → just [o]
+
+  (mk-Board  _  [o]  _
+             _  [o]  _
+             _  [o]  _ ) → just [o]
+
+  (mk-Board  _   _  [o]
+             _   _  [o]
+             _   _  [o]) → just [o]
+
+  (mk-Board [o] [o] [o]
+             _   _   _
+             _   _   _ ) → just [o]
+
+  (mk-Board  _   _   _
+            [o] [o] [o]
+             _   _   _ ) → just [o]
+
+  (mk-Board  _   _   _
+             _   _   _
+            [o] [o] [o]) → just [o]
+
+  (mk-Board [o]  _   _
+              _  [o]  _
+              _   _  [o]) → just [o]
+
+  (mk-Board  _   _  [o]
+             _  [o]  _
+            [o]  _   _ ) → just [o]
+
+  (mk-Board [-]  _   _
+             _   _   _
+             _   _   _ ) → nothing
+
+  (mk-Board  _  [-]  _
+             _   _   _
+             _   _   _ ) → nothing
+
+  (mk-Board  _   _  [-]
+             _   _   _
+             _   _   _ ) → nothing
+
+  (mk-Board  _   _   _
+            [-]  _   _
+             _   _   _ ) → nothing
+
+  (mk-Board  _   _   _
+             _  [-]  _
+             _   _   _ ) → nothing
+
+  (mk-Board  _   _   _
+             _   _  [-]
+             _   _   _ ) → nothing
+
+  (mk-Board  _   _   _
+             _   _   _
+            [-]  _   _ ) → nothing
+
+  (mk-Board  _   _   _
+             _   _   _
+             _  [-]  _ ) → nothing
+
+  (mk-Board  _   _   _
+             _   _   _
+             _   _  [-]) → nothing
+
+  (mk-Board  _   _   _
+             _   _   _
+             _   _   _ ) → just [-]
+
+b0 : Board
+b0 = mk-Board
+  [-] [-] [-]
+  [-] [-] [-]
+  [-] [-] [-]
+
+step1 : Board → Board
+step1 b = case winner b of λ where
+  (just _) → b
+  nothing → b0
+
+step2 : Board → Board
+step2 b with winner b
+... | just _ = b
+... | nothing = b0
+
+-- The fixed module is about 125 KB, while the regression produced 114 MB.
+-- Check the generated entry module with enough headroom for ordinary changes.
+postulate checkGeneratedSize : IO Unit
+
+{-# COMPILE JS checkGeneratedSize =
+    cb => {
+      import("node:fs").then(fs => {
+        const size = fs.statSync(process.argv[1]).size;
+        if (size > 1000000) {
+          process.stderr.write(
+            "generated JavaScript exceeds 1000000 bytes: " + size + "\n");
+          process.exitCode = 1;
+          return;
+        }
+        cb(0);
+      });
+    }
+#-}
+
+main : IO Unit
+main = checkGeneratedSize >>= \ _ -> putStr "OK\n"

--- a/test/Compiler/simple/Issue7595.options
+++ b/test/Compiler/simple/Issue7595.options
@@ -1,0 +1,7 @@
+TestOptions
+  { forCompilers =
+      [ (JS NonOptimized, CompilerOptions {extraAgdaArgs = []})
+      ]
+  , runtimeOptions = []
+  , executeProg = True
+  }

--- a/test/Compiler/simple/Issue7595.out
+++ b/test/Compiler/simple/Issue7595.out
@@ -1,0 +1,5 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > OK
+out >


### PR DESCRIPTION
## Summary

- remove the treeless simplifier's nested case-of-case distribution, which duplicates the outer case tree into every inner branch
- add the original issue shape as a generated-JavaScript size regression
- add smaller cross-backend semantic coverage for MAlonzo and JavaScript

Fixes #7595.

## Performance

On the pinned issue fixture, generated JavaScript falls from 113,979,281 bytes
to 124,697 bytes: 99.89% smaller, or about 914x less output. The generated
artifact SHA-256 and byte count were identical across the repeated strict runs.

This follows the issue analysis: the removed branch distributes `case1` into
each nested alternative, causing the outer case tree to grow combinatorially.
Falling back to the existing `tCase` path preserves the original clauses
without that duplication.

This deliberately removes the case-of-case optimization for all nested cases.
Some non-pathological programs may therefore miss that optimization, but the
compiler avoids the unbounded duplication described in the issue.

## Validation

- focused compiler harness for the issue fixture and cross-backend semantic fixture
- generated JavaScript executes successfully and prints the expected output
- strict candidate-scope checks and cleanup/interrupt contract tests
- repeated baseline-to-candidate compiler rebuilds with deterministic output

## Autoresearch

This optimization was found during autoresearch with Weco. The public trajectory
records the baseline, the accepted first candidate, and the rejected follow-up
attempts: https://dashboard.weco.ai/share/u5fanRLAyQzYbiC1lIV2SmUyGLhOo35j
