### PR TITLE
[ test ] Run GHC compiler tests with -O0

### DIFF
--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -175,7 +175,10 @@ simpleTests comp = do
 
   where compArgs :: Compiler -> AgdaArgs
         compArgs MAlonzo{} =
-          ghcArgsAsAgdaArgs ["-itest/", "-fno-excess-precision"]
+          -- Compile the generated code without optimising it: the test
+          -- suite only checks the behaviour of the compiled program, and
+          -- GHC's -O pass dominates the runtime of each test.
+          ghcArgsAsAgdaArgs ["-itest/", "-fno-excess-precision", "-O0"]
         compArgs JS{} = []
 
 -- The Compiler tests using the standard library are horribly


### PR DESCRIPTION
While debugging #8638 I noticed that the compiler tests run quite slowly, especially `Char.agda` which is a large file that takes over 20 seconds to run. Essentially all the time is taken by GHC compiling the code generated by Agda. Since we are not testing the GHC binary itself, it makes more sense to turn off optimizations for these IMHO.