### PR TITLE
Fix `COMPILE JS _∷_`

### DIFF
--- a/doc/user-manual/language/foreign-function-interface.lagda.rst
+++ b/doc/user-manual/language/foreign-function-interface.lagda.rst
@@ -356,4 +356,4 @@ code for the ``List`` type, compiling lists to JavaScript arrays::
       }
     } #-}
   {-# COMPILE JS []  = Array() #-}
-  {-# COMPILE JS _∷_ = function (x) { return function(y) { return Array(x).concat(y); }; } #-}
+  {-# COMPILE JS _∷_ = function (x) { return function(y) { return [x].concat(y); }; } #-}

--- a/src/data/lib/prim/Agda/Builtin/List.agda
+++ b/src/data/lib/prim/Agda/Builtin/List.agda
@@ -13,4 +13,4 @@ data List {a} (A : Set a) : Set a where
   if (x.length < 1) { return v["[]"](); } else { return v["_∷_"](x[0], x.slice(1)); }
 } #-}
 {-# COMPILE JS [] = Array() #-}
-{-# COMPILE JS _∷_ = function (x) { return function(y) { return Array(x).concat(y); }; } #-}
+{-# COMPILE JS _∷_ = function (x) { return function(y) { return [x].concat(y); }; } #-}

--- a/test/Compiler/simple/Issue8639.agda
+++ b/test/Compiler/simple/Issue8639.agda
@@ -1,0 +1,8 @@
+
+open import Common.IO
+open import Common.List
+
+s = 95.0 ∷ []
+
+main = printNat (length s)
+

--- a/test/Compiler/simple/Issue8639.out
+++ b/test/Compiler/simple/Issue8639.out
@@ -1,0 +1,4 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > 1


### PR DESCRIPTION
This PR makes the JS backend correctly compile `_∷_`, even for lists containing floats.

Tested locally with `nix build .#compiler-test`.

Closes #8639
