### PR TITLE
syntactic equality optimization

### DIFF
--- a/src/full/Agda/TypeChecking/SyntacticEquality.hs
+++ b/src/full/Agda/TypeChecking/SyntacticEquality.hs
@@ -155,9 +155,12 @@ instance SynEq Bool where
 -- | Syntactic term equality ignores 'DontCare' stuff.
 instance SynEq Term where
   synEq v v' = expand \ret -> if unsafeComparePointers v v' then ret $ pure (v, v') else ret do
-    (v, v') <- lift $ instantiate' (v, v')
+    v <- lift $ instantiate' v
+    v' <- lift $ instantiate' v'
     expand \ret -> case (v, v') of
-      (Var   i vs, Var   i' vs')  | i == i' -> ret $ Var i   <$$> synEq vs vs'
+      -- note Var' on next line: if the Var-s are cacheable, the pointer equality above
+      -- suceeds. So here there's no point trying to cache them.
+      (Var   i vs, Var   i' vs')  | i == i' -> ret $ Var' i   <$$> synEq vs vs'
       (Con c i vs, Con c' i' vs') | c == c' -> ret $ Con c (bestConInfo i i') <$$> synEq vs vs'
       (Def   f vs, Def   f' vs')  | f == f' -> ret $ Def f   <$$> synEq vs vs'
       (MetaV x vs, MetaV x' vs')  | x == x' -> ret $ MetaV x <$$> synEq vs vs'
@@ -189,7 +192,8 @@ instance SynEq PlusLevel where
 
 instance SynEq Sort where
   synEq s s' = expand \ret -> if unsafeComparePointers s s' then ret $ pure (s, s') else ret do
-    (s, s') <- lift $ instantiate' (s, s')
+    s <- lift $ instantiate' s
+    s' <- lift $ instantiate' s'
     expand \ret -> case (s, s') of
       (Univ u l, Univ u' l') | u == u' -> ret $ Univ u <$$> synEq l l'
       (PiSort a b c, PiSort a' b' c') -> ret $ PiSort <$$> synEq a a' <**> synEq' b b' <**> synEq' c c'


### PR DESCRIPTION
Small optimization on syntactic equality, adapted from https://codeberg.org/1lab/mikan/pulls/167
The main change (how deeply syntactic equality traverses) in that PR is not adapted here, because while it's a big speedup on `cubical` (10% time reduction), it's a slight regression on TypeTopology (1.5% time increase), so it's worth a bit more investigation IMO. 

Benchmarks show a small heap allocation decrease from 1048GB to 1045GB in `cubical` and proportionally similar in TypeTopology. Time change is likewise small and within measurement noise.
