### PR TITLE
[ fix #8649 ] Don't eta-expand no-eta records in confluence checker

### DIFF
--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -758,6 +758,9 @@ forceEtaExpansion a v (e:es) = case e of
       [ "Forcing" , prettyTCM v , ":" , prettyTCM a , "to be projectible by" , prettyTCM f ]
     r <- fromMaybe __IMPOSSIBLE__ <$> getRecordOfField f
     Defn{ defType = ra, theDef = RecordDefn rdef } <- getConstInfo r
+
+    if not (isEtaRecordDef rdef) then return Nothing else do
+
     pars <- newArgsMeta ra
     s <- ra `piApplyM` pars >>= \s -> ifIsSort s return __IMPOSSIBLE__
     equalType a $ El s (Def r $ map' Apply pars)

--- a/test/Succeed/Issue8649-global.agda
+++ b/test/Succeed/Issue8649-global.agda
@@ -1,0 +1,33 @@
+{-# OPTIONS --rewriting --confluence-check #-}
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Agda.Builtin.Equality.Rewrite
+
+postulate
+  A : Set
+
+record Tree : Set where
+  coinductive
+  field
+    force : A
+
+postulate
+  sem : A → Tree
+
+  sem-force :
+    {a : A} →
+    Tree.force (sem a) ≡ a
+
+{-# REWRITE sem-force #-}
+
+data Rel : Tree → Set where
+  state :
+    {a : A} →
+    Rel (sem a)
+
+step :
+  ∀ {X : Tree} →
+  Rel X →
+  Tree.force X ≡ Tree.force X
+step state =
+  refl

--- a/test/Succeed/Issue8649-local.agda
+++ b/test/Succeed/Issue8649-local.agda
@@ -1,0 +1,33 @@
+{-# OPTIONS --rewriting --local-confluence-check #-}
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Agda.Builtin.Equality.Rewrite
+
+postulate
+  A : Set
+
+record Tree : Set where
+  coinductive
+  field
+    force : A
+
+postulate
+  sem : A → Tree
+
+  sem-force :
+    {a : A} →
+    Tree.force (sem a) ≡ a
+
+{-# REWRITE sem-force #-}
+
+data Rel : Tree → Set where
+  state :
+    {a : A} →
+    Rel (sem a)
+
+step :
+  ∀ {X : Tree} →
+  Rel X →
+  Tree.force X ≡ Tree.force X
+step state =
+  refl


### PR DESCRIPTION
fixes #8649