### PR TITLE
Fix #8655

### DIFF
--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -513,7 +513,7 @@ warningHighlighting' b w = case tcWarning w of
   RewriteMaybeNonConfluent{} -> confluenceErrorHighlighting w
   RewriteAmbiguousRules{}    -> confluenceErrorHighlighting w
   RewriteMissingRule{}       -> confluenceErrorHighlighting w
-  IllegalRewriteRule (GlobalRewrite x)  _ -> deadcodeHighlighting (defName x)
+  IllegalRewriteRule (GlobalRewrite x)    _ -> deadcodeHighlighting x
   IllegalRewriteRule (LocalRewrite _ x _) _ -> deadcodeHighlighting x
   NotARewriteRule x _        -> deadcodeHighlighting x
   InferredLocalRewrite _ _   -> mempty

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5220,7 +5220,7 @@ data Warning
     -- ^ Confluence checking with @--cubical@ might be incomplete.
   | NotARewriteRule C.QName IsAmbiguous
     -- ^ 'IllegalRewriteRule' detected during scope checking.
-  | IllegalRewriteRule RewriteSource IllegalRewriteRuleReason
+  | IllegalRewriteRule SerialisableRewriteSource IllegalRewriteRuleReason
   | RewriteNonConfluent Term Term Term Doc
     -- ^ Confluence checker found critical pair and equality checking
     --   resulted in a type error
@@ -6121,11 +6121,17 @@ data InductionAndEta = InductionAndEta
   , recordEtaEquality :: EtaEquality
   } deriving (Show, Generic)
 
--- Source of the rewrite rule
-data RewriteSource
-  = GlobalRewrite Definition
+-- | Source of the rewrite rule
+--   Parameterised by the info for global rewrite rules (it is convenient
+--   to remember the definition during checking, but when serialising we just
+--   store the 'QName')
+data RewriteSource' a
+  = GlobalRewrite a
   | LocalRewrite Context (Maybe Name) Type
-  deriving (Show, Generic)
+  deriving (Show, Generic, Functor)
+
+type RewriteSource = RewriteSource' Definition
+type SerialisableRewriteSource = RewriteSource' QName
 
 isLocalRewrite :: RewriteSource -> Bool
 isLocalRewrite (LocalRewrite g r t) = True
@@ -7452,7 +7458,7 @@ instance NFData ClashingName
 instance NFData InvalidFileNameReason
 instance NFData LHSOrPatSyn
 instance NFData InductionAndEta
-instance NFData RewriteSource
+instance NFData SerialisableRewriteSource
 instance NFData IllegalRewriteRuleReason
 instance NFData IncorrectTypeForRewriteRelationReason
 instance NFData GHCBackendError

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -625,7 +625,7 @@ defaultAddLetBinding' isAxiom o x v t ret = do
     localTC (over eLetBindings (Map.insert x vt)) ret
 
 unsafeRule :: (MonadWarning m) => RewriteSource -> IllegalRewriteRuleReason -> MaybeT m ()
-unsafeRule s reason = lift $ warning $ IllegalRewriteRule s reason
+unsafeRule s reason = lift $ warning $ IllegalRewriteRule (defName <$> s) reason
 
 illegalRule :: (MonadWarning m) => RewriteSource -> IllegalRewriteRuleReason -> MaybeT m a
 illegalRule s reason = do

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -819,11 +819,13 @@ instance PrettyTCM DataOrRecord_ where
     IsRecord{} -> "record"
 
 instance PrettyTCM RewriteSource where
+  prettyTCM s = prettyTCM (defName <$> s)
+
+instance PrettyTCM SerialisableRewriteSource where
   prettyTCM = \case
     LocalRewrite g n t ->
       maybe "_" prettyTCM n <+> ":" <+> addContext g (prettyTCM t)
-    GlobalRewrite q    -> prettyTCM (defName q)
-
+    GlobalRewrite q    -> prettyTCM q
 
 {-# SPECIALIZE prettyRecordFieldWarning :: RecordFieldWarning -> TCM Doc #-}
 prettyRecordFieldWarning :: MonadPretty m => RecordFieldWarning -> m Doc

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -255,7 +255,7 @@ instance EmbPrj Context where
     N2 0 a -> valuN Context a
     _      -> malformed
 
-instance EmbPrj RewriteSource where
+instance EmbPrj SerialisableRewriteSource where
   icod_ = \case
     LocalRewrite a b c -> icodeN 0 LocalRewrite a b c
     GlobalRewrite a    -> icodeN 1 GlobalRewrite a

--- a/test/Succeed/Issue8655.agda
+++ b/test/Succeed/Issue8655.agda
@@ -1,0 +1,21 @@
+{-# OPTIONS --rewriting #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Sigma
+
+variable
+  A : Set
+  x : A
+
+abstract
+  to : A → A
+  to x = x
+
+  from : A → A
+  from x = x
+
+  to-from : to (from x) ≡ x
+  to-from = refl
+
+{-# REWRITE to-from #-}

--- a/test/Succeed/Issue8655.warn
+++ b/test/Succeed/Issue8655.warn
@@ -1,0 +1,23 @@
+Issue8655.agda:21.13-20: warning: -W[no]RewriteVariablesBoundInSingleton
+I am not certain that the rewrite rule  to-from  is safe because it
+appears that the following variable is only bound in contexts which
+might become definitionally singular:
+  x
+This warning can be silenced with
+  -WnoRewriteVariablesBoundInSingleton
+but be aware that this rewrite might behave strangely in the
+presence of e.g. eta records with no fields
+when checking the pragma REWRITE to-from
+
+———— All done; warnings encountered ————————————————————————
+
+Issue8655.agda:21.13-20: warning: -W[no]RewriteVariablesBoundInSingleton
+I am not certain that the rewrite rule  to-from  is safe because it
+appears that the following variable is only bound in contexts which
+might become definitionally singular:
+  x
+This warning can be silenced with
+  -WnoRewriteVariablesBoundInSingleton
+but be aware that this rewrite might behave strangely in the
+presence of e.g. eta records with no fields
+when checking the pragma REWRITE to-from


### PR DESCRIPTION
Fixes #8655 

When serialising global rewrite rule warnings, we should only serialise the `QName` of the definition.