### PR TITLE
[ fix #4688 #8633 ] More conservative dropping of candidates

### DIFF
--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -25,6 +25,7 @@ import Control.Monad.Except   (ExceptT(..), runExceptT, MonadError(..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.List as List
+import Data.Either
 import Data.Function (on)
 import Data.Monoid hiding ((<>))
 import Data.Foldable (toList, foldrM)
@@ -805,11 +806,20 @@ resolveInstanceOverlap overlapOk rel itemC cands = wrapper where
 -- This is sufficient to reduce the list to a singleton should all be equal.
 dropSameCandidates :: MetaId -> Bool -> [(Candidate, Term, TCState)] -> TCM [(Candidate, Term, TCState)]
 dropSameCandidates m overlapOk cands0 = verboseBracket "tc.instance" 30 "dropSameCandidates" $ do
+  initialState <- getTCState
   !nextMeta    <- nextLocalMeta
   isRemoteMeta <- isRemoteMeta
 
   -- Does "it" contain any fresh meta-variables?
   let freshMetas = getAny . allMetas (\m -> Any (not (isRemoteMeta m || m < nextMeta)))
+
+  -- We only discard equal candidates if the candidate we are keeping
+  -- does not result in any metas or constraints being solved (see #8633).
+  let constraintIds = List.sort . map constraintProblems
+      hasEffects st =
+           Map.keys (st ^. stOpenMetaStore) /= Map.keys (initialState ^. stOpenMetaStore)
+        || constraintIds (st ^. stAwakeConstraints) /= constraintIds (initialState ^. stAwakeConstraints)
+        || constraintIds (st ^. stSleepingConstraints) /= constraintIds (initialState ^. stSleepingConstraints)
 
   rel <- getRelevance <$> lookupMetaModality m
 
@@ -827,42 +837,43 @@ dropSameCandidates m overlapOk cands0 = verboseBracket "tc.instance" 30 "dropSam
 
   case cands of
     [] -> return cands
-    cvd : _ | isIrrelevant rel -> do
-      reportSLn "tc.instance" 30 "dropSameCandidates: Meta is irrelevant so any candidate will do."
-      return [cvd]
-
     -- If there's nothing, try not to reduce the candidate.
     [cvd] -> pure [cvd]
 
-    cvd@(_, v, st) : vas -> do
-      let
-        equal :: (Candidate, Term, a) -> TCM Bool
-        equal (c, v', _)
-            | isIncoherent c = return True   -- See 'sinkIncoherent'
-            | freshMetas v'  = return False  -- If there are fresh metas we can't compare
-            | otherwise      =
-          verboseBracket "tc.instance" 30 "dropSameCandidates: " $ do
-          reportSDoc "tc.instance" 30 $ sep [ prettyTCM v <+> "==", nest 2 $ prettyTCM v' ]
-          a <- uncurry piApplyM =<< ((,) <$> getMetaType m <*> getContextArgs)
-          pureBlockOrEqualTerm a v v' <&> \case
-            Left{}  -> False
-            Right b -> b
+    _ -> do
+      -- If we do actually have to remove overlap then we have to find
+      -- a candidate that is "safe" to compare against other candidates:
+      -- it should not have any fresh metas, and there should not be any
+      -- newly solved metas or constraints in its state.
+      let getSafeCandidate [] = return Nothing
+          getSafeCandidate (cand@(c, v, st):cands) = do
+            -- ... issue #8215: while fastReduce is perfectly happy to block
+            -- on a meta that doesn't exist, the short-circuit blocking in
+            -- maybeFastReduce explodes, we have to reduce in the new TC
+            -- state.
+            v' <- localTCState $ putTC st >> reduce v
+            if freshMetas v' || hasEffects st then
+              fmap (second ((c, v', st):)) <$> getSafeCandidate cands
+            else
+              return $ Just ((c, v', st) , cands)
 
-      -- If we do actually have to remove overlap then we have to reduce
-      -- the candidate to eliminate any "phantom" dependencies on fresh
-      -- metas.
-      -- ... issue #8215: while fastReduce is perfectly happy to block
-      -- on a meta that doesn't exist, the short-circuit blocking in
-      -- maybeFastReduce explodes, we have to reduce in the new TC
-      -- state.
-      v <- localTCState do
-        putTC st
-        reduce v
-      if
-        | freshMetas v -> do
-          reportSLn "tc.instance" 30 "dropSameCandidates: Solution of instance meta has fresh metas so we don't filter equal candidates yet"
-          return (cvd : vas)
-        | otherwise -> (cvd :) <$> dropWhileM equal vas
+      getSafeCandidate cands >>= \case
+        Just (safeCand@(c0, v0, st0), cands') -> do
+          reportSDoc "tc.instance" 30 $ "dropSameCandidates: Found effect-free candidate" <+> prettyTCM c0
+          let canDrop (c, v, st)
+                | isIncoherent c = return True   -- See 'sinkIncoherent'
+                | isIrrelevant rel = return True
+                | otherwise = verboseBracket "tc.instance" 30 "dropSameCandidates: " $ do
+                    reportSDoc "tc.instance" 30 $ sep [ prettyTCM v0 <+> "==", nest 2 $ prettyTCM v ]
+                    a <- uncurry piApplyM =<< ((,) <$> getMetaType m <*> getContextArgs)
+                    localTCState $ do
+                      putTC st
+                      fromRight False <$> pureBlockOrEqualTerm a v0 v
+          (safeCand :) <$> dropWhileM canDrop cands'
+
+        Nothing -> do
+          reportSLn "tc.instance" 30 "dropSameCandidates: No effect-free solution found; we don't filter equal candidates yet"
+          return cands
 
 data YesNo = Yes Term Bool | No | NoBecause TCErr | HellNo TCErr
   deriving (Show)

--- a/test/Succeed/Issue4688a.agda
+++ b/test/Succeed/Issue4688a.agda
@@ -1,0 +1,22 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+postulate
+  A B : Set
+  b : B
+
+  f : {{B}} → Set
+
+instance
+  inst₁ : {{A}} → B
+  inst₁ = b
+
+  inst₂ : B
+  inst₂ = b
+
+test : Set
+test = f
+-- WAS: No instance of type A was found in scope.
+-- when checking that the expression f has type Set
+
+-- NOW: unsolved instance with 2 open candidates
+

--- a/test/Succeed/Issue4688b-swap.agda
+++ b/test/Succeed/Issue4688b-swap.agda
@@ -1,0 +1,28 @@
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+
+mutual
+
+  A : Set
+  A = _
+
+  postulate
+    B : Set
+    b : B
+
+    f : {{B}} → Set
+
+  -- The order of these two instances should not matter
+  instance
+    inst₂ : B
+    inst₂ = b
+
+    inst₁ : {A} → B
+    inst₁ = b
+
+  test : Set
+  test = f
+
+  _ : A ≡ Bool
+  _ = refl
+

--- a/test/Succeed/Issue4688b.agda
+++ b/test/Succeed/Issue4688b.agda
@@ -1,0 +1,28 @@
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+
+mutual
+
+  A : Set
+  A = _
+
+  postulate
+    B : Set
+    b : B
+
+    f : {{B}} → Set
+
+  -- The order of these two instances should not matter
+  instance
+    inst₁ : {A} → B
+    inst₁ = b
+
+    inst₂ : B
+    inst₂ = b
+
+  test : Set
+  test = f
+
+  _ : A ≡ Bool
+  _ = refl
+

--- a/test/Succeed/Issue4688c.agda
+++ b/test/Succeed/Issue4688c.agda
@@ -1,0 +1,16 @@
+
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Nat
+open import Agda.Builtin.FromNat
+
+data MyNat : Set where
+  zero : MyNat
+  suc  : MyNat → MyNat
+
+postulate
+  convert : {{_ : ⊤}} → Nat → MyNat
+
+instance
+  myInst : Number MyNat
+  myInst .Number.Constraint = λ _ → ⊤
+  myInst .Number.fromNat = λ n → convert n

--- a/test/Succeed/Issue8633.agda
+++ b/test/Succeed/Issue8633.agda
@@ -1,0 +1,29 @@
+postulate A : Set
+postulate a : A
+
+data P (x : A) : Set where mkP : P x
+data Q (x : A) : Set where mkQ : Q x
+
+record Register (R : A → Set) : Set where
+  constructor Reg
+open Register
+
+record Pointed  (R : A → Set) : Set where
+  constructor Pt
+  field at : R a
+open Pointed {{...}}
+
+wrap : {R : A → Set} {{_ : Register R}} {x : A} → R x → R x
+wrap r = r
+
+val : {R : A → Set} {{_ : Register R}} {{_ : Pointed R}} → R a
+val = at
+
+instance
+  Register-A : Register P ; Register-A = Reg
+  Register-B : Register Q ; Register-B = Reg
+  Pointed-P  : Pointed P  ; Pointed-P  = Pt mkP
+  Pointed-Q  : Pointed Q  ; Pointed-Q  = Pt mkQ
+
+q : Q a
+q = wrap val


### PR DESCRIPTION
This fixes #4688 and #8633 by making the dropping of equal instance candidates more conservative: we first wait until we have at least one candidate that is "safe" in the sense of not having new metas *and* not having solved any metas or constraints in its state. If we find such a candidate, we compare it against all the other candidates in the *state of the other candidate*. Otherwise we simply postpone the instance search.

I'm glad to have a solution for this, but it's also not unlikely that this will cause regressions (like any change to instance search seems to do). So perhaps it is better to wait with merging this until after the release.