### PR TITLE
[wasm] nix: Bump nix pkgs for ghc-wasm to include critical bug fix for ghc/ghc#27447

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1783919537,
-        "narHash": "sha256-YBXYe6BXFmwhQ4cJXwsknv3SCsNWUs8iGE2bUaaS9J8=",
+        "lastModified": 1786484825,
+        "narHash": "sha256-ZsE82Ga5c1unUidHzzsN+2ywA80L+q0Flu/ut5yt/rk=",
         "ref": "refs/heads/master",
-        "rev": "1da639656e710abae174e7f736507461d1b5bca5",
-        "revCount": 566,
+        "rev": "58260711fd5c8ffbb81f4ac56e40323ff509d43b",
+        "revCount": 585,
         "type": "git",
         "url": "https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta.git"
       },
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783549019,
-        "narHash": "sha256-0XnckG4ZhBmAsYa9mLuEIFowBG0fDGPLHduQGsbMS4A=",
+        "lastModified": 1786367589,
+        "narHash": "sha256-OThVjKEZnNLw3eGBuxY644zKkmrDywlejQSZXR1vUUA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "74cc63f702f7d60a557e152a57b40fb1fd0f72ac",
+        "rev": "4014d8bb312b04b49ec74adff5f9b32982bd0580",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Last bump was #8622; we should bump it again to receive a critical bug fix for ghc 9.10 and above from ghc-wasm at https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta/-/commit/5b96779e3d356b3962b6e9c85a9db3a1fcc31ed1

Upstream issue: https://gitlab.haskell.org/ghc/ghc/-/work_items/27447

The lock file's hash is updated via the command `nix flake update ghc-wasm`. Depending on the activity of ghc-wasm, your local result might be different than mine. Ping me if it is the case and I will bump it again.