### PR TITLE
Remove case-of-case optimization in compiler

### DIFF
--- a/src/full/Agda/Compiler/Treeless/Simplify.hs
+++ b/src/full/Agda/Compiler/Treeless/Simplify.hs
@@ -125,24 +125,10 @@ simplify FunctionKit{ divAux, modAux, natMinus, true, false } = simpl
         case u of                          -- TODO: also for literals
           _ | Just (c, as)     <- conView u   -> simpl $ matchCon lets c as d bs
             | Just (k, TVar y) <- plusKView u -> simpl . mkLets lets . TCase y t d =<< mapM (matchPlusK y x k) bs
-          TCase y t1 d1 bs1 -> simpl $ mkLets lets $ TCase y t1 (distrDef case1 d1) $
-                                       map (distrCase case1) bs1
-            where
-              -- Γ x Δ -> Γ _ Δ Θ y, where x maps to y and Θ are the lets
-              n     = length lets
-              rho   = liftS (x + n + 1) (raiseS 1)    `composeS`
-                      singletonS (x + n + 1) (TVar 0) `composeS`
-                      raiseS (n + 1)
-              case1 = applySubst rho (TCase x t d bs)
-
-              distrDef v d | isUnreachable d = tUnreachable
-                           | otherwise       = tLet d v
-
-              distrCase v (TACon c a b) = TACon c a $ TLet b $ raiseFrom 1 a v
-              distrCase v (TALit l b)   = TALit l   $ TLet b v
-              distrCase v (TAGuard g b) = TAGuard g $ TLet b v
-
-          _ -> do
+            -- We are not normalizing the case-of-case commuting converison
+            -- since it can lead to major code duplication without join points
+            -- or continuations. See issue #7595.
+            | otherwise -> do
             d <- simpl d
             tCase x t d bs
 

--- a/test/Compiler/simple/CaseOnCase.out
+++ b/test/Compiler/simple/CaseOnCase.out
@@ -16,18 +16,32 @@ out >       _ | c >= 1 → CaseOnCase.Cmp.greater
 out >       _ → CaseOnCase.Cmp.less
 out > CaseOnCase._<_ =
 out >   λ a b →
-out >     let c = CaseOnCase._-_ a b in
+out >     let c =
+out >           let d = CaseOnCase._-_ a b in
+out >           case d of
+out >             0 → CaseOnCase.Cmp.equal
+out >             _ | d >= 1 → CaseOnCase.Cmp.greater
+out >             _ → CaseOnCase.Cmp.less in
 out >     case c of
-out >       0 → Agda.Builtin.Bool.Bool.false
-out >       _ | c >= 1 → Agda.Builtin.Bool.Bool.false
-out >       _ → Agda.Builtin.Bool.Bool.true
+out >       CaseOnCase.Cmp.less → Agda.Builtin.Bool.Bool.true
+out >       CaseOnCase.Cmp.equal → Agda.Builtin.Bool.Bool.false
+out >       CaseOnCase.Cmp.greater → Agda.Builtin.Bool.Bool.false
 out > CaseOnCase.cmp =
 out >   λ a b →
-out >     let c = CaseOnCase._-_ a b in
+out >     let c =
+out >           let d =
+out >                 let e = CaseOnCase._-_ a b in
+out >                 case e of
+out >                   0 → CaseOnCase.Cmp.equal
+out >                   _ | e >= 1 → CaseOnCase.Cmp.greater
+out >                   _ → CaseOnCase.Cmp.less in
+out >           case d of
+out >             CaseOnCase.Cmp.less → Agda.Builtin.Bool.Bool.true
+out >             CaseOnCase.Cmp.equal → Agda.Builtin.Bool.Bool.false
+out >             CaseOnCase.Cmp.greater → Agda.Builtin.Bool.Bool.false in
 out >     case c of
-out >       0 → "not less"
-out >       _ | c >= 1 → "not less"
-out >       _ → "less"
+out >       Agda.Builtin.Bool.Bool.false → "not less"
+out >       Agda.Builtin.Bool.Bool.true → "less"
 out > CaseOnCase.fancyCase =
 out >   λ a b →
 out >     let c = a - 1 in

--- a/test/Compiler/simple/CompareNat.agda
+++ b/test/Compiler/simple/CompareNat.agda
@@ -23,7 +23,7 @@ compare a b with a <? b
 
 {-# INLINE compare #-}
 
--- This should compile to two calls of _<?_ and only the possible cases.
+-- This should ideally compile to two calls of _<?_ and only the possible cases.
 compare-lots : (a b : Nat) → String
 compare-lots a b with compare a b | compare (suc a) (suc b)
 compare-lots a b | less (diff k eq) | less (diff k₁ eq₁) = "less-less"

--- a/test/Compiler/simple/CompareNat.out
+++ b/test/Compiler/simple/CompareNat.out
@@ -15,14 +15,48 @@ out >       Agda.Builtin.Bool.Bool.true →
 out >         CompareNat.Comparison.less (CompareNat._<_.diff (b - a - 1) _)
 out > CompareNat.compare-lots =
 out >   λ a b →
-out >     let c = a < b in
+out >     let c =
+out >           let e = a < b in
+out >           case e of
+out >             Agda.Builtin.Bool.Bool.false →
+out >               let f = b < a in
+out >               case f of
+out >                 Agda.Builtin.Bool.Bool.false → CompareNat.Comparison.equal _
+out >                 Agda.Builtin.Bool.Bool.true →
+out >                   CompareNat.Comparison.greater (CompareNat._<_.diff (a - b - 1) _)
+out >             Agda.Builtin.Bool.Bool.true →
+out >               CompareNat.Comparison.less (CompareNat._<_.diff (b - a - 1) _)
+out >         d =
+out >           let e = a < b in
+out >           case e of
+out >             Agda.Builtin.Bool.Bool.false →
+out >               let f = b < a in
+out >               case f of
+out >                 Agda.Builtin.Bool.Bool.false → CompareNat.Comparison.equal _
+out >                 Agda.Builtin.Bool.Bool.true →
+out >                   CompareNat.Comparison.greater (CompareNat._<_.diff (a - b - 1) _)
+out >             Agda.Builtin.Bool.Bool.true →
+out >               CompareNat.Comparison.less (CompareNat._<_.diff (b - a - 1) _) in
 out >     case c of
-out >       Agda.Builtin.Bool.Bool.false →
-out >         let d = b < a in
+out >       CompareNat.Comparison.less e →
+out >         seq
+out >           e
+out >           (case d of
+out >              CompareNat.Comparison.less f → seq f "less-less"
+out >              CompareNat.Comparison.equal _ → "less-equal"
+out >              CompareNat.Comparison.greater f → seq f "less-greater")
+out >       CompareNat.Comparison.equal _ →
 out >         case d of
-out >           Agda.Builtin.Bool.Bool.false → "equal-equal"
-out >           Agda.Builtin.Bool.Bool.true → "greater-greater"
-out >       Agda.Builtin.Bool.Bool.true → "less-less"
+out >           CompareNat.Comparison.less e → seq e "equal-less"
+out >           CompareNat.Comparison.equal _ → "equal-equal"
+out >           CompareNat.Comparison.greater e → seq e "equal-greater"
+out >       CompareNat.Comparison.greater e →
+out >         seq
+out >           e
+out >           (case d of
+out >              CompareNat.Comparison.less f → seq f "greater-less"
+out >              CompareNat.Comparison.equal _ → "greater-equal"
+out >              CompareNat.Comparison.greater f → seq f "greater-greater")
 out > CompareNat.main =
 out >   Common.IO.then
 out >     () () _ _ (Common.IO.putStrLn (CompareNat.compare-lots 1500 2000))

--- a/test/Compiler/simple/CompileNumbers.agda
+++ b/test/Compiler/simple/CompileNumbers.agda
@@ -51,7 +51,8 @@ neg zero    = pos zero
 neg (suc a) = negsuc a
 {-# INLINE neg #-}
 
--- Should compile to a - b
+-- This does not compile to 'a - b' without the case-of-case commuting
+-- conversion, which was removed to fix issue #7595.
 _-N_ : Nat → Nat → Integer
 a -N b with compareNat a b
 ... | less k    = negsuc k
@@ -59,7 +60,8 @@ a -N b with compareNat a b
 ... | greater k = pos (suc k)
 {-# INLINE _-N_ #-}
 
--- Should compile to a + b
+-- This does not compile to 'a - b' without the case-of-case commuting
+-- conversion, which was removed to fix issue #7595.
 _+Z_ : Integer → Integer → Integer
 pos    a +Z pos    b = pos (a + b)
 pos    a +Z negsuc b = a -N suc b

--- a/test/Compiler/simple/CompileNumbers.out
+++ b/test/Compiler/simple/CompileNumbers.out
@@ -32,8 +32,66 @@ out >           Agda.Builtin.Bool.Bool.true →
 out >             CompileNumbers.Diff.greater (a - b - 1)
 out >       Agda.Builtin.Bool.Bool.true → CompileNumbers.Diff.less (b - a - 1)
 out > CompileNumbers.neg = λ a → 0 - a
-out > CompileNumbers._-N_ = λ a b → a - b
-out > CompileNumbers._+Z_ = λ a b → a + b
+out > CompileNumbers._-N_ =
+out >   λ a b →
+out >     let c =
+out >           let d = a < b in
+out >           case d of
+out >             Agda.Builtin.Bool.Bool.false →
+out >               let e = b < a in
+out >               case e of
+out >                 Agda.Builtin.Bool.Bool.false → CompileNumbers.Diff.equal
+out >                 Agda.Builtin.Bool.Bool.true →
+out >                   CompileNumbers.Diff.greater (a - b - 1)
+out >             Agda.Builtin.Bool.Bool.true →
+out >               CompileNumbers.Diff.less (b - a - 1) in
+out >     case c of
+out >       CompileNumbers.Diff.less d → -1 - d
+out >       CompileNumbers.Diff.equal → Agda.Builtin.Nat._-_ a b
+out >       CompileNumbers.Diff.greater d → 1 + d
+out > CompileNumbers._+Z_ =
+out >   λ a b →
+out >     case a of
+out >       _ | a >= 0 →
+out >         case b of
+out >           _ | b >= 0 → a + b
+out >           _ → let c = 0 - b
+out >                   d =
+out >                     let e = 0 - b
+out >                         f = a < 0 - b in
+out >                     case f of
+out >                       Agda.Builtin.Bool.Bool.false →
+out >                         let g = e < a in
+out >                         case g of
+out >                           Agda.Builtin.Bool.Bool.false → CompileNumbers.Diff.equal
+out >                           Agda.Builtin.Bool.Bool.true →
+out >                             CompileNumbers.Diff.greater (a + b - 1)
+out >                       Agda.Builtin.Bool.Bool.true →
+out >                         CompileNumbers.Diff.less (-1 - a - b) in
+out >               case d of
+out >                 CompileNumbers.Diff.less e → -1 - e
+out >                 CompileNumbers.Diff.equal → Agda.Builtin.Nat._-_ a c
+out >                 CompileNumbers.Diff.greater e → 1 + e
+out >       _ → case b of
+out >             _ | b >= 0 →
+out >               let c = 0 - a
+out >                   d =
+out >                     let e = 0 - a
+out >                         f = b < 0 - a in
+out >                     case f of
+out >                       Agda.Builtin.Bool.Bool.false →
+out >                         let g = e < b in
+out >                         case g of
+out >                           Agda.Builtin.Bool.Bool.false → CompileNumbers.Diff.equal
+out >                           Agda.Builtin.Bool.Bool.true →
+out >                             CompileNumbers.Diff.greater (a + b - 1)
+out >                       Agda.Builtin.Bool.Bool.true →
+out >                         CompileNumbers.Diff.less (-1 - a - b) in
+out >               case d of
+out >                 CompileNumbers.Diff.less e → -1 - e
+out >                 CompileNumbers.Diff.equal → Agda.Builtin.Nat._-_ b c
+out >                 CompileNumbers.Diff.greater e → 1 + e
+out >             _ → a + b
 out > CompileNumbers._*Z_ = λ a b → a * b
 out > CompileNumbers.printInt =
 out >   λ a → Common.IO.putStrLn (Common.String.intToString a)

--- a/test/Compiler/simple/Issue7595.agda
+++ b/test/Compiler/simple/Issue7595.agda
@@ -1,0 +1,132 @@
+{-# OPTIONS -v treeless.opt.simpl:30 -v 0 #-}
+
+module Issue7595 where
+
+open import Agda.Builtin.Maybe using (Maybe; just; nothing)
+
+data Cell : Set where
+  [-] [o] [x] : Cell
+
+data Board : Set where
+  mk-Board :
+    (_ _ _
+     _ _ _
+     _ _ _ : Cell) → Board
+
+winner : Board → Maybe Cell
+winner = λ where
+  (mk-Board [x]  _   _
+            [x]  _   _
+            [x]  _   _) → just [x]
+
+  (mk-Board  _  [x]  _
+             _  [x]  _
+             _  [x]  _) → just [x]
+
+  (mk-Board  _   _  [x]
+             _   _  [x]
+             _   _  [x]) → just [x]
+
+  (mk-Board [x] [x] [x]
+             _   _   _
+             _   _   _ ) → just [x]
+
+  (mk-Board  _   _   _
+            [x] [x] [x]
+             _   _   _ ) → just [x]
+
+  (mk-Board  _   _   _
+             _   _   _
+            [x] [x] [x]) → just [x]
+
+  (mk-Board [x]  _   _
+             _  [x]  _
+             _   _  [x]) → just [x]
+
+  (mk-Board  _   _  [x]
+             _  [x]  _
+            [x]  _   _ ) → just [x]
+
+  (mk-Board [o]  _   _
+            [o]  _   _
+            [o]  _   _ ) → just [o]
+
+  (mk-Board  _  [o]  _
+             _  [o]  _
+             _  [o]  _ ) → just [o]
+
+  (mk-Board  _   _  [o]
+             _   _  [o]
+             _   _  [o]) → just [o]
+
+  (mk-Board [o] [o] [o]
+             _   _   _
+             _   _   _ ) → just [o]
+
+  (mk-Board  _   _   _
+            [o] [o] [o]
+             _   _   _ ) → just [o]
+
+  (mk-Board  _   _   _
+             _   _   _
+            [o] [o] [o]) → just [o]
+
+  (mk-Board [o]  _   _
+              _  [o]  _
+              _   _  [o]) → just [o]
+
+  (mk-Board  _   _  [o]
+             _  [o]  _
+            [o]  _   _ ) → just [o]
+
+  (mk-Board [-]  _   _
+             _   _   _
+             _   _   _ ) → nothing
+
+  (mk-Board  _  [-]  _
+             _   _   _
+             _   _   _ ) → nothing
+
+  (mk-Board  _   _  [-]
+             _   _   _
+             _   _   _ ) → nothing
+
+  (mk-Board  _   _   _
+            [-]  _   _
+             _   _   _ ) → nothing
+
+  (mk-Board  _   _   _
+             _  [-]  _
+             _   _   _ ) → nothing
+
+  (mk-Board  _   _   _
+             _   _  [-]
+             _   _   _ ) → nothing
+
+  (mk-Board  _   _   _
+             _   _   _
+            [-]  _   _ ) → nothing
+
+  (mk-Board  _   _   _
+             _   _   _
+             _  [-]  _ ) → nothing
+
+  (mk-Board  _   _   _
+             _   _   _
+             _   _  [-]) → nothing
+
+  (mk-Board  _   _   _
+             _   _   _
+             _   _   _ ) → just [-]
+
+b0 : Board
+b0 = mk-Board
+  [-] [-] [-]
+  [-] [-] [-]
+  [-] [-] [-]
+
+step : Board → Board
+step b with winner b
+... | just _ = b
+... | nothing = b0
+

--- a/test/Compiler/simple/Issue7595.options
+++ b/test/Compiler/simple/Issue7595.options
@@ -1,0 +1,8 @@
+TestOptions
+  { forCompilers =
+      [ (MAlonzo Lazy,    CompilerOptions {extraAgdaArgs = ["--no-main"]})
+      , (JS NonOptimized, CompilerOptions {extraAgdaArgs = ["--no-main"]})
+      ]
+  , runtimeOptions = []
+  , executeProg = False
+  }

--- a/test/Compiler/simple/Issue7595.out
+++ b/test/Compiler/simple/Issue7595.out
@@ -1,0 +1,1018 @@
+COMPILE_SUCCEEDED
+
+ret > ExitSuccess
+out > -- simplification (No effect)
+out > -- simplification (No effect)
+out > -- simplification
+out > Issue7595.step =
+out >   λ a →
+out >     let b =
+out >           case a of
+out >             Issue7595.Board.mk-Board c d e f g h i j k →
+out >               let l =
+out >                     let m =
+out >                           let n =
+out >                                 let o =
+out >                                       let p =
+out >                                             let q =
+out >                                                   let r =
+out >                                                         let s =
+out >                                                               let t =
+out >                                                                     Agda.Builtin.Maybe.Maybe.just
+out >                                                                       Issue7595.Cell.[-] in
+out >                                                               case k of
+out >                                                                 Issue7595.Cell.[-] →
+out >                                                                   Agda.Builtin.Maybe.Maybe.nothing
+out >                                                                 _ → t in
+out >                                                         case j of
+out >                                                           Issue7595.Cell.[-] →
+out >                                                             Agda.Builtin.Maybe.Maybe.nothing
+out >                                                           _ → s in
+out >                                                   case h of
+out >                                                     Issue7595.Cell.[-] →
+out >                                                       Agda.Builtin.Maybe.Maybe.nothing
+out >                                                     _ → r in
+out >                                             case g of
+out >                                               Issue7595.Cell.[-] → Agda.Builtin.Maybe.Maybe.nothing
+out >                                               _ → q in
+out >                                       case i of
+out >                                         Issue7595.Cell.[-] →
+out >                                           let q =
+out >                                                 let r = Agda.Builtin.Maybe.Maybe.nothing in
+out >                                                 case h of
+out >                                                   Issue7595.Cell.[-] →
+out >                                                     Agda.Builtin.Maybe.Maybe.nothing
+out >                                                   _ → r in
+out >                                           case g of
+out >                                             Issue7595.Cell.[-] → Agda.Builtin.Maybe.Maybe.nothing
+out >                                             _ → q
+out >                                         Issue7595.Cell.[o] →
+out >                                           case j of
+out >                                             Issue7595.Cell.[o] →
+out >                                               case k of
+out >                                                 Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                                 _ → p
+out >                                             _ → p
+out >                                         Issue7595.Cell.[x] →
+out >                                           case j of
+out >                                             Issue7595.Cell.[x] →
+out >                                               case k of
+out >                                                 Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                                 _ → p
+out >                                             _ → p in
+out >                                 case f of
+out >                                   Issue7595.Cell.[-] →
+out >                                     let p = Agda.Builtin.Maybe.Maybe.nothing in
+out >                                     case i of
+out >                                       Issue7595.Cell.[o] →
+out >                                         case j of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       Issue7595.Cell.[x] →
+out >                                         case j of
+out >                                           Issue7595.Cell.[x] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       _ → p
+out >                                   Issue7595.Cell.[o] →
+out >                                     let p =
+out >                                           case g of
+out >                                             Issue7595.Cell.[o] →
+out >                                               case h of
+out >                                                 Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just h
+out >                                                 _ → o
+out >                                             _ → o in
+out >                                     case i of
+out >                                       Issue7595.Cell.[x] →
+out >                                         case j of
+out >                                           Issue7595.Cell.[x] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       _ → p
+out >                                   Issue7595.Cell.[x] →
+out >                                     case g of
+out >                                       Issue7595.Cell.[x] →
+out >                                         case h of
+out >                                           Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just h
+out >                                           _ → o
+out >                                       _ → o in
+out >                           case e of
+out >                             Issue7595.Cell.[-] →
+out >                               let o =
+out >                                     let p = Agda.Builtin.Maybe.Maybe.nothing in
+out >                                     case i of
+out >                                       Issue7595.Cell.[o] →
+out >                                         case j of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       Issue7595.Cell.[x] →
+out >                                         case j of
+out >                                           Issue7595.Cell.[x] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       _ → p in
+out >                               case f of
+out >                                 Issue7595.Cell.[o] →
+out >                                   let p =
+out >                                         case g of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case h of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just h
+out >                                               _ → o
+out >                                           _ → o in
+out >                                   case i of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case j of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → p
+out >                                 Issue7595.Cell.[x] →
+out >                                   case g of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case h of
+out >                                         Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just h
+out >                                         _ → o
+out >                                     _ → o
+out >                                 _ → o
+out >                             Issue7595.Cell.[o] →
+out >                               let o =
+out >                                     let p =
+out >                                           case h of
+out >                                             Issue7595.Cell.[o] →
+out >                                               case k of
+out >                                                 Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                                 _ → n
+out >                                             _ → n in
+out >                                     case i of
+out >                                       Issue7595.Cell.[o] →
+out >                                         let q =
+out >                                               let r =
+out >                                                     case g of
+out >                                                       Issue7595.Cell.[o] →
+out >                                                         Agda.Builtin.Maybe.Maybe.just g
+out >                                                       _ → p in
+out >                                               case j of
+out >                                                 Issue7595.Cell.[o] →
+out >                                                   case k of
+out >                                                     Issue7595.Cell.[o] →
+out >                                                       Agda.Builtin.Maybe.Maybe.just k
+out >                                                     _ → r
+out >                                                 _ → r in
+out >                                         case h of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → q
+out >                                           _ → q
+out >                                       Issue7595.Cell.[x] →
+out >                                         case j of
+out >                                           Issue7595.Cell.[x] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       _ → p in
+out >                               case f of
+out >                                 Issue7595.Cell.[o] →
+out >                                   let p =
+out >                                         case h of
+out >                                           Issue7595.Cell.[o] →
+out >                                             let q =
+out >                                                   case g of
+out >                                                     Issue7595.Cell.[o] →
+out >                                                       Agda.Builtin.Maybe.Maybe.just g
+out >                                                     _ → o in
+out >                                             case k of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → q
+out >                                           _ → o in
+out >                                   case i of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case j of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → p
+out >                                 Issue7595.Cell.[x] →
+out >                                   case g of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case h of
+out >                                         Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just h
+out >                                         _ → o
+out >                                     _ → o
+out >                                 _ → o
+out >                             Issue7595.Cell.[x] →
+out >                               let o =
+out >                                     case i of
+out >                                       Issue7595.Cell.[x] →
+out >                                         let p =
+out >                                               case g of
+out >                                                 Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just g
+out >                                                 _ → n in
+out >                                         case j of
+out >                                           Issue7595.Cell.[x] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       _ → n in
+out >                               case h of
+out >                                 Issue7595.Cell.[x] →
+out >                                   let p =
+out >                                         case f of
+out >                                           Issue7595.Cell.[x] →
+out >                                             case g of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just g
+out >                                               _ → o
+out >                                           _ → o in
+out >                                   case k of
+out >                                     Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                     _ → p
+out >                                 _ → o in
+out >                     case d of
+out >                       Issue7595.Cell.[-] →
+out >                         let n =
+out >                               let o =
+out >                                     let p = Agda.Builtin.Maybe.Maybe.nothing in
+out >                                     case i of
+out >                                       Issue7595.Cell.[o] →
+out >                                         case j of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       Issue7595.Cell.[x] →
+out >                                         case j of
+out >                                           Issue7595.Cell.[x] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       _ → p in
+out >                               case f of
+out >                                 Issue7595.Cell.[o] →
+out >                                   let p =
+out >                                         case g of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case h of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just h
+out >                                               _ → o
+out >                                           _ → o in
+out >                                   case i of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case j of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → p
+out >                                 Issue7595.Cell.[x] →
+out >                                   case g of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case h of
+out >                                         Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just h
+out >                                         _ → o
+out >                                     _ → o
+out >                                 _ → o in
+out >                         case e of
+out >                           Issue7595.Cell.[o] →
+out >                             let o =
+out >                                   let p =
+out >                                         case h of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → n
+out >                                           _ → n in
+out >                                   case i of
+out >                                     Issue7595.Cell.[o] →
+out >                                       let q =
+out >                                             let r =
+out >                                                   case g of
+out >                                                     Issue7595.Cell.[o] →
+out >                                                       Agda.Builtin.Maybe.Maybe.just g
+out >                                                     _ → p in
+out >                                             case j of
+out >                                               Issue7595.Cell.[o] →
+out >                                                 case k of
+out >                                                   Issue7595.Cell.[o] →
+out >                                                     Agda.Builtin.Maybe.Maybe.just k
+out >                                                   _ → r
+out >                                               _ → r in
+out >                                       case h of
+out >                                         Issue7595.Cell.[o] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → q
+out >                                         _ → q
+out >                                     Issue7595.Cell.[x] →
+out >                                       case j of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → p in
+out >                             case f of
+out >                               Issue7595.Cell.[o] →
+out >                                 let p =
+out >                                       case h of
+out >                                         Issue7595.Cell.[o] →
+out >                                           let q =
+out >                                                 case g of
+out >                                                   Issue7595.Cell.[o] →
+out >                                                     Agda.Builtin.Maybe.Maybe.just g
+out >                                                   _ → o in
+out >                                           case k of
+out >                                             Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → q
+out >                                         _ → o in
+out >                                 case i of
+out >                                   Issue7595.Cell.[x] →
+out >                                     case j of
+out >                                       Issue7595.Cell.[x] →
+out >                                         case k of
+out >                                           Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                           _ → p
+out >                                       _ → p
+out >                                   _ → p
+out >                               Issue7595.Cell.[x] →
+out >                                 case g of
+out >                                   Issue7595.Cell.[x] →
+out >                                     case h of
+out >                                       Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just h
+out >                                       _ → o
+out >                                   _ → o
+out >                               _ → o
+out >                           Issue7595.Cell.[x] →
+out >                             let o =
+out >                                   case i of
+out >                                     Issue7595.Cell.[x] →
+out >                                       let p =
+out >                                             case g of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just g
+out >                                               _ → n in
+out >                                       case j of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → n in
+out >                             case h of
+out >                               Issue7595.Cell.[x] →
+out >                                 let p =
+out >                                       case f of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case g of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just g
+out >                                             _ → o
+out >                                         _ → o in
+out >                                 case k of
+out >                                   Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                   _ → p
+out >                               _ → o
+out >                           _ → n
+out >                       Issue7595.Cell.[o] →
+out >                         let n =
+out >                               let o =
+out >                                     let p =
+out >                                           case g of
+out >                                             Issue7595.Cell.[o] →
+out >                                               case j of
+out >                                                 Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just j
+out >                                                 _ → m
+out >                                             _ → m in
+out >                                     case i of
+out >                                       Issue7595.Cell.[x] →
+out >                                         case j of
+out >                                           Issue7595.Cell.[x] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       _ → p in
+out >                               case f of
+out >                                 Issue7595.Cell.[x] →
+out >                                   case g of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case h of
+out >                                         Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just h
+out >                                         _ → o
+out >                                     _ → o
+out >                                 _ → o in
+out >                         case e of
+out >                           Issue7595.Cell.[x] →
+out >                             let o =
+out >                                   case i of
+out >                                     Issue7595.Cell.[x] →
+out >                                       let p =
+out >                                             case g of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just g
+out >                                               _ → n in
+out >                                       case j of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → n in
+out >                             case h of
+out >                               Issue7595.Cell.[x] →
+out >                                 let p =
+out >                                       case f of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case g of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just g
+out >                                             _ → o
+out >                                         _ → o in
+out >                                 case k of
+out >                                   Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                   _ → p
+out >                               _ → o
+out >                           _ → n
+out >                       Issue7595.Cell.[x] →
+out >                         case g of
+out >                           Issue7595.Cell.[x] →
+out >                             case j of
+out >                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just j
+out >                               _ → m
+out >                           _ → m in
+out >               case c of
+out >                 Issue7595.Cell.[-] →
+out >                   let m =
+out >                         let n =
+out >                               let o =
+out >                                     let p = Agda.Builtin.Maybe.Maybe.nothing in
+out >                                     case i of
+out >                                       Issue7595.Cell.[o] →
+out >                                         case j of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       Issue7595.Cell.[x] →
+out >                                         case j of
+out >                                           Issue7595.Cell.[x] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       _ → p in
+out >                               case f of
+out >                                 Issue7595.Cell.[o] →
+out >                                   let p =
+out >                                         case g of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case h of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just h
+out >                                               _ → o
+out >                                           _ → o in
+out >                                   case i of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case j of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → p
+out >                                 Issue7595.Cell.[x] →
+out >                                   case g of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case h of
+out >                                         Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just h
+out >                                         _ → o
+out >                                     _ → o
+out >                                 _ → o in
+out >                         case e of
+out >                           Issue7595.Cell.[o] →
+out >                             let o =
+out >                                   let p =
+out >                                         case h of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → n
+out >                                           _ → n in
+out >                                   case i of
+out >                                     Issue7595.Cell.[o] →
+out >                                       let q =
+out >                                             let r =
+out >                                                   case g of
+out >                                                     Issue7595.Cell.[o] →
+out >                                                       Agda.Builtin.Maybe.Maybe.just g
+out >                                                     _ → p in
+out >                                             case j of
+out >                                               Issue7595.Cell.[o] →
+out >                                                 case k of
+out >                                                   Issue7595.Cell.[o] →
+out >                                                     Agda.Builtin.Maybe.Maybe.just k
+out >                                                   _ → r
+out >                                               _ → r in
+out >                                       case h of
+out >                                         Issue7595.Cell.[o] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → q
+out >                                         _ → q
+out >                                     Issue7595.Cell.[x] →
+out >                                       case j of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → p in
+out >                             case f of
+out >                               Issue7595.Cell.[o] →
+out >                                 let p =
+out >                                       case h of
+out >                                         Issue7595.Cell.[o] →
+out >                                           let q =
+out >                                                 case g of
+out >                                                   Issue7595.Cell.[o] →
+out >                                                     Agda.Builtin.Maybe.Maybe.just g
+out >                                                   _ → o in
+out >                                           case k of
+out >                                             Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → q
+out >                                         _ → o in
+out >                                 case i of
+out >                                   Issue7595.Cell.[x] →
+out >                                     case j of
+out >                                       Issue7595.Cell.[x] →
+out >                                         case k of
+out >                                           Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                           _ → p
+out >                                       _ → p
+out >                                   _ → p
+out >                               Issue7595.Cell.[x] →
+out >                                 case g of
+out >                                   Issue7595.Cell.[x] →
+out >                                     case h of
+out >                                       Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just h
+out >                                       _ → o
+out >                                   _ → o
+out >                               _ → o
+out >                           Issue7595.Cell.[x] →
+out >                             let o =
+out >                                   case i of
+out >                                     Issue7595.Cell.[x] →
+out >                                       let p =
+out >                                             case g of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just g
+out >                                               _ → n in
+out >                                       case j of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → n in
+out >                             case h of
+out >                               Issue7595.Cell.[x] →
+out >                                 let p =
+out >                                       case f of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case g of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just g
+out >                                             _ → o
+out >                                         _ → o in
+out >                                 case k of
+out >                                   Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                   _ → p
+out >                               _ → o
+out >                           _ → n in
+out >                   case d of
+out >                     Issue7595.Cell.[o] →
+out >                       let n =
+out >                             let o =
+out >                                   let p =
+out >                                         case g of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case j of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just j
+out >                                               _ → m
+out >                                           _ → m in
+out >                                   case i of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case j of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → p in
+out >                             case f of
+out >                               Issue7595.Cell.[x] →
+out >                                 case g of
+out >                                   Issue7595.Cell.[x] →
+out >                                     case h of
+out >                                       Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just h
+out >                                       _ → o
+out >                                   _ → o
+out >                               _ → o in
+out >                       case e of
+out >                         Issue7595.Cell.[x] →
+out >                           let o =
+out >                                 case i of
+out >                                   Issue7595.Cell.[x] →
+out >                                     let p =
+out >                                           case g of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just g
+out >                                             _ → n in
+out >                                     case j of
+out >                                       Issue7595.Cell.[x] →
+out >                                         case k of
+out >                                           Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                           _ → p
+out >                                       _ → p
+out >                                   _ → n in
+out >                           case h of
+out >                             Issue7595.Cell.[x] →
+out >                               let p =
+out >                                     case f of
+out >                                       Issue7595.Cell.[x] →
+out >                                         case g of
+out >                                           Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just g
+out >                                           _ → o
+out >                                       _ → o in
+out >                               case k of
+out >                                 Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                 _ → p
+out >                             _ → o
+out >                         _ → n
+out >                     Issue7595.Cell.[x] →
+out >                       case g of
+out >                         Issue7595.Cell.[x] →
+out >                           case j of
+out >                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just j
+out >                             _ → m
+out >                         _ → m
+out >                     _ → m
+out >                 Issue7595.Cell.[o] →
+out >                   let m =
+out >                         let n =
+out >                               let o =
+out >                                     let p =
+out >                                           case g of
+out >                                             Issue7595.Cell.[o] →
+out >                                               case k of
+out >                                                 Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                                 _ → l
+out >                                             _ → l in
+out >                                     case i of
+out >                                       Issue7595.Cell.[o] →
+out >                                         case j of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       Issue7595.Cell.[x] →
+out >                                         case j of
+out >                                           Issue7595.Cell.[x] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       _ → p in
+out >                               case f of
+out >                                 Issue7595.Cell.[o] →
+out >                                   let p =
+out >                                         case g of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case h of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just h
+out >                                               _ → o
+out >                                           _ → o in
+out >                                   case i of
+out >                                     Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just i
+out >                                     Issue7595.Cell.[x] →
+out >                                       case j of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → p
+out >                                 Issue7595.Cell.[x] →
+out >                                   case g of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case h of
+out >                                         Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just h
+out >                                         _ → o
+out >                                     _ → o
+out >                                 _ → o in
+out >                         case e of
+out >                           Issue7595.Cell.[o] →
+out >                             let o =
+out >                                   let p =
+out >                                         case h of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → n
+out >                                           _ → n in
+out >                                   case i of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case j of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → p in
+out >                             case f of
+out >                               Issue7595.Cell.[o] →
+out >                                 case i of
+out >                                   Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just i
+out >                                   Issue7595.Cell.[x] →
+out >                                     case j of
+out >                                       Issue7595.Cell.[x] →
+out >                                         case k of
+out >                                           Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                           _ → o
+out >                                       _ → o
+out >                                   _ → o
+out >                               Issue7595.Cell.[x] →
+out >                                 case g of
+out >                                   Issue7595.Cell.[x] →
+out >                                     case h of
+out >                                       Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just h
+out >                                       _ → o
+out >                                   _ → o
+out >                               _ → o
+out >                           Issue7595.Cell.[x] →
+out >                             let o =
+out >                                   case i of
+out >                                     Issue7595.Cell.[x] →
+out >                                       let p =
+out >                                             case g of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just g
+out >                                               _ → n in
+out >                                       case j of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → n in
+out >                             case h of
+out >                               Issue7595.Cell.[x] →
+out >                                 let p =
+out >                                       case f of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case g of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just g
+out >                                             _ → o
+out >                                         _ → o in
+out >                                 case k of
+out >                                   Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                   _ → p
+out >                               _ → o
+out >                           _ → n in
+out >                   case d of
+out >                     Issue7595.Cell.[o] →
+out >                       let n =
+out >                             let o =
+out >                                   let p =
+out >                                         case g of
+out >                                           Issue7595.Cell.[o] →
+out >                                             case j of
+out >                                               Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just j
+out >                                               _ → m
+out >                                           _ → m in
+out >                                   case i of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case j of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → p in
+out >                             case f of
+out >                               Issue7595.Cell.[o] →
+out >                                 case i of
+out >                                   Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just i
+out >                                   Issue7595.Cell.[x] →
+out >                                     case j of
+out >                                       Issue7595.Cell.[x] →
+out >                                         case k of
+out >                                           Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                           _ → o
+out >                                       _ → o
+out >                                   _ → o
+out >                               Issue7595.Cell.[x] →
+out >                                 case g of
+out >                                   Issue7595.Cell.[x] →
+out >                                     case h of
+out >                                       Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just h
+out >                                       _ → o
+out >                                   _ → o
+out >                               _ → o in
+out >                       case e of
+out >                         Issue7595.Cell.[o] →
+out >                           let o =
+out >                                 let p =
+out >                                       let q =
+out >                                             let r = Agda.Builtin.Maybe.Maybe.just e in
+out >                                             case h of
+out >                                               Issue7595.Cell.[o] →
+out >                                                 case k of
+out >                                                   Issue7595.Cell.[o] →
+out >                                                     Agda.Builtin.Maybe.Maybe.just k
+out >                                                   _ → r
+out >                                               _ → r in
+out >                                       case g of
+out >                                         Issue7595.Cell.[o] →
+out >                                           case j of
+out >                                             Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just j
+out >                                             _ → q
+out >                                         _ → q in
+out >                                 case i of
+out >                                   Issue7595.Cell.[x] →
+out >                                     case j of
+out >                                       Issue7595.Cell.[x] →
+out >                                         case k of
+out >                                           Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                           _ → p
+out >                                       _ → p
+out >                                   _ → p in
+out >                           case f of
+out >                             Issue7595.Cell.[o] →
+out >                               case i of
+out >                                 Issue7595.Cell.[o] → Agda.Builtin.Maybe.Maybe.just i
+out >                                 Issue7595.Cell.[x] →
+out >                                   case j of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case k of
+out >                                         Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                         _ → o
+out >                                     _ → o
+out >                                 _ → o
+out >                             Issue7595.Cell.[x] →
+out >                               case g of
+out >                                 Issue7595.Cell.[x] →
+out >                                   case h of
+out >                                     Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just h
+out >                                     _ → o
+out >                                 _ → o
+out >                             _ → o
+out >                         Issue7595.Cell.[x] →
+out >                           let o =
+out >                                 case i of
+out >                                   Issue7595.Cell.[x] →
+out >                                     let p =
+out >                                           case g of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just g
+out >                                             _ → n in
+out >                                     case j of
+out >                                       Issue7595.Cell.[x] →
+out >                                         case k of
+out >                                           Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                           _ → p
+out >                                       _ → p
+out >                                   _ → n in
+out >                           case h of
+out >                             Issue7595.Cell.[x] →
+out >                               let p =
+out >                                     case f of
+out >                                       Issue7595.Cell.[x] →
+out >                                         case g of
+out >                                           Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just g
+out >                                           _ → o
+out >                                       _ → o in
+out >                               case k of
+out >                                 Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                 _ → p
+out >                             _ → o
+out >                         _ → n
+out >                     Issue7595.Cell.[x] →
+out >                       case g of
+out >                         Issue7595.Cell.[x] →
+out >                           case j of
+out >                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just j
+out >                             _ → m
+out >                         _ → m
+out >                     _ → m
+out >                 Issue7595.Cell.[x] →
+out >                   let m =
+out >                         let n =
+out >                               let o =
+out >                                     let p =
+out >                                           case g of
+out >                                             Issue7595.Cell.[x] →
+out >                                               case k of
+out >                                                 Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                                 _ → l
+out >                                             _ → l in
+out >                                     case i of
+out >                                       Issue7595.Cell.[x] →
+out >                                         case j of
+out >                                           Issue7595.Cell.[x] →
+out >                                             case k of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                               _ → p
+out >                                           _ → p
+out >                                       _ → p in
+out >                               case e of
+out >                                 Issue7595.Cell.[x] →
+out >                                   case h of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case k of
+out >                                         Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                         _ → o
+out >                                     _ → o
+out >                                 _ → o in
+out >                         case d of
+out >                           Issue7595.Cell.[x] →
+out >                             let o =
+out >                                   case e of
+out >                                     Issue7595.Cell.[x] →
+out >                                       let p = Agda.Builtin.Maybe.Maybe.just e in
+out >                                       case h of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → n in
+out >                             case g of
+out >                               Issue7595.Cell.[x] →
+out >                                 case j of
+out >                                   Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just j
+out >                                   _ → o
+out >                               _ → o
+out >                           _ → n in
+out >                   case f of
+out >                     Issue7595.Cell.[x] →
+out >                       let n =
+out >                             let o =
+out >                                   let p =
+out >                                         case g of
+out >                                           Issue7595.Cell.[x] →
+out >                                             case h of
+out >                                               Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just h
+out >                                               _ → m
+out >                                           _ → m in
+out >                                   case e of
+out >                                     Issue7595.Cell.[x] →
+out >                                       case h of
+out >                                         Issue7595.Cell.[x] →
+out >                                           case k of
+out >                                             Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                             _ → p
+out >                                         _ → p
+out >                                     _ → p in
+out >                             case d of
+out >                               Issue7595.Cell.[x] →
+out >                                 let p =
+out >                                       case e of
+out >                                         Issue7595.Cell.[x] →
+out >                                           let q = Agda.Builtin.Maybe.Maybe.just e in
+out >                                           case h of
+out >                                             Issue7595.Cell.[x] →
+out >                                               case k of
+out >                                                 Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just k
+out >                                                 _ → q
+out >                                             _ → q
+out >                                         _ → o in
+out >                                 case g of
+out >                                   Issue7595.Cell.[x] →
+out >                                     case j of
+out >                                       Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just j
+out >                                       _ → p
+out >                                   _ → p
+out >                               _ → o in
+out >                       case i of
+out >                         Issue7595.Cell.[x] → Agda.Builtin.Maybe.Maybe.just i
+out >                         _ → n
+out >                     _ → m in
+out >     case b of
+out >       Agda.Builtin.Maybe.Maybe.just _ → a
+out >       Agda.Builtin.Maybe.Maybe.nothing → Issue7595.b0
+out > -- simplification (No effect)
+out >


### PR DESCRIPTION
This is a non-LLM generated version of #8631.

There are unfortunately a few regressions in the compiler tests, but I'm not sure if we should care about those. I feel like some of the optimizations done in `Simplify.hs` is more for proof of concept rather than important optimizations that should trigger on a wide set of programs. Some of the optimizations should also rather be performed in later stages of the compiler (or in GHC for MAlonzo). CC @UlfNorell since you wrote the code / tests.    

Fixes #7595 