### PR TITLE
[ fix #5665 ] Close information gaps in the JSON interaction protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -481,6 +481,21 @@ Library management
 Interaction and emacs mode
 --------------------------
 
+* The JSON interaction protocol (`--interaction-json`) no longer loses
+  information that the Emacs frontend displays:
+
+  - `GoalAndHave` responses now include a `boundary` field with the
+    boundary faces of the checked expression
+    ("Boundary (actual)" in the Emacs mode).
+
+  - `NormalForm` and `InferredType` responses now pretty-print the
+    expression in the command state captured when the command ran, as
+    the Emacs frontend does, instead of in the current state
+    (fixes [Issue #5665](https://github.com/agda/agda/issues/5665)).
+
+  - `Mimer` responses now include the `interactionPoint` the solution
+    refers to.
+
 * Syntax highlighting and go-to-definition now also works in the Agda
   information and debug buffers in Emacs where goals etc. are displayed.
   This fixes long-standing [Issue #706](https://github.com/agda/agda/issues/706).

--- a/src/full/Agda/Interaction/EmacsTop.hs
+++ b/src/full/Agda/Interaction/EmacsTop.hs
@@ -9,6 +9,8 @@ module Agda.Interaction.EmacsTop
     , explainWhyInScope
     , prettyResponseContext
     , prettyTypeOfMeta
+    , prettyNormalForm
+    , prettyInferredType
     ) where
 
 import Prelude hiding (null)
@@ -22,6 +24,7 @@ import Data.List qualified as List
 
 import Agda.Syntax.Common
 import Agda.Syntax.Common.Pretty as P
+import Agda.Syntax.Abstract qualified as A
 import Agda.Syntax.Abstract.Pretty (prettyATop)
 import Agda.Syntax.Concrete as C
 
@@ -194,29 +197,16 @@ lispifyDisplayInfo = \case
       format "*Time*" $ prettyTimed time
 
     Info_NormalForm state cmode time expr -> do
-      exprDoc <- evalStateT prettyExpr state
+      exprDoc <- prettyNormalForm state cmode expr
       let doc = maybe empty prettyTimed time $$ exprDoc
           lbl | cmode == HeadCompute = "*Head Normal Form*"
               | otherwise            = "*Normal Form*"
       format lbl doc
-      where
-        prettyExpr = localStateCommandM
-            $ lift
-            $ B.atTopLevel
-            $ (B.withComputeIgnoreAbstract cmode)
-            $ (B.showComputed cmode)
-            $ expr
 
     Info_InferredType state time expr -> do
-      exprDoc <- evalStateT prettyExpr state
+      exprDoc <- prettyInferredType state expr
       let doc = maybe empty prettyTimed time $$ exprDoc
       format "*Inferred Type*" doc
-      where
-        prettyExpr = localStateCommandM
-            $ lift
-            $ B.atTopLevel
-            $ TCP.prettyA
-            $ expr
 
     Info_ModuleContents modules tel types -> do
       doc <- localTCState $ do
@@ -469,6 +459,31 @@ prettyTypeOfMeta norm ii = do
   B.typeOfMeta norm ii >>= \case
     OfType _ e -> prettyATop e
     form       -> prettyATop form
+
+-- | Pretty-print the result of a compute command in the command state
+--   captured when the command completed.  Shared with the JSON frontend
+--   ("Agda.Interaction.JSONTop") so that both frontends render the
+--   expression identically.
+prettyNormalForm :: CommandState -> ComputeMode -> A.Expr -> TCM Doc
+prettyNormalForm state cmode expr = evalStateT prettyExpr state
+  where
+    prettyExpr = localStateCommandM
+        $ lift
+        $ B.atTopLevel
+        $ (B.withComputeIgnoreAbstract cmode)
+        $ (B.showComputed cmode)
+        $ expr
+
+-- | Pretty-print an inferred type in the command state captured when the
+--   inference command completed.  Shared with the JSON frontend.
+prettyInferredType :: CommandState -> A.Expr -> TCM Doc
+prettyInferredType state expr = evalStateT prettyExpr state
+  where
+    prettyExpr = localStateCommandM
+        $ lift
+        $ B.atTopLevel
+        $ TCP.prettyA
+        $ expr
 
 -- | Prefix prettified CPUTime with "Time:"
 prettyTimed :: CPUTime -> Doc

--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -358,12 +358,12 @@ instance EncodeTCM DisplayInfo where
     [ "commandState"      @= commandState
     , "computeMode"       @= computeMode
     , "time"              @= time
-    , "expr"              #= encodePrettyTCM expr
+    , "expr"              #= (encodeShow <$> prettyNormalForm commandState computeMode expr)
     ]
   encodeTCM (Info_InferredType commandState time expr) = kind "InferredType"
     [ "commandState"      @= commandState
     , "time"              @= time
-    , "expr"              #= encodePrettyTCM expr
+    , "expr"              #= (encodeShow <$> prettyInferredType commandState expr)
     ]
   encodeTCM (Info_Context ii ctx) = kind "Context"
     [ "interactionPoint"  @= ii
@@ -379,8 +379,10 @@ instance EncodeTCM DisplayInfo where
 
 instance EncodeTCM GoalTypeAux where
   encodeTCM GoalOnly = kind "GoalOnly" []
-  encodeTCM (GoalAndHave expr _) = kind "GoalAndHave"
-    [ "expr" #= encodePrettyTCM expr ]
+  encodeTCM (GoalAndHave expr boundary) = kind "GoalAndHave"
+    [ "expr"     #= encodePrettyTCM expr
+    , "boundary" @= map encodePretty boundary
+    ]
   encodeTCM (GoalAndElaboration expr) = kind "GoalAndElaboration"
     [ "term" #= encodePrettyTCM expr ]
 
@@ -479,7 +481,8 @@ instance EncodeTCM Response where
         , "expression"        .= P.prettyShow expr
         ]
   encodeTCM (Resp_Mimer ii str) = kind "Mimer"
-    [ "solution" @= str
+    [ "interactionPoint" @= ii
+    , "solution"         @= str
     ]
 
 -- | Convert Response to an JSON value for interactive editor frontends.


### PR DESCRIPTION
The --interaction-json frontend dropped information that the Emacs frontend displays. After this PR, Agda:

- Encodes the boundary faces of GoalAndHave ("Boundary (actual)"), previously discarded by the encoder.
- Pretty-prints NormalForm/InferredType expressions in the command state captured when the command ran (as EmacsTop does), which fixes the needlessly qualified names of #5665.
- Includes the interaction point in Mimer responses, matching the Emacs agda2-solve-action encoding.

I noticed this because of an issue someone made on my VSCode extension for Agda (https://github.com/willtunnels/agda2-vscode/issues/1). The first bullet point fixes that issue, and I figured I might as well do some other, general cleanup.

Closes #5665.