### PR TITLE
Fix for #8636

### DIFF
--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -421,15 +421,23 @@ compareTerm' !cmp !a !m !n =
 
                  | otherwise -> do
                     whenProfile Profile.Conversion $ tick "compare at eta-record: eta-expanding"
-                    (tel, m') <- etaExpandRecord r ps $ ignoreBlocking m
-                    (_  , n') <- etaExpandRecord r ps $ ignoreBlocking n
-                    -- No subtyping on record terms
-                    c <- getRecordConstructor r
-                    -- Record constructors are covariant (see test/succeed/CovariantConstructors).
-                    compareArgs (repeat $ polFromCmp cmp) []
-                      (telePi_ tel (raise (size tel) a'))
-                      (Con c ConOSystem [])
-                      m' n'
+                    mm' <- etaExpandRecord r ps $ ignoreBlocking m
+                    nn' <- etaExpandRecord r ps $ ignoreBlocking n
+                    case (mm', nn') of
+                      (Just (tel, m'), Just (_, n')) -> do
+                        -- No subtyping on record terms
+                        c <- getRecordConstructor r
+                        -- Record constructors are covariant (see test/succeed/CovariantConstructors).
+                        compareArgs (repeat $ polFromCmp cmp) []
+                          (telePi_ tel (raise (size tel) a'))
+                          (Con c ConOSystem [])
+                          m' n'
+                      -- Issue #8636: Eta-expansion may fail if a term is a
+                      -- constructor of a different (but possibly definitionally
+                      -- equal under unsolvable constraints) record type. In that
+                      -- case we fall back to atomic comparison, which will produce a
+                      -- proper conversion error rather than crashing.
+                      _ -> compareAtom cmp (AsTermsOf a') (ignoreBlocking m) (ignoreBlocking n)
 
             else ret do pathview <- pathView a'
                         equalPath pathview a' m n

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -190,16 +190,19 @@ initialInstanceCandidates blockOverlap instTy = do
       let n = size piTel
       addContext piTel $ caseMaybeM (etaExpand etaOnce t') (return []) $ \ (r, pars) -> do
         let v' = raise n v `apply` teleArgs piTel
-        (tel, args) <- lift $ forceEtaExpandRecord r pars v'
-        let types = map' unDom $ applySubst (parallelS $ reverse $ map' unArg args) (flattenTel tel)
-        fmap concat $ forM (zip' args types) $ \ (arg, t) -> do
-          let
-            absArg = abstract piTel (unArg arg)
-            absTy = telePi piTel t
-          ([ Candidate LocalCandidate absArg absTy (infoOverlapMode arg)
-            | isInstance arg
-            ] ++) <$>
-           instanceFields' False (LocalCandidate, absArg, absTy)
+        mtelargs <- lift $ forceEtaExpandRecord r pars v'
+        case mtelargs of
+          Nothing -> return [] -- Issue #8636: cannot eta-expand the value at this record type
+          Just (tel, args) -> do
+            let types = map' unDom $ applySubst (parallelS $ reverse $ map' unArg args) (flattenTel tel)
+            fmap concat $ forM (zip' args types) $ \ (arg, t) -> do
+              let
+                absArg = abstract piTel (unArg arg)
+                absTy = telePi piTel t
+              ([ Candidate LocalCandidate absArg absTy (infoOverlapMode arg)
+                | isInstance arg
+                ] ++) <$>
+               instanceFields' False (LocalCandidate, absArg, absTy)
 
     -- Compute whether we should block this instance constraint at the
     -- discrimination tree stage.

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1657,36 +1657,6 @@ etaExpandProjectedVar mvar x t n qs = inTopContext $ do
   patternViolation
 -}
 
-{-
-  -- first, strip the leading n domains (which remain unchanged)
-  TelV gamma core <- telViewUpTo n t
-  case unEl core of
-    -- There should be at least one domain left
-    Pi (Dom ai a) b -> do
-      -- Eta-expand @dom@ along @qs@ into a telescope @tel@, computing a substitution.
-      -- For now, we only eta-expand once.
-      -- This might trigger another call to @etaExpandProjectedVar@ later.
-      -- A more efficient version does all the eta-expansions at once here.
-      (r, pars, def) <- fromMaybe __IMPOSSIBLE__ <$> isRecordType a
-      unless (recEtaEquality def) __IMPOSSIBLE__
-      let tel = recTel def `apply` pars
-          m   = size tel
-          v   = Con (recConHead def) $ map' var $ downFrom m
-          b'  = raise m b `absApp` v
-          fs  = recFields def
-          vs  = zipWith' (\ f i -> Var i [Proj f]) fs $ downFrom m
-          -- v = c (n-1) ... 1 0
-      (tel, u) <- etaExpandAtRecordType a $ var 0
-      -- TODO: compose argInfo ai with tel.
-      -- Substitute into @b@.
-      -- Abstract over @tel@.
-      -- Abstract over @gamma@.
-      -- Create new meta.
-      -- Solve old meta, using substitution.
-      patternViolation
-    _ -> __IMPOSSIBLE__
--}
-
 type FVs = VarSet
 type SubstCand = [(Int,Term)] -- ^ a possibly non-deterministic substitution
 

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -679,8 +679,9 @@ etaExpandRecord :: (HasConstInfo m)
   => QName       -- ^ Name of record type.
   -> Args        -- ^ Parameters applied to record type.
   -> Term        -- ^ Term to eta-expand.
-  -> m (Telescope, Args)
+  -> m (Maybe (Telescope, Args))
      -- ^ Field types instantiated to parameters, field values.
+     --   'Nothing' if the term is a constructor of a different record type.
 etaExpandRecord = etaExpandRecord' False
 
 -- | Eta expand a record regardless of whether it's an eta-record or not.
@@ -688,42 +689,45 @@ forceEtaExpandRecord :: (HasConstInfo m)
   => QName       -- ^ Name of record type.
   -> Args        -- ^ Parameters applied to record type.
   -> Term        -- ^ Term to eta-expand.
-  -> m (Telescope, Args)
+  -> m (Maybe (Telescope, Args))
      -- ^ Field types instantiated to parameters, field values.
+     --   'Nothing' if the term is a constructor of a different record type.
 forceEtaExpandRecord = etaExpandRecord' True
 
--- | Eta-expand a value at the given record type (must match).
+-- | Eta-expand a value at the given record type.
 etaExpandRecord' :: (HasConstInfo m)
   => Bool        -- ^ Force expansion, overriding '_recEtaEquality'?
   -> QName       -- ^ Name of record type.
   -> Args        -- ^ Parameters applied to record type.
   -> Term        -- ^ Term to eta-expand.
-  -> m (Telescope, Args)
+  -> m (Maybe (Telescope, Args))
      -- ^ Field types instantiated to parameters, field values.
+     --   'Nothing' if the term is a constructor of a different record type.
 etaExpandRecord' forceEta r pars u = do
   def <- fromMaybe __IMPOSSIBLE__ <$> isRecord r
-  (tel, _, _, args) <- etaExpandRecord'_ forceEta r pars def u
-  return (tel, args)
+  fmap (\(tel, _, _, args) -> (tel, args)) <$> etaExpandRecord'_ forceEta r pars def u
 
--- | Eta-expand a value at the given eta record type (must match).
+-- | Eta-expand a value at the given eta record type.
 etaExpandRecord_ :: HasConstInfo m
   => QName       -- ^ Name of record type.
   -> Args        -- ^ Parameters applied to record type.
   -> RecordData  -- ^ Definition of record type.
   -> Term        -- ^ Term to eta-expand.
-  -> m (Telescope, ConHead, ConInfo, Args)
+  -> m (Maybe (Telescope, ConHead, ConInfo, Args))
      -- ^ Field types instantiated to parameters, disassembled constructor term.
+     --   'Nothing' if the term is a constructor of a different record type.
 etaExpandRecord_ = etaExpandRecord'_ False
 
--- | Eta-expand a value at the given record type (must match).
+-- | Eta-expand a value at the given record type.
 etaExpandRecord'_ :: HasConstInfo m
   => Bool        -- ^ Force expansion, overriding '_recEtaEquality'?
   -> QName       -- ^ Name of record type.
   -> Args        -- ^ Parameters applied to record type.
   -> RecordData  -- ^ Definition of record type.
   -> Term        -- ^ Term to eta-expand.
-  -> m (Telescope, ConHead, ConInfo, Args)
+  -> m (Maybe (Telescope, ConHead, ConInfo, Args))
      -- ^ Field types instantiated to parameters, disassembled constructor term.
+     --   'Nothing' if the term is a constructor of a different record type.
 etaExpandRecord'_ forceEta r pars
     def@RecordData{ _recConHead = con, _recFields = xs, _recTel = tel }
     u = do
@@ -737,14 +741,22 @@ etaExpandRecord'_ forceEta r pars
       let args = mustAllApplyElims es
       -- Andreas, 2019-10-21, issue #4148
       -- @con == con_@ might fail, but their normal forms should be equal.
-      whenNothingM (conName con `sameDef` conName con_) $ do
-        reportSDoc "impossible" 10 $ vcat
-          [ "etaExpandRecord_: the following two constructors should be identical"
-          , nest 2 $ text $ "con  = " ++ prettyShow con
-          , nest 2 $ text $ "con_ = " ++ prettyShow con_
-          ]
-        __IMPOSSIBLE__
-      return (tel', con, ci, args)
+      mc <- conName con `sameDef` conName con_
+      case mc of
+        Nothing -> do
+          -- Jesper, 2026-08-05, issue #8636: The term is a constructor of a
+          -- different record type. This can legitimately happen e.g. when a meta
+          -- of one singleton record type is (tentatively) solved with the constructor
+          -- of another (definitionally equal under unsolvable constraints) one.
+          -- Rather than crashing, we report this and let the caller decide how to
+          -- proceed (e.g. by falling back to atomic comparison).
+          reportSDoc "tc.record.eta" 20 $ vcat
+            [ "etaExpandRecord_: the term's constructor does not match the record type"
+            , nest 2 $ text $ "con  = " ++ prettyShow con
+            , nest 2 $ text $ "con_ = " ++ prettyShow con_
+            ]
+          return Nothing
+        Just _ -> return $ Just (tel', con, ci, args)
 
     -- Not yet expanded.
     _ -> do
@@ -758,13 +770,15 @@ etaExpandRecord'_ forceEta r pars
           , "args =" <+> prettyTCM xs'
           ]
         ]
-      return (tel', con, ConOSystem, xs')
+      return $ Just (tel', con, ConOSystem, xs')
 
-etaExpandAtRecordType :: Type -> Term -> TCM (Telescope, Term)
+etaExpandAtRecordType :: Type -> Term -> TCM (Maybe (Telescope, Term))
 etaExpandAtRecordType t u = do
   (r, pars, def) <- fromMaybe __IMPOSSIBLE__ <$> isRecordType t
-  (tel, con, ci, args) <- etaExpandRecord_ r pars def u
-  return (tel, mkCon con ci args)
+  mtelargs <- etaExpandRecord_ r pars def u
+  case mtelargs of
+    Nothing -> return Nothing
+    Just (tel, con, ci, args) -> return $ Just (tel, mkCon con ci args)
 
 -- | The fields should be eta contracted already.
 --

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -772,14 +772,6 @@ etaExpandRecord'_ forceEta r pars
         ]
       return $ Just (tel', con, ConOSystem, xs')
 
-etaExpandAtRecordType :: Type -> Term -> TCM (Maybe (Telescope, Term))
-etaExpandAtRecordType t u = do
-  (r, pars, def) <- fromMaybe __IMPOSSIBLE__ <$> isRecordType t
-  mtelargs <- etaExpandRecord_ r pars def u
-  case mtelargs of
-    Nothing -> return Nothing
-    Just (tel, con, ci, args) -> return $ Just (tel, mkCon con ci args)
-
 -- | The fields should be eta contracted already.
 --
 --   We can eta contract if all fields @f = ...@ are irrelevant

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -282,69 +282,74 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
         -- If the second rewrite rule has more eliminations than the
         -- subpattern of the first rule, the only chance of overlap is
         -- by eta-expanding the subpattern of the first rule.
-        hole1 <- addContext bvTel0 $
+        mhole1 <- addContext bvTel0 $
           forceEtaExpansion b0 (hdg es0) $ drop (size es0) qs2
 
-        verboseS "rewriting.confluence.eta" 30 $
-          unless (size es0 == size qs2) $
-          addContext bvTel0 $
-          reportSDoc "rewriting.confluence.eta" 30 $ vcat
-            [ "forceEtaExpansion result:"
-            , nest 2 $ "bound vars: " <+> prettyTCM (ohBoundVars hole1)
-            , nest 2 $ "hole contents: " <+> addContext (ohBoundVars hole1) (prettyTCM $ ohContents hole1)
+        -- Issue #8636: If eta-expansion is not possible (e.g. the subpattern
+        -- is a constructor of a different record type), we cannot check this
+        -- potential overlap, so we skip it.
+        whenJust mhole1 $ \hole1 -> do
+
+          verboseS "rewriting.confluence.eta" 30 $
+            unless (size es0 == size qs2) $
+            addContext bvTel0 $
+            reportSDoc "rewriting.confluence.eta" 30 $ vcat
+              [ "forceEtaExpansion result:"
+              , nest 2 $ "bound vars: " <+> prettyTCM (ohBoundVars hole1)
+              , nest 2 $ "hole contents: " <+> addContext (ohBoundVars hole1) (prettyTCM $ ohContents hole1)
+              ]
+
+          let hole      = hole1 `composeHole` hole0
+              g         = ohHeadName hole -- == grHead rew2
+              es'       = ohElims hole
+              bvTel     = ohBoundVars hole
+              plug      = ohPlugHole hole
+
+          sub2 <- addContext bvTel $ makeMetaSubst $ grContext rew2
+
+          let es1 = applySubst (liftS (size bvTel) sub1) es'
+          es2 <- applySubst sub2 <$> nlPatToTerm (grPats rew2)
+
+          -- Make sure we are comparing eliminations with the same arity
+          -- (see #3810). Because we forced eta-expansion of es1, we
+          -- know that it is at least as long as es2.
+          when (size es1 < size es2) __IMPOSSIBLE__
+          let n = size es2
+              (es1' , es1r) = splitAt n es1
+
+          let lhs1 = applySubst sub1 $ hdf $ plug $ hdg es1
+              lhs2 = applySubst sub1 $ hdf $ plug $ hdg $ es2 ++! es1r
+              a    = applySubst sub1 $ grType rew1
+
+          reportSDoc "rewriting.confluence" 20 $ sep
+            [ "Considering potential critical pair at subpattern: "
+            , nest 2 $ prettyTCM $ lhs1 , " =?= "
+            , nest 2 $ prettyTCM $ lhs2 , " : " , nest 2 $ prettyTCM a
             ]
 
-        let hole      = hole1 `composeHole` hole0
-            g         = ohHeadName hole -- == grHead rew2
-            es'       = ohElims hole
-            bvTel     = ohBoundVars hole
-            plug      = ohPlugHole hole
+          maybeCriticalPair <- tryUnification lhs1 lhs2 $ do
+            -- Unify the subpattern of the first rewrite rule with the lhs
+            -- of the second one
+            ga   <- defType <$> getConstInfo g
+            gpol <- getPolarity' CmpEq g
+            onlyReduceTypes $ addContext bvTel $
+              compareElims gpol [] ga (hdg []) es1' es2
 
-        sub2 <- addContext bvTel $ makeMetaSubst $ grContext rew2
+            -- Right-hand side of first rewrite rule (after unification)
+            let rhs1 = applySubst sub1 $ grRHS rew1
 
-        let es1 = applySubst (liftS (size bvTel) sub1) es'
-        es2 <- applySubst sub2 <$> nlPatToTerm (grPats rew2)
+            -- Left-hand side of first rewrite rule, with subpattern
+            -- rewritten by the second rewrite rule
+            let w = applySubst sub2 (grRHS rew2) `applyE` es1r
+            reportSDoc "rewriting.confluence" 30 $ sep
+              [ "Plugging hole with w = "
+              , nest 2 $ addContext bvTel $ prettyTCM w
+              ]
+            let rhs2 = applySubst sub1 $ hdf $ plug w
 
-        -- Make sure we are comparing eliminations with the same arity
-        -- (see #3810). Because we forced eta-expansion of es1, we
-        -- know that it is at least as long as es2.
-        when (size es1 < size es2) __IMPOSSIBLE__
-        let n = size es2
-            (es1' , es1r) = splitAt n es1
+            return (rhs1 , rhs2)
 
-        let lhs1 = applySubst sub1 $ hdf $ plug $ hdg es1
-            lhs2 = applySubst sub1 $ hdf $ plug $ hdg $ es2 ++! es1r
-            a    = applySubst sub1 $ grType rew1
-
-        reportSDoc "rewriting.confluence" 20 $ sep
-          [ "Considering potential critical pair at subpattern: "
-          , nest 2 $ prettyTCM $ lhs1 , " =?= "
-          , nest 2 $ prettyTCM $ lhs2 , " : " , nest 2 $ prettyTCM a
-          ]
-
-        maybeCriticalPair <- tryUnification lhs1 lhs2 $ do
-          -- Unify the subpattern of the first rewrite rule with the lhs
-          -- of the second one
-          ga   <- defType <$> getConstInfo g
-          gpol <- getPolarity' CmpEq g
-          onlyReduceTypes $ addContext bvTel $
-            compareElims gpol [] ga (hdg []) es1' es2
-
-          -- Right-hand side of first rewrite rule (after unification)
-          let rhs1 = applySubst sub1 $ grRHS rew1
-
-          -- Left-hand side of first rewrite rule, with subpattern
-          -- rewritten by the second rewrite rule
-          let w = applySubst sub2 (grRHS rew2) `applyE` es1r
-          reportSDoc "rewriting.confluence" 30 $ sep
-            [ "Plugging hole with w = "
-            , nest 2 $ addContext bvTel $ prettyTCM w
-            ]
-          let rhs2 = applySubst sub1 $ hdf $ plug w
-
-          return (rhs1 , rhs2)
-
-        whenJust maybeCriticalPair $ uncurry (checkCriticalPair a hdf (applySubst sub1 $ plug $ hdg es1))
+          whenJust maybeCriticalPair $ uncurry (checkCriticalPair a hdf (applySubst sub1 $ plug $ hdg es1))
 
     checkCriticalPair
       :: Type     -- Type of the critical pair
@@ -726,8 +731,8 @@ allHolesList a = sequenceListT . allHoles a
 --   2. @v : _A@ and @es = [.fst]@: this will instantiate
 --      @_A := _A1 × _A2@ and return the @OneHole Term@
 --      @([v .fst]) , (v .snd)@.
-forceEtaExpansion :: Type -> Term -> [Elim' a] -> TCM (OneHole Term)
-forceEtaExpansion a v [] = return $ idHole a v
+forceEtaExpansion :: Type -> Term -> [Elim' a] -> TCM (Maybe (OneHole Term))
+forceEtaExpansion a v [] = return $ Just $ idHole a v
 forceEtaExpansion a v (e:es) = case e of
 
   Apply (Arg i w) -> do
@@ -743,7 +748,7 @@ forceEtaExpansion a v (e:es) = case e of
     let body = raise 1 v `apply` [Arg i $ var 0]
 
     -- Continue with remaining eliminations
-    addContext dom $ ohAddBV "x" dom . fmap (Lam i . mkAbs "x") <$>
+    addContext dom $ fmap (ohAddBV "x" dom . fmap (Lam i . mkAbs "x")) <$>
       forceEtaExpansion cod body es
 
   Proj o f -> do
@@ -758,18 +763,21 @@ forceEtaExpansion a v (e:es) = case e of
     equalType a $ El s (Def r $ map' Apply pars)
 
     -- Eta-expand v at record type r, and get field corresponding to f
-    (_ , c , ci , fields) <- etaExpandRecord_ r pars rdef v
-    let fs        = map' argFromDom $ _recFields rdef
-        i         = fromMaybe __IMPOSSIBLE__ $ elemIndex f $ map' unArg fs
-        fContent  = unArg $ fromMaybe __IMPOSSIBLE__ $ fields !!! i
-        fUpdate w = Con c ci $ map' Apply $ updateAt i (w <$) fields
+    mcfields <- etaExpandRecord_ r pars rdef v
+    case mcfields of
+      Nothing -> return Nothing -- Issue #8636: cannot eta-expand
+      Just (_, c, ci, fields) -> do
+        let fs        = map' argFromDom $ _recFields rdef
+            i         = fromMaybe __IMPOSSIBLE__ $ elemIndex f $ map' unArg fs
+            fContent  = unArg $ fromMaybe __IMPOSSIBLE__ $ fields !!! i
+            fUpdate w = Con c ci $ map' Apply $ updateAt i (w <$) fields
 
-    -- Get type of field corresponding to f
-    ~(Just (El _ (Pi b c))) <- getDefType f =<< reduce a
-    let fa = c `absApp` v
+        -- Get type of field corresponding to f
+        ~(Just (El _ (Pi b c))) <- getDefType f =<< reduce a
+        let fa = c `absApp` v
 
-    -- Continue with remaining eliminations
-    fmap fUpdate <$> forceEtaExpansion fa fContent es
+        -- Continue with remaining eliminations
+        fmap (fmap fUpdate) <$> forceEtaExpansion fa fContent es
 
   IApply{} -> __IMPOSSIBLE__ -- Not yet implemented
 

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -341,18 +341,21 @@ instance Match NLPat Term where
           -- type, e.g., we eta-expand both v to (c vs) and
           -- the pattern (p = PDef f ps) to @c (p .f1) ... (p .fn)@.
             RecordDefn def <- addContext k $ theDef <$> getConstInfo d
-            (tel, c, ci, vs) <- addContext k $ etaExpandRecord_ d pars def v
-            addContext k (getFullyAppliedConType c t) >>= \case
-              Just (_ , ct) -> do
-                let flds = map' argFromDom $ _recFields def
-                    mkField fld = PDef f (ps ++! [Proj ProjSystem fld])
-                    -- Issue #3335: when matching against the record constructor,
-                    -- don't add projections but take record field directly.
-                    ps'
-                      | conName c == f = ps
-                      | otherwise      = map' (Apply . fmap mkField) flds
-                match r gamma k (ct, Con c ci) ps' (map' Apply vs)
-              Nothing -> no ""
+            metelcivs <- addContext k $ etaExpandRecord_ d pars def v
+            case metelcivs of
+              Nothing -> no "" -- Issue #8636: cannot eta-expand
+              Just (tel, c, ci, vs) -> do
+                addContext k (getFullyAppliedConType c t) >>= \case
+                  Just (_ , ct) -> do
+                    let flds = map' argFromDom $ _recFields def
+                        mkField fld = PDef f (ps ++! [Proj ProjSystem fld])
+                        -- Issue #3335: when matching against the record constructor,
+                        -- don't add projections but take record field directly.
+                        ps'
+                          | conName c == f = ps
+                          | otherwise      = map' (Apply . fmap mkField) flds
+                    match r gamma k (ct, Con c ci) ps' (map' Apply vs)
+                  Nothing -> no ""
           v -> maybeBlock v
       PLam i p' -> case unEl t of
         Pi a b -> do
@@ -394,13 +397,16 @@ instance Match NLPat Term where
           match r gamma k' (absBody b) pbody body
         _ | Just (d, pars) <- etaRecord -> do
           RecordDefn def <- addContext k $ theDef <$> getConstInfo d
-          (tel, c, ci, vs) <- addContext k $ etaExpandRecord_ d pars def v
-          addContext k (getFullyAppliedConType c t) >>= \case
-            Just (_ , ct) -> do
-              let flds = map' argFromDom $ _recFields def
-                  ps'  = map' (fmap $ \fld -> PBoundVar i (ps ++! [Proj ProjSystem fld])) flds
-              match r gamma k (ct, Con c ci) (map' Apply ps') (map' Apply vs)
-            Nothing -> no ""
+          metelcivs <- addContext k $ etaExpandRecord_ d pars def v
+          case metelcivs of
+            Nothing -> no "" -- Issue #8636: cannot eta-expand
+            Just (tel, c, ci, vs) -> do
+              addContext k (getFullyAppliedConType c t) >>= \case
+                Just (_ , ct) -> do
+                  let flds = map' argFromDom $ _recFields def
+                      ps'  = map' (fmap $ \fld -> PBoundVar i (ps ++! [Proj ProjSystem fld])) flds
+                  match r gamma k (ct, Con c ci) (map' Apply ps') (map' Apply vs)
+                Nothing -> no ""
         v -> maybeBlock v
       PTerm u -> traceSDoc "rewriting.match" 60 ("matching a PTerm" <+> addContext gamma (addContext k $ prettyTCM u)) $
         -- #8231: We need to skip testing conversion if we are matching at

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -178,9 +178,12 @@ instance PatternFrom Term NLPat where
        | otherwise -> done
       (_ , _ ) | Just (d, pars) <- etaRecord -> do
         RecordDefn def <- theDef <$> getConstInfo d
-        (tel, c, ci, vs) <- etaExpandRecord_ d pars def v
-        ct <- assertConOf c t
-        PDef (conName c) <$> patternFrom r1 r1 k0 k1 (ct , Con c ci) (map Apply vs)
+        metelcivs <- etaExpandRecord_ d pars def v
+        case metelcivs of
+          Nothing -> done -- Issue #8636: cannot eta-expand
+          Just (tel, c, ci, vs) -> do
+            ct <- assertConOf c t
+            PDef (conName c) <$> patternFrom r1 r1 k0 k1 (ct , Con c ci) (map Apply vs)
       (_ , Lam{})   -> errNotPi t
       (_ , Lit{})   -> done
       -- Terms wrapped in the primRewriteNoMatch primitive are converted to PTerms

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -740,9 +740,12 @@ unifyStep s EtaExpandEquation{ expandAt = k, expandRecordType = d, expandParamet
   where
     expandKth us = do
       let (us1,v:us2) = fromMaybe __IMPOSSIBLE__ $ splitExactlyAt k us
-      vs <- snd <$> etaExpandRecord d pars (unArg v)
-      vs <- addContext (varTel s) $ reduce vs
-      return $! us1 ++! vs ++! us2
+      mvs <- etaExpandRecord d pars (unArg v)
+      case mvs of
+        Nothing -> lift $ patternViolation neverUnblock -- Issue #8636: cannot eta-expand
+        Just (_, vs) -> do
+          vs <- addContext (varTel s) $ reduce vs
+          return $! us1 ++! vs ++! us2
 
 unifyStep s LitConflict
   { litType          = a

--- a/test/Succeed/Issue8636.agda
+++ b/test/Succeed/Issue8636.agda
@@ -1,0 +1,21 @@
+-- Jesper, 2026-08-05, issue #8636 reported by Soares
+-- Internal error when an instance value is used as an index.
+
+record ⊤ : Set where constructor tt
+
+record HasSection {A : Set} (B : A → Set) : Set where
+  field section : (a : A) → B a
+open HasSection {{...}}
+
+record Fam1 (A : ⊤) : Set where
+record Fam2 (x : Fam1 tt) : Set where
+
+instance
+  HasSection[Fam1] : HasSection Fam1
+  HasSection[Fam1] .section _ = record {}
+
+  HasSection[Fam2] : HasSection Fam2
+  HasSection[Fam2] .section _ = record {}
+
+crash : Fam2 (section tt)
+crash = section (section _)


### PR DESCRIPTION
This fixes #8636 by making eta-expansion robust against the possibility that the term we're trying to eta-expand is a constructor of a different record type. Such situations might pop up in case we are under inconsistent unsolved constraints, in particular (but not just) when speculatively checking instance candidates as in the reported issue of #8636.

As an aside: this ended up being a bit more invasive than I'd expected. Alternatively we could go with the more local fix of freezing the instance meta while we're checking its candidates - but this doesn't really addresses the root of the problem afaict.

AI disclosure: assisted by GLM-5.2 for analysis and DeepSeek V4 Flash for coding (running on EU servers with renewable energy).