### PR TITLE
Fix #8638

### DIFF
--- a/src/full/Agda/Compiler/Treeless/Erase.hs
+++ b/src/full/Agda/Compiler/Treeless/Erase.hs
@@ -10,6 +10,7 @@ module Agda.Compiler.Treeless.Erase
 
 import Control.Monad.State ( StateT, evalStateT )
 
+import Data.List
 import Data.Map (Map)
 import qualified Data.Map as Map
 
@@ -26,6 +27,7 @@ import Agda.TypeChecking.Datatypes
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Primitive
 
+import Agda.Compiler.Treeless.Pretty ()
 import Agda.Compiler.Treeless.Subst
 import Agda.Compiler.Treeless.Unused
 
@@ -66,7 +68,12 @@ computeErasedConstructorArgs d = do
   runE $ mapM_ getFunInfo cs
 
 eraseTerms :: QName -> EvaluationStrategy -> TTerm -> TCM TTerm
-eraseTerms q eval t = usedArguments q t *> runE (eraseTop q t)
+eraseTerms q eval t = do
+  t' <- usedArguments q t *> runE (eraseTop q t)
+  reportSDoc "treeless.opt.erase" 40 $
+    "Term before erasure:" $$ nest 2 (pretty t) $$
+    "Term after erasure:" $$ nest 2 (pretty t')
+  return t'
   where
     eraseTop q t = do
       (_, h) <- getFunInfo q
@@ -205,12 +212,18 @@ pruneUnreachable' _ erased (CTData q) d bs' = do
         if isErased erased
         then getConstructors q
         else getNotErasedConstructors q
-  let bs | isErased erased = bs'
-         | otherwise       =
-           flip filter bs' $ \case
-             a@TACon{} -> (aCon a) `elem` cs
-             TAGuard{} -> True
-             TALit{}   -> True
+  let (bs, pruned)
+        | isErased erased = (bs', [])
+        | otherwise       =
+          flip partition bs' $ \case
+            a@TACon{} -> (aCon a) `elem` cs
+            TAGuard{} -> True
+            TALit{}   -> True
+  lift $ reportSDoc "treeless.opt.erase.prune" 50 $
+    ("The match is" <+>
+     (if isErased erased then id else ("not" <+>)) "erased.") $$
+    "Kept branches:" $$ nest 2 (vcat (map pretty bs)) $$
+    "Pruned branches:" $$ nest 2 (vcat (map pretty pruned))
   let -- In the case of a match on an erased argument the value d is
       -- equal to tUnreachable, except perhaps if bs is empty. In the
       -- latter case complete is True exactly when the type has zero

--- a/src/full/Agda/Compiler/Treeless/Erase.hs
+++ b/src/full/Agda/Compiler/Treeless/Erase.hs
@@ -10,7 +10,7 @@ module Agda.Compiler.Treeless.Erase
 
 import Control.Monad.State ( StateT, evalStateT )
 
-import Data.List
+import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map as Map
 
@@ -215,7 +215,7 @@ pruneUnreachable' _ erased (CTData q) d bs' = do
   let (bs, pruned)
         | isErased erased = (bs', [])
         | otherwise       =
-          flip partition bs' $ \case
+          flip List.partition bs' $ \case
             a@TACon{} -> (aCon a) `elem` cs
             TAGuard{} -> True
             TALit{}   -> True

--- a/src/full/Agda/Compiler/Treeless/Pretty.hs
+++ b/src/full/Agda/Compiler/Treeless/Pretty.hs
@@ -10,6 +10,7 @@ import Control.Monad.Reader
 import Data.Maybe
 import qualified Data.IntMap as IntMap
 
+import Agda.Syntax.Common
 import Agda.Syntax.Common.Pretty
 import Agda.Syntax.Treeless
 
@@ -17,6 +18,7 @@ import Agda.Compiler.Treeless.Subst
 
 import Agda.Utils.Function
 import Agda.Utils.List
+import Agda.Utils.Null (empty)
 import Agda.Utils.Tuple (first)
 
 import Agda.Utils.Impossible
@@ -83,6 +85,9 @@ runP p = runReader p PEnv{ pPrec = 0, pFresh = names, pBound = [] }
 
 instance Pretty TTerm where
   prettyPrec p t = runP $ prec p (pTerm t)
+
+instance Pretty TAlt where
+  prettyPrec p b = runP $ prec p (pAlt b)
 
 opName :: TPrim -> String
 opName PAdd = "+"
@@ -173,26 +178,31 @@ pTerm = \case
         e <- pTerm' 0 e
         first ((x, e) :) <$> bindName x (pLets bs b)
 
-  TCase x _ def alts -> paren 0 $
+  TCase x i def alts -> paren 0 $
     (\ sc alts defd ->
-      sep [ "case" <+> sc <+> "of"
+      sep [ "case" <+>
+            (if isErased (caseErased i) then "(erased)" else empty) <+>
+            sc <+> "of"
           , nest 2 $ vcat (alts ++ [ "_ →" <+> defd | null alts || def /= TError TUnreachable ]) ]
     ) <$> pTerm' 0 (TVar x)
       <*> mapM pAlt alts
       <*> pTerm' 0 def
-    where
-      pAlt (TALit l b) = pAlt' <$> pTerm' 0 (TLit l) <*> pTerm' 0 b
-      pAlt (TAGuard g b) =
-        pAlt' <$> (("_" <+> "|" <+>) <$> pTerm' 0 g)
-              <*> (pTerm' 0 b)
-      pAlt (TACon c a b) =
-        withNames' a b $ \ xs -> bindNames xs $
-        pAlt' <$> pTerm' 0 (TApp (TCon c) [TVar i | i <- reverse [0..a - 1]])
-              <*> pTerm' 0 b
-      pAlt' p b = sep [p <+> "→", nest 2 b]
 
   TUnit -> pure "()"
   TSort -> pure "Set"
   TErased -> pure "_"
   TError err -> paren 9 $ pure $ "error" <+> text (show (show err))
   TCoerce t -> paren 9 $ ("coe" <+>) <$> pTerm' 10 t
+
+pAlt' :: Doc -> Doc -> Doc
+pAlt' p b = sep [p <+> "→", nest 2 b]
+
+pAlt :: TAlt -> P Doc
+pAlt (TALit l b) = pAlt' <$> pTerm' 0 (TLit l) <*> pTerm' 0 b
+pAlt (TAGuard g b) =
+  pAlt' <$> (("_" <+> "|" <+>) <$> pTerm' 0 g)
+        <*> (pTerm' 0 b)
+pAlt (TACon c a b) =
+  withNames' a b $ \ xs -> bindNames xs $
+  pAlt' <$> pTerm' 0 (TApp (TCon c) [TVar i | i <- reverse [0..a - 1]])
+        <*> pTerm' 0 b

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -557,8 +557,8 @@ cover infermissing f cs sc@(SClause tel ps _ _ target) = updateRelevance $ do
               , "ps  = " <+> inTopContext (addContext tel $ prettyTCMPatternList $ fromSplitPatterns ps)
               ]
             ]
-          let trees' = zipWith (second . etaRecordSplits (unArg n) ps) trees scs
-              tree   = SplitAt n StrictSplit (trees' ++! trees_extra) -- TODO: Lazy?
+          trees' <- zipWithM (etaRecordSplits (unArg n) ps) trees scs
+          let tree   = SplitAt n StrictSplit (trees' ++! trees_extra) -- TODO: Lazy?
           -- Andreas, 2025-10-12: Debug printing to clarify the trees_extra situation.
           reportSDoc "tc.cover.cubical" 30 $ vcat $
             "trees:"           : map' pretty trees ++
@@ -682,8 +682,11 @@ cover infermissing f cs sc@(SClause tel ps _ _ target) = updateRelevance $ do
       IApplyP{}     -> addEtaSplits (k + 1) ps t
 
     etaRecordSplits :: Int -> [NamedArg SplitPattern]
-                    -> SplitTree -> SplitClause -> SplitTree
-    etaRecordSplits n ps t sc = addEtaSplits 0 (gatherEtaSplits n sc ps) t
+                    -> SplitTree -> (SplitTag, SplitClause) -> TCM (SplitTag, SplitTree)
+    etaRecordSplits n ps t (tag, sc) = do
+      let splitsTodo = gatherEtaSplits n sc ps
+      reportSDoc "tc.cover.split.eta" 60 $ "gatherEtaSplits result: " <+> pretty splitsTodo
+      return (tag, addEtaSplits 0 splitsTodo t)
 
 
 -- | Append a instance clause to the clauses of a function.

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -549,15 +549,15 @@ cover infermissing f cs sc@(SClause tel ps _ _ target) = updateRelevance $ do
           -- Jesper, 2016-03-10  We need to remember which variables were
           -- eta-expanded by the unifier in order to generate a correct split
           -- tree (see Issue 1872).
-          addContext tel $ reportSDoc "tc.cover.split.eta" 60 $ vcat
-            [ "etaRecordSplits"
+          addContext tel $ reportSDoc "tc.cover.split.lazy" 60 $ vcat
+            [ "lazySplits"
             , nest 2 $ vcat
               [ "n   = " <+> pretty n
               , "scs = " <+> prettyTCM scs
               , "ps  = " <+> inTopContext (addContext tel $ prettyTCMPatternList $ fromSplitPatterns ps)
               ]
             ]
-          trees' <- zipWithM (etaRecordSplits (unArg n) ps) trees scs
+          trees' <- zipWithM (lazySplits (unArg n) ps) trees scs
           let tree   = SplitAt n StrictSplit (trees' ++! trees_extra) -- TODO: Lazy?
           -- Andreas, 2025-10-12: Debug printing to clarify the trees_extra situation.
           reportSDoc "tc.cover.cubical" 30 $ vcat $
@@ -643,53 +643,53 @@ cover infermissing f cs sc@(SClause tel ps _ _ target) = updateRelevance $ do
               tree  = SplitAt n StrictSplit $ zip projs trees   -- TODO: Lazy?
           return $ CoverResult tree (IntSet.unions useds) (concat psss) (concat qsss) (IntSet.unions noex)
 
-    gatherEtaSplits :: Int -> SplitClause
+    gatherLazySplits :: Int -> SplitClause
                     -> [NamedArg SplitPattern] -> [NamedArg SplitPattern]
-    gatherEtaSplits n sc []
+    gatherLazySplits n sc []
        | n >= 0    = __IMPOSSIBLE__ -- we should have encountered the main
                                     -- split by now already
        | otherwise = []
-    gatherEtaSplits n sc (p:ps) = case namedArg p of
+    gatherLazySplits n sc (p:ps) = case namedArg p of
       VarP _ x
        | n == 0    -> case p' of -- this is the main split
-           VarP  _ _    -> p : gatherEtaSplits (-1) sc ps
+           VarP  _ _    -> p : gatherLazySplits (-1) sc ps
            DotP  _ _    -> __IMPOSSIBLE__
-           ConP  _ _ qs -> qs ++! gatherEtaSplits (-1) sc ps
-           LitP{}       -> gatherEtaSplits (-1) sc ps
+           ConP  _ _ qs -> qs ++! gatherLazySplits (-1) sc ps
+           LitP{}       -> gatherLazySplits (-1) sc ps
            ProjP{}      -> __IMPOSSIBLE__
            IApplyP{}    -> __IMPOSSIBLE__
-           DefP  _ _ qs -> qs ++! gatherEtaSplits (-1) sc ps -- __IMPOSSIBLE__ -- Andrea: maybe?
+           DefP  _ _ qs -> qs ++! gatherLazySplits (-1) sc ps -- __IMPOSSIBLE__ -- Andrea: maybe?
        | otherwise ->
-           updateNamedArg (\ _ -> p') p : gatherEtaSplits (n-1) sc ps
+           updateNamedArg (\ _ -> p') p : gatherLazySplits (n-1) sc ps
         where p' = lookupS (scSubst sc) $ splitPatVarIndex x
       IApplyP{}   ->
-           updateNamedArg (applySubst (scSubst sc)) p : gatherEtaSplits (n-1) sc ps
-      DotP  _ _    -> p : gatherEtaSplits (n-1) sc ps -- count dot patterns
-      ConP  _ _ qs -> gatherEtaSplits n sc (qs ++! ps)
-      DefP  _ _ qs -> gatherEtaSplits n sc (qs ++! ps)
-      LitP{}       -> gatherEtaSplits n sc ps
-      ProjP{}      -> gatherEtaSplits n sc ps
+           updateNamedArg (applySubst (scSubst sc)) p : gatherLazySplits (n-1) sc ps
+      DotP  _ _    -> p : gatherLazySplits (n-1) sc ps -- count dot patterns
+      ConP  _ _ qs -> gatherLazySplits n sc (qs ++! ps)
+      DefP  _ _ qs -> gatherLazySplits n sc (qs ++! ps)
+      LitP{}       -> gatherLazySplits n sc ps
+      ProjP{}      -> gatherLazySplits n sc ps
 
-    addEtaSplits :: Int -> [NamedArg SplitPattern] -> SplitTree -> SplitTree
-    addEtaSplits k []     t = t
-    addEtaSplits k (p:ps) t = case namedArg p of
-      VarP  _ _     -> addEtaSplits (k + 1) ps t
-      DotP  _ _     -> addEtaSplits (k + 1) ps t
+    addLazySplits :: Int -> [NamedArg SplitPattern] -> SplitTree -> SplitTree
+    addLazySplits k []     t = t
+    addLazySplits k (p:ps) t = case namedArg p of
+      VarP  _ _     -> addLazySplits (k + 1) ps t
+      DotP  _ _     -> addLazySplits (k + 1) ps t
       ConP c cpi qs ->
         -- Jesper, 2026-08-18, issue #8638: propagate erasure to subpatterns
         let qs' = map (mapQuantity $ composeQuantity $ getQuantity p) qs
-        in SplitAt (p $> k) LazySplit [(SplitCon (conName c) , addEtaSplits k (qs' ++! ps) t)]
+        in SplitAt (p $> k) LazySplit [(SplitCon (conName c) , addLazySplits k (qs' ++! ps) t)]
       LitP{}        -> __IMPOSSIBLE__
       ProjP{}       -> __IMPOSSIBLE__
       DefP{}        -> __IMPOSSIBLE__ -- Andrea: maybe?
-      IApplyP{}     -> addEtaSplits (k + 1) ps t
+      IApplyP{}     -> addLazySplits (k + 1) ps t
 
-    etaRecordSplits :: Int -> [NamedArg SplitPattern]
+    lazySplits :: Int -> [NamedArg SplitPattern]
                     -> SplitTree -> (SplitTag, SplitClause) -> TCM (SplitTag, SplitTree)
-    etaRecordSplits n ps t (tag, sc) = do
-      let splitsTodo = gatherEtaSplits n sc ps
-      reportSDoc "tc.cover.split.eta" 60 $ "gatherEtaSplits result: " <+> pretty splitsTodo
-      return (tag, addEtaSplits 0 splitsTodo t)
+    lazySplits n ps t (tag, sc) = do
+      let splitsTodo = gatherLazySplits n sc ps
+      reportSDoc "tc.cover.split.lazy" 60 $ "gatherLazySplits result: " <+> pretty splitsTodo
+      return (tag, addLazySplits 0 splitsTodo t)
 
 
 -- | Append a instance clause to the clauses of a function.

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -675,7 +675,10 @@ cover infermissing f cs sc@(SClause tel ps _ _ target) = updateRelevance $ do
     addEtaSplits k (p:ps) t = case namedArg p of
       VarP  _ _     -> addEtaSplits (k + 1) ps t
       DotP  _ _     -> addEtaSplits (k + 1) ps t
-      ConP c cpi qs -> SplitAt (p $> k) LazySplit [(SplitCon (conName c) , addEtaSplits k (qs ++! ps) t)]
+      ConP c cpi qs ->
+        -- Jesper, 2026-08-18, issue #8638: propagate erasure to subpatterns
+        let qs' = map (mapQuantity $ composeQuantity $ getQuantity p) qs
+        in SplitAt (p $> k) LazySplit [(SplitCon (conName c) , addEtaSplits k (qs' ++! ps) t)]
       LitP{}        -> __IMPOSSIBLE__
       ProjP{}       -> __IMPOSSIBLE__
       DefP{}        -> __IMPOSSIBLE__ -- Andrea: maybe?

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -552,7 +552,7 @@ cover infermissing f cs sc@(SClause tel ps _ _ target) = updateRelevance $ do
           addContext tel $ reportSDoc "tc.cover.split.eta" 60 $ vcat
             [ "etaRecordSplits"
             , nest 2 $ vcat
-              [ "n   = " <+> text (show n)
+              [ "n   = " <+> pretty n
               , "scs = " <+> prettyTCM scs
               , "ps  = " <+> inTopContext (addContext tel $ prettyTCMPatternList $ fromSplitPatterns ps)
               ]
@@ -1453,10 +1453,10 @@ split' checkEmpty ind allowPartialCover inserttrailing
       reportSDoc "tc.cover.top" 60 $ vcat
         [ "TypeChecking.Coverage.split': split"
         , nest 2 $ vcat
-          [ "tel     =" <+> (text . show) tel
-          , "x       =" <+> (text . show) x
-          , "ps      =" <+> (text . show) ps
-          , "cps     =" <+> (text . show) cps
+          [ "tel     =" <+> pretty tel
+          , "x       =" <+> pretty x
+          , "ps      =" <+> pretty ps
+          , "cps     =" <+> pretty cps
           ]
         ]
 

--- a/src/full/Agda/TypeChecking/Coverage/SplitTree.hs
+++ b/src/full/Agda/TypeChecking/Coverage/SplitTree.hs
@@ -83,12 +83,18 @@ data SplitTreeLabel a = SplitTreeLabel
 instance Pretty a => Pretty (SplitTreeLabel a) where
   pretty = \case
     SplitTreeLabel Nothing Nothing   _  (Just n) -> text $ "done, " ++ prettyShow n ++ " bindings"
-    SplitTreeLabel Nothing (Just n)  lz Nothing  -> lzp lz <+> text ("split at " ++ prettyShow n)
+    SplitTreeLabel Nothing (Just n)  lz Nothing  -> lzp n lz <+> text ("split at " ++ prettyShow n)
     SplitTreeLabel (Just q) Nothing  _  (Just n) -> pretty q <+> text ("-> done, " ++ prettyShow n ++ " bindings")
-    SplitTreeLabel (Just q) (Just n) lz Nothing  -> pretty q <+> text "->" <+> lzp lz <+> text ("split at " ++ prettyShow n)
+    SplitTreeLabel (Just q) (Just n) lz Nothing  -> pretty q <+> text "->" <+> lzp n lz <+> text ("split at " ++ prettyShow n)
     _ -> __IMPOSSIBLE__
-    where lzp lz | lz == LazySplit = "lazy"
-                 | otherwise       = empty
+    where
+    lzp n lz =
+      (if hasQuantity0 (getQuantity n)
+       then "erased"
+       else empty) <+>
+      (case lz of
+         LazySplit   -> "lazy"
+         StrictSplit -> empty)
 
 -- | Convert a split tree into a 'Data.Tree' (for printing).
 toTree :: SplitTree' a -> Tree (SplitTreeLabel a)

--- a/test/Compiler/simple/Issue8638.agda
+++ b/test/Compiler/simple/Issue8638.agda
@@ -1,0 +1,32 @@
+{-# OPTIONS --erasure #-}
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.IO
+open import Agda.Builtin.Unit
+
+postulate
+  exitFailure exitSuccess : IO ⊤
+
+{-# FOREIGN GHC import System.Exit qualified as Exit #-}
+{-# COMPILE GHC exitFailure = Exit.exitFailure #-}
+{-# COMPILE GHC exitSuccess = Exit.exitSuccess #-}
+{-# COMPILE JS exitFailure = function(cb) { process.exit(1); } #-}
+{-# COMPILE JS exitSuccess = function(cb) { process.exit(0); } #-}
+
+data ENat : Set where
+  z    : ENat
+  @0 s : ENat → ENat
+
+data GE2 : ENat → Set where
+  swap : (@0 n : _) → GE2 (s (s n))
+
+snot : ∀ {@0 n} → GE2 n → Bool → Bool
+snot {n = s (s n)} (swap n) false = true
+snot {n = s (s n)} (swap n) true  = false
+
+test : Bool → IO ⊤
+test false = exitSuccess
+test true  = exitFailure
+
+main : IO ⊤
+main = test (snot (swap z) true)

--- a/test/Compiler/simple/Issue8638.out
+++ b/test/Compiler/simple/Issue8638.out
@@ -1,0 +1,3 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess


### PR DESCRIPTION
This fixes #8638 by propagating the erasure into subpatterns in the addEtaSplits function (which seems rather poorly named since it apparently does more than just adding splits on eta records).