### PR TITLE
Fix #8634: internal error with --interaction when .agda-lib file contains bogus fields

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -202,6 +202,8 @@ parseSource sourceFile = Bench.billTo [Bench.Parsing] $ do
 
   -- Now parse again, with module name present to be filled into the ranges.
   let rf = mkRangeFile f $ Just parsedModName0
+  setCurrentRange (beginningOfFile rf) do
+
   ((parsedMod, attrs), fileType) <- runPM $ parseFile mdOnlyAgdaBlocks moduleParser rf txt
   parsedModName                  <- moduleName f parsedMod
 

--- a/src/full/Agda/Interaction/Library/Parse.hs
+++ b/src/full/Agda/Interaction/Library/Parse.hs
@@ -167,13 +167,8 @@ fromGeneric' file fields fs = do
   foldM upd emptyLibFile fs
   where
     -- The range points to the start of the file.
-    r = Range
-          (Strict.Just $ mkRangeFile file Nothing)
-          (singleton i)
-      where
-      p  = Pn () 1 1 1
-      !i = PackIWF (posToInterval () p p)
-
+    r :: Range
+    r = beginningOfFile file
     upd :: AgdaLibFile -> GenericEntry -> P AgdaLibFile
     upd l (GenericEntry h cs) = do
       mf <- findField h fields

--- a/test/Interaction/Issue8634.agda
+++ b/test/Interaction/Issue8634.agda
@@ -1,0 +1,1 @@
+-- Placeholder file for testsuite logic

--- a/test/Interaction/Issue8634.out
+++ b/test/Interaction/Issue8634.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-info-action "*Type-checking*" "Checking Issue8634 (Issue8634/Issue8634.agda)." t)
+(agda2-info-action "*Type-checking*" " Issue8634/Issue8634.agda:1.1: warning: -W[no]LibUnknownField Issue8634/issue8634.agda-lib: Unknown field 'unknown-field'" t '(60 61 (symbol) t) '(62 63 (symbol) t) '(64 65 (symbol) t) '(81 96 (url "https://agda.readthedocs.io/en/v2.9.0/tools/command-line-options.html#cmdoption-arg-libunknownfield") t))
+(agda2-status-action "Checked")
+(agda2-info-action "*All Warnings*" "Issue8634/Issue8634.agda:1.1: warning: -W[no]LibUnknownField Issue8634/issue8634.agda-lib: Unknown field 'unknown-field'" nil '(59 60 (symbol) t) '(61 62 (symbol) t) '(63 64 (symbol) t) '(80 95 (url "https://agda.readthedocs.io/en/v2.9.0/tools/command-line-options.html#cmdoption-arg-libunknownfield") t))
+((last . 1) . (agda2-goals-action '()))

--- a/test/Interaction/Issue8634/Issue8634.agda
+++ b/test/Interaction/Issue8634/Issue8634.agda
@@ -1,0 +1,1 @@
+module Issue8634 where

--- a/test/interaction/Issue8634.sh
+++ b/test/interaction/Issue8634.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+AGDA=$1
+
+cd Issue8634
+rm -rf _build
+$AGDA --interaction <<EOF
+IOTCM "Issue8634.agda" None Indirect (Cmd_load "Issue8634.agda" [])
+EOF

--- a/test/interaction/Issue8634/issue8634.agda-lib
+++ b/test/interaction/Issue8634/issue8634.agda-lib
@@ -1,0 +1,2 @@
+include: .
+unknown-field: foo


### PR DESCRIPTION
Commits:

- Refactor: use beginningOfFile
  
- Fix #8634 by patching #7929
  In --interaction mode, somehow the eRange field with a omitted TopLevelModuleName leaks into the serialization.
  Bisection showed this likely comes from the setCurrentRange in Interaction.Imports.parseSource introduced in PR #7929.
  By emitting another setCurrentRange once we have the TopLevelModuleName we make the symptom go away.
  
Closes #8634.
  