### PR TITLE
Highlight ShouldBeEtaRecordPattern the same way as exactSplitWarnings

### DIFF
--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -497,7 +497,7 @@ warningHighlighting' b w = case tcWarning w of
   CoInfectiveImport{}                   -> errorWarningHighlighting w
   InvalidDisplayForm{}                  -> deadcodeHighlighting w
   UnusedVariablesInDisplayForm xs       -> foldMap deadcodeHighlighting xs
-  ShouldBeEtaRecordPattern              -> errorWarningHighlighting w
+  ShouldBeEtaRecordPattern              -> catchallHighlighting $ getRange w
   TooManyArgumentsToSort _ args         -> errorWarningHighlighting args
   RewritesNothing                       -> cosmeticProblemHighlighting w
   RecursiveRecordNeedsInductivity _x    -> errorWarningHighlighting w


### PR DESCRIPTION
In Emacs, the highlighting color of `-WShouldBeEtaRecordPattern` as initially implemented in #8503 is light coral ![#F08080](https://placehold.co/15x15/f08080/f08080.png), the generic error-like color for "error warnings that do not have dedicated highlighting" (#4456).

However, it was later decided to guard `-WShouldBeEtaRecordPattern` behind `--exact-split` (#8592) and it seems like `-WShouldBeEtaRecordPattern` won't become an error (https://github.com/agda/agda/pull/8503#discussion_r3092053072). Since `--exact-split` isn't the default flag, there would be no warning in Emacs, leaving the light coral color in the air.

<img width="349" height="205" alt="wrap.agda in Emacs" src="https://github.com/user-attachments/assets/27d6c324-3481-4c1a-b3bd-52e0525ed71e" />
 
This feels strange given that there is no warning, so I'd hope `-WShouldBeEtaRecordPattern` to have the same color as the `--exact-split` warning.