### PR TITLE
Fix #8644: disable Issue6492 sans -fdebug

### DIFF
--- a/test/Fail/Tests.hs
+++ b/test/Fail/Tests.hs
@@ -122,6 +122,7 @@ fdebugTestFilter =
   , disable "Fail/Issue4175"
   , disable "Fail/Issue641"
   , disable "Fail/Issue641-all-interfaces"
+  , disable "Fail/Issue6492"
   ]
   where disable = RFInclude
 


### PR DESCRIPTION
Issue6492's golden output contains debug lines that are only valid when the agda was built with the `debug` flag. So iiuc it should be added to the `fdebugTestFilter` list which disables tests that are skipped unless the `debug` flag was set. It was missing from that list, and thus causing me a bunch of spurious errors when I tried to run the test suite using optimized builds.

(FYI I used an AI to diagnose the problem and identify the fix. Idk if
y'all have a disclosure policy around that sort of thing and I only
recently became aware that opinions seem split among the dev team; I
don't want to be clandestine about it. I personally stand behind any
actual code I submit as a PR, obv.)