### PR TITLE
Fix #8599: classifyPattern: projection patterns only in LHSs

### DIFF
--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -4111,7 +4111,7 @@ instance (Pretty nm, Pretty p, Pretty e) => Pretty (RewriteEqn' qn nm p e) where
   pretty = \case
     Rewrite es   -> prefixedThings (text "rewrite") $ List1.toList (pretty . snd <$> es)
     LeftLet pes  -> prefixedThings (text "using") [pretty p <+> "<-" <+> pretty e | (p, e) <- List1.toList pes]
-    Invert _ pes -> prefixedThings (text "invert") $ List1.toList (namedWith <$> pes) where
+    Invert _ pes -> prefixedThings (text "with") $ List1.toList (namedWith <$> pes) where
 
       namedWith (Named nm (p, e)) =
         let patexp = pretty p <+> "<-" <+> pretty e in

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -741,7 +741,12 @@ classifyPattern conf p =
       return $ ParseLHS x $ lhsCoreAddSpine (LHSHead x []) ps
 
     -- case @d ps@
-    Arg _ (Named _ (IdentP _ x)) :| ps | fldName conf x -> do
+    -- Andreas, 2026-08-21, issue #8599:
+    -- A field can only head a projection (copattern) if we are parsing a lhs,
+    -- i.e., if we are looking for the defined name @topName@.
+    -- When parsing a mere pattern, a field name has to be treated
+    -- like an ordinary identifier, falling through to the last case.
+    Arg _ (Named _ (IdentP _ x)) :| ps | isJust (topName conf), fldName conf x -> do
 
       -- Step 1: check for valid copattern lhs.
       ps0 :: [NamedArg ParseLHS] <- mapM classPat ps

--- a/test/Succeed/Issue8599.agda
+++ b/test/Succeed/Issue8599.agda
@@ -1,0 +1,41 @@
+-- Andreas, 2026-08-21, issue #8599, shrunk to not use the standard library.
+--
+-- The pattern of an irrefutable @with@ bind (@with p ← e@) was not parsed
+-- correctly if @p@ was a single name that is also in scope as a record field:
+-- the LHS parser only considered @p@ as a projection (copattern)
+-- and gave up with a @NoParseForLHS@ error.
+--
+-- In the original example, the offending name was @refl@, in scope both as
+-- constructor @_≡_.refl@ and as field @Setoid.refl@ (via @open Setoid S@).
+-- Note that the field alone was enough to trigger the problem;
+-- neither the ambiguity nor the constructor are needed.
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Issue8599 where
+
+-- Note: the record has to be declared before @refl@ is brought into scope
+-- by the import below, lest we get a @ClashingDefinition@ error.
+
+record Setoid : Set₁ where
+  field
+    Carrier : Set
+    refl    : Carrier   -- Cf. @Setoid.refl@ in the standard library.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+
+module _ (S : Setoid) where
+
+  open Setoid S  -- Brings field @refl@ into scope, unqualified.
+
+  -- Matching on the constructor @refl@ in an ordinary clause works:
+
+  ok : (x y : Carrier) (eq : x ≡ y) → Carrier
+  ok x y refl = x
+
+  -- The same pattern in an irrefutable @with@ bind did not parse:
+
+  test : (x y : Carrier) (eq : x ≡ y) → Carrier
+  test x y eq
+    with refl ← eq
+    = x


### PR DESCRIPTION
- **Re #8599: fix rendering of error message: invert -> with**
  

- **Fix #8599: classifyPattern: in ordinary patterns can't be copatterns**
  Closes #8599.
  
  AI disclosure: Fixed by Claude.
  