### PR TITLE
Dead code elimination: don't traverse meta judgement types

### DIFF
--- a/src/full/Agda/TypeChecking/DeadCode.hs
+++ b/src/full/Agda/TypeChecking/DeadCode.hs
@@ -10,6 +10,8 @@ import qualified Data.Map.Strict as MapS
 import qualified Data.HashMap.Strict as HMap
 import Data.IORef
 
+import Agda.Interaction.Options (optSaveMetas)
+
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Names
@@ -47,6 +49,7 @@ eliminateDeadCode !scope = Bench.billTo [Bench.DeadCode] $ do
   !sig <- getSignature
   let !defs = sig ^. sigDefinitions
   !metas <- useR stSolvedMetaStore
+  !saveMetas <- optSaveMetas <$> pragmaOptions
 
   -- #2921: Eliminating definitions with attached COMPILE pragmas results in
   -- the pragmas not being checked. Simple solution: don't eliminate these.
@@ -128,7 +131,16 @@ eliminateDeadCode !scope = Bench.billTo [Bench.DeadCode] $ do
             Just mv -> do
               writeIORef insideDef Nothing
               go (instBody (theInstantiation mv))
-              go (jMetaType (mvJudgement mv))
+              -- The meta's judgement reaches the interface (as
+              -- rmvJudgement) only under --save-metas; otherwise the
+              -- meta store is dropped after instantiateFull, so
+              -- nothing reachable solely through the judgement's type
+              -- can occur in the serialised interface, and traversing
+              -- it would only grow the kept sets and the traversal
+              -- cost (quadratically in the module's section
+              -- telescopes, since each solved meta's type is closed
+              -- over its context).
+              when saveMetas $ go (jMetaType (mvJudgement mv))
               writeIORef insideDef prevRef -- restore ref
           )
 


### PR DESCRIPTION
# Dead code elimination: don't traverse meta judgement types that cannot reach the interface

## Problem

`eliminateDeadCode` runs before every interface write. For each solved metavariable it reaches, `goMeta` traverses both the instantiation and the judgement's type (`jMetaType (mvJudgement mv)`). The judgement type of a solved meta is closed over the meta's creation context, so in a module with a large parameter section every such type carries the whole telescope. Since the reachability traversal walks terms as trees (its visited sets are keyed on `QName`/`MetaId` only), the pass costs roughly (number of solved metas) × (telescope tree size), which grows super-linearly in the number of module parameters. On modules with large dependent telescopes this makes `DeadCodeReachable` the dominant cost of the whole invocation, several times larger than type checking itself.

The expensive data is dead weight. Without `--save-metas`, the interface pipeline discards the meta store right after dead code elimination: `Interface`'s `instantiateFull` replaces meta occurrences by their instantiations and drops the remote metas (`pure mempty` in `Agda.TypeChecking.Reduce`, the `-- remote metas are dropped` line), under the `optSaveMetas` branch of `Agda.Interaction.Imports.buildInterface`. Instantiation bodies do become part of the serialised definitions — but judgement types are not inlined anywhere by `instantiateFull`, so nothing reachable *only* through a judgement type can occur in the written interface. Traversing them buys no correctness; it only grows the kept sets and the traversal cost.

## Fix

Unless `--save-metas` is set, skip the `jMetaType` traversal in `goMeta`. Instantiations are still traversed.

With `--save-metas`, judgement types genuinely reach the interface as `rmvJudgement` and importers consult them, so the traversal is kept unchanged in that mode. Pruning data an importer still needs is exactly how this pass has broken before: in [#6931](https://github.com/agda/agda/issues/6931) it dropped module-section data needed to instantiate a parametrized module from another file, and in [#7382](https://github.com/agda/agda/issues/7382) a meta pruned under `--save-metas` produced "Meta-variable not found" on reload — hence the conservative condition here. The change can drop metas from the kept set that were previously retained — those reachable only via judgement types — but in the mode where the change is active the whole store is discarded downstream regardless, so the written interface is unaffected. The measurements below confirm this at the byte level.

## Benchmark

The pathology surfaced while porting [Bonak](https://github.com/artagnon/bonak), an indexed construction of semi-simplicial and semi-cubical sets and groupoids formalised in Rocq, to Cubical Agda ([olympichek/cubical-bonak](https://github.com/olympichek/cubical-bonak)): stating its coherence-pasting lemmas over abstract families naturally produces modules whose parameter telescopes carry dozens of large dependent types, at which point interface writing came to dominate type checking.

The stress case is that development's pasting kit, [`Bonak/GpdLemmas.agda`](https://github.com/olympichek/cubical-bonak/blob/7de60bb/Bonak/GpdLemmas.agda) (measured at the pinned commit), a `--cubical` module of ~1,200 lines whose final section is an anonymous module with a ~60-parameter dependent telescope; the parameters include six large stated squares, each an instantiated lemma type mentioning many earlier parameters, which is what makes the solved metas' context-closed judgement types large. Checking it produces 141 reachable definitions and ~2,100 solved metavariables. It can serve as a regression benchmark.

Each measurement is one cold run of

    agda --profile=all +RTS -M40G -s -RTS Bonak/GpdLemmas.agda

from an empty `_build`, so the invocation checks the module and its five small dependencies from scratch and writes their interfaces. Reported numbers are the `DeadCode.DeadCodeReachable` bucket from Agda's `--profile` output (the reachability traversal of `eliminateDeadCode`, summed over the modules of the run and entirely dominated by the stress module — the dependencies' shares are milliseconds) and the total wall clock of the invocation. Machine: 32-core Linux, GHC 9.12.2, `optimise-heavily` build, no other load.

## Results

At master c33ffaadc, this change against the unchanged tip, same machine, fresh `_build` for each run:

| | master | master + this change |
|---|---|---|
| `DeadCode.DeadCodeReachable` | 326.9 s | 4.6 s (~71×) |
| total invocation | 420.9 s | 89.5 s |
| type checking (`Typing` bucket), for scale | 50.6 s | 37.6 s |

The produced `.agdai` files are **byte-identical** (md5-compared) between the two builds, and a downstream module ([`Bonak/νGpd.agda`](https://github.com/olympichek/cubical-bonak/blob/7de60bb/Bonak/%CE%BDGpd.agda)) importing the stress module's interface checks with exit 0 under the patched build.
