### PR TITLE
Repair `nix build`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,7 @@
               agdaExe=''${bin:-$out}/bin/agda
 
               echo "Generating Agda core library interface files..."
-              (cd "$("$agdaExe" --print-agda-data-dir)/lib/prim" && "$agdaExe" --build-library)
+              (cd "$("$agdaExe" --print-agda-data-dir)/lib/prim" && find . -name '*.agda' | while read f; do "$agdaExe" $f; done)
             '';
           });
         };


### PR DESCRIPTION
By pre-compiling the builtins with a different command.

This is *not* a fix for #8627: `--build-library` still fails on the builtin library.
