### PR TITLE
Allow deepseq-1.5.2.0 (warns about rnf for functions)

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -7478,7 +7478,10 @@ instance NFData Statistics
 instance NFData UnusedImportsState
 instance NFData OpenedModule
 instance NFData IsAxiom
-instance NFData SessionState
+
+instance NFData SessionState where
+  rnf (SessionState backends fileDict moduleToSourceId _interactionCallback) =
+    rnf backends `seq` rnf fileDict `seq` rnf moduleToSourceId
 
 instance NFData PrimFun where
   rnf (PrimFun a b c _fun) =


### PR DESCRIPTION
This is needed for GHC 9.14.2-RC1 ( 9.14.1.20260728 ).