### PR TITLE
Change R.constructor so that R is the record module rather than the type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,6 +346,38 @@ Language
 
 Changes to type checker and other components defining the Agda language.
 
+* (**BREAKING**) The pseudo-name `R.constructor`, which refers to the
+  constructor of record `R`, is now resolved by the ordinary scope lookup:
+  `constructor` is a name bound in the record module `R`.
+  (It can never be written unqualified, since `constructor` is a keyword;
+  in particular, `open R` does not bring it into scope, and a module
+  application `module M = R` does not provide `M.constructor`.)
+
+  Consequently, the qualification `R` in `R.constructor` is now interpreted
+  as the name of the record *module* rather than the name of the record
+  *type*.  Thus, this now succeeds:
+  ```agda
+  module M where
+    record R : Set where
+
+  open M using (module R)
+
+  t = R.constructor   -- used to fail
+  ```
+  while this now fails:
+  ```agda
+  module M where
+    record R : Set where
+
+  open M using (R) hiding (module R)
+
+  t = R.constructor   -- used to succeed
+  ```
+
+  This also fixes [Issue #8625](https://github.com/agda/agda/issues/8625):
+  an internal error when referring to `R.constructor` from the interaction
+  top level.
+
 * (**BREAKING**): In the presence of `--erasure`, types of lambdas expressions
   are not inferred unless every lambda-bound variable has been given its erasure
   status (`@0` or `@ω`) explicitely.

--- a/doc/user-manual/language/record-types.lagda.rst
+++ b/doc/user-manual/language/record-types.lagda.rst
@@ -290,16 +290,25 @@ though the constructor had been named.
 
   {-# INLINE Anon.constructor #-}
 
-However, keep in mind that the ``Record.constructor`` syntax is
-*syntax*, and there is no binding for ``constructor`` in the module
-``Anon``, nor is it possible to declare a function called
-``constructor`` in another module. Moreover, the ``constructor``
-pseudo-name is not affected by ``using``, ``hiding`` *or* ``renaming``
-declarations, and attempting to list it in these is a syntax error.
+Technically, ``constructor`` is a name bound in the
+:ref:`record module <record-modules>` ``Anon``.  However, since
+``constructor`` is a keyword, it can never be written as an unqualified
+name: it is not possible to declare a function called ``constructor``,
+opening the record module does not make the constructor accessible as
+``constructor``, and the pseudo-name cannot be listed in ``using``,
+``hiding`` *or* ``renaming`` directives (attempting to do so is a syntax
+error).
+
+Note also that ``constructor`` is merely an alias.  Unlike the projections,
+the record constructor is not itself a definition of the record module: it
+does not take an element of the record type as an argument.  Since a
+:ref:`module application <module-application>` copies the definitions of
+the module it instantiates, no ``M.constructor`` is available after
+``module M = Anon``.
 
 The constructor of a record can be referred to whenever the record
-itself is in scope, though note that if the record is abstract (see
-:ref:`abstract-definitions`), it's still an error to refer to the
+module itself is in scope, though note that if the record is abstract
+(see :ref:`abstract-definitions`), it's still an error to refer to the
 constructor:
 
 .. code-block:: agda

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -126,8 +126,6 @@ data ScopeInfo = ScopeInfo
       , _scopeInScope       :: InScopeSet
       , _scopeFixities      :: C.Fixities    -- ^ Maps concrete names C.Name to fixities
       , _scopePolarities    :: C.Polarities  -- ^ Maps concrete names C.Name to polarities
-      , _scopeRecords       :: Map A.QName (A.QName, Maybe Induction)
-        -- ^ Maps the name of a record to the name of its (co)constructor.
       }
   deriving (Show, Generic)
 
@@ -148,7 +146,7 @@ type NameMap   = HashMap NameId      NameMapEntry
 type ModuleMap = HashMap A.ModuleName [C.QName]
 
 instance Eq ScopeInfo where
-  ScopeInfo c1 m1 v1 l1 p1 _ _ _ _ _ _ == ScopeInfo c2 m2 v2 l2 p2 _ _ _ _ _ _ =
+  ScopeInfo c1 m1 v1 l1 p1 _ _ _ _ _ == ScopeInfo c2 m2 v2 l2 p2 _ _ _ _ _ =
     c1 == c2 && m1 == m2 && v1 == v2 && l1 == l2 && p1 == p2
 
 -- | Local variables.
@@ -274,11 +272,6 @@ scopePolarities :: Lens' ScopeInfo C.Polarities
 scopePolarities f s =
   f (_scopePolarities s) <&>
   \x -> s { _scopePolarities = x }
-
-scopeRecords :: Lens' ScopeInfo (Map A.QName (A.QName, Maybe Induction))
-scopeRecords f s =
-  f (_scopeRecords s) <&>
-  \x -> s { _scopeRecords = x }
 
 scopeFixitiesAndPolarities :: Lens' ScopeInfo (C.Fixities, C.Polarities)
 scopeFixitiesAndPolarities f s =
@@ -778,7 +771,6 @@ emptyScopeInfo = ScopeInfo
   , _scopeInScope       = Set.empty
   , _scopeFixities      = Map.empty
   , _scopePolarities    = Map.empty
-  , _scopeRecords       = Map.empty
   }
 
 -- | Map functions over the names and modules in a scope.
@@ -1521,6 +1513,15 @@ recomputeInverseNamesAndModules scope = St2.execState goCurrent (mempty, mempty)
     intern (C.Name _ _ (C.Id ('.' : '#' : _) :| [])) = True
     intern _ = False
 
+  -- The pseudo-name @constructor@ bound in a record module (see
+  -- 'Agda.Syntax.Scope.Monad.bindRecordConstructorPseudoName') is a keyword,
+  -- so it cannot be parsed unqualified.  Thus, it must not be offered as an
+  -- unqualified rendering of the record constructor (which could happen after
+  -- @open R@).  Qualified renderings like @R.constructor@ are fine.
+  unqualifiedKeyword :: C.QName -> Bool
+  unqualifiedKeyword (C.QName (C.Name _ _ (C.Id "constructor" :| []))) = True
+  unqualifiedKeyword _ = False
+
   updModules qualx m =
     St2.modify2 $ HMap.insertWith (\_ acc -> qualx:acc) m [qualx]
 
@@ -1542,7 +1543,7 @@ recomputeInverseNamesAndModules scope = St2.execState goCurrent (mempty, mempty)
         -- names
         Map.forWithKey_ names \x ys -> do
           let !qualx = applyQuals (C.QName x) quals
-          when (not (internalName qualx)) do
+          when (not (internalName qualx || unqualifiedKeyword qualx)) do
             forM_ ys \y -> do
               let nid   = A.nameId y
               let entry = NameMapEntry (anameKind y) (qualx :| [])
@@ -1672,7 +1673,7 @@ blockOfLines _  [] = []
 blockOfLines hd ss = hd : map (nest 2) ss
 
 instance Pretty ScopeInfo where
-  pretty (ScopeInfo this mods toBind locals ctx _ _ _ fixs _ _) = vcat $ concat
+  pretty (ScopeInfo this mods toBind locals ctx _ _ _ fixs _) = vcat $ concat
     [ [ "ScopeInfo"
       , nest 2 $ "current =" <+> pretty this
       ]

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -10,9 +10,7 @@ import Prelude hiding (null)
 import Control.Monad.Except       ( MonadError, throwError, runExceptT )
 import Control.Monad.State        ( StateT, runStateT, gets, modify )
 import Control.Monad.Trans        ( MonadTrans, lift )
-import Control.Monad.Trans.Maybe  ( MaybeT(MaybeT), runMaybeT )
 import Control.Monad.IO.Class
-import Control.Applicative
 
 import Data.Either ( partitionEithers )
 import Data.Foldable (all, traverse_)
@@ -361,21 +359,26 @@ tryResolveName kinds names x = do
           (Just (_, ss), _) ->
             throwAmb $ AmbiguousDeclName $ List2.append (d :| map fst ds) (fmap fst ss)
 
-        -- Name is of the form r.constructor
-        Nothing | Just r <- isRecordConstructor x -> do
-          -- We resolve the record name r with no filter, that way we
-          -- can know when printing an error message whether r is not in
-          -- scope, or whether it's some other type of name, etc.
-          recd <- tryResolveName AllKindsOfNames Nothing r
-
-          case recd of
-            DefinedName acc abs suf -> getRecordConstructor (anameName abs) >>= \case
-              Just (qn, ind) -> return $ ConstructorName (Set1.singleton $ fromMaybe Inductive ind) $
-                List1.singleton $ upd abs { anameName = qn, anameKind = ConName }
-              Nothing -> throwError $ ConstrOfNonRecord r recd
-            _ -> throwError $ ConstrOfNonRecord r recd
-
         Nothing -> case suffixedNames of
+          -- Name is of the form R.constructor but did not resolve.
+          -- Since the record constructor is bound as @constructor@ in the
+          -- scope of the record module R (see 'bindRecordConstructorPseudoName'),
+          -- this means that R is not (the module of) a record type.
+          -- Produce a more informative error than "not in scope".
+          Nothing | Just r <- isRecordConstructor x -> do
+            -- We resolve the record name r with no filter, that way we
+            -- can know when printing an error message whether r is not in
+            -- scope, or whether it's some other type of name, etc.
+            tryResolveName AllKindsOfNames Nothing r >>= \case
+              -- If R does resolve to a record type, its constructor is
+              -- simply not in scope here; report the plain not-in-scope error.
+              DefinedName _ d _ | anameKind d == RecName -> return UnknownName
+              -- If R is not a name but a module (e.g. a copy of a record module),
+              -- report R.constructor rather than R as not in scope.
+              UnknownName | not $ null (scopeLookup r scope :: [AbstractModule]) ->
+                return UnknownName
+              recd -> throwError $ ConstrOfNonRecord r recd
+
           Nothing -> return UnknownName
           Just (suffix , (d, a) :| []) -> return $ DefinedName a (upd d) suffix
           Just (suffix , (d1,_) :| (d2,_) : sds) ->
@@ -566,28 +569,67 @@ bindQModule acc q m = do
 -- * Operations to do with record constructor names
 ---------------------------------------------------
 
--- | Record (ha) that a given record has the specified constructor name.
-setRecordConstructor :: A.QName -> (A.QName, Maybe Induction) -> ScopeM ()
-setRecordConstructor recr con = modifyScope $ over scopeRecords $ Map.insert recr con
+-- | Bind the pseudo-name @constructor@ in the scope of the record module,
+--   mapping it to the (possibly anonymous) constructor of the record.
+--
+--   This is what makes @R.constructor@ resolve: @R@ is the record /module/
+--   and @constructor@ an ordinary name in it, so no special treatment is
+--   needed when resolving the qualified name @R.constructor@.
+--
+--   Note that @constructor@ is a keyword, thus, it can never be parsed
+--   as an unqualified name.  In particular, @open R@ does not make the
+--   record constructor accessible under the name @constructor@, and
+--   @constructor@ cannot be mentioned in @using@, @hiding@ or @renaming@.
+--
+--   This does not put the record constructor itself into the record module
+--   (which would be wrong, see issue #4189, since the record module is
+--   parameterized over the record value, but the constructor is not);
+--   it only adds this alias for it.
+bindRecordConstructorPseudoName :: A.ModuleName -> KindOfName -> A.QName -> ScopeM ()
+bindRecordConstructorPseudoName m kind y = do
+  modifyNamedScope m $
+    addNameToScope PublicNS recordConstructorPseudoName $
+      AbsName y kind Defined noMetadata
+  -- Note: we cannot use 'addNameToInverseScope' here, since that would
+  -- register the unqualified (and thus unparseable) rendering @constructor@.
+  recomputeInverseScope
 
--- | Get the internal 'QName' for the  name of a record constructor. If
--- the name does not refer to a record type, 'Nothing' is returned.
-getRecordConstructor :: ReadTCState m => A.QName -> m (Maybe (A.QName, Maybe Induction))
-getRecordConstructor recr = runMaybeT $ local <|> imported where
-  local = do
-    recs <- useScope scopeRecords
-    MaybeT $ pure $ Map.lookup recr recs
-  imported = do
-    idefs <- useTC (stImports . sigDefinitions)
-    case theDef <$> HMap.lookup recr idefs of
-      Just def@I.Record{} -> pure (I.recCon def, I.recInduction def)
-      _ -> MaybeT $ pure Nothing
+-- | Remove the record constructor pseudo-name from the scope of a record module.
+--
+--   The alias @constructor@ is only meant to be used in the qualified form
+--   @R.constructor@, where @R@ is the record module.  Thus, it is not brought
+--   into scope by @open R@.
+--
+--   It is also not copied when the record module @R@ itself is applied to
+--   arguments (as in @module M = R@): the record module is parameterized over
+--   the record value, but the record constructor is not (issue #4189).
+--   (When @R@ is only copied as a submodule of the applied module, the
+--   constructor is copied correctly, since the arguments are then taken from
+--   the enclosing module.)
+dropRecordConstructorPseudoName :: Scope -> Scope
+dropRecordConstructorPseudoName s
+  | Just IsRecordModule <- scopeDatatypeModule s =
+      -- We don't have enough information for an incremental update of the
+      -- in-scope sets, so recompute them (cheap: record modules are small).
+      recomputeInScopeSets $ mapScope_ (Map.delete recordConstructorPseudoName) id id s
+  | otherwise = s
 
+-- | The pseudo-name @constructor@ under which the constructor of a record
+--   is bound in the scope of the record module.
+--
+--   Since @constructor@ is a keyword, this name is only reachable
+--   as the tail of a qualified name, e.g., @R.constructor@.
+recordConstructorPseudoName :: C.Name
+recordConstructorPseudoName = C.simpleName "constructor"
 
--- | Is this the qualified name which refers to the constructor of an
--- anonymous record (like @Foo.constructor@)?
+-- | Is this the qualified name which refers to the constructor of a
+-- record (like @Foo.constructor@)?
 --
 -- If so, return the part of the name referring to the record (@Foo@).
+--
+-- This is only used to produce a good error message when @Foo.constructor@
+-- does not resolve; the resolution itself goes through the ordinary
+-- scope lookup, see 'bindRecordConstructorPseudoName'.
 isRecordConstructor :: C.QName -> Maybe C.QName
 isRecordConstructor = fmap to . toplevel where
   toplevel, is :: C.QName -> Maybe [C.Name]
@@ -648,7 +690,8 @@ copyName from to = do
 --   renamings.
 copyScope :: C.QName -> A.ModuleName -> Scope -> ScopeM (Scope, ScopeCopyInfo)
 copyScope oldc new0 s =
-  (inScopeBecause (Applied oldc) *** memoToScopeInfo) <$> runStateT (copy new0 s) (ScopeMemo mempty mempty)
+  (inScopeBecause (Applied oldc) *** memoToScopeInfo) <$>
+    runStateT (copy new0 $ dropRecordConstructorPseudoName s) (ScopeMemo mempty mempty)
   where
     copy :: A.ModuleName -> Scope -> WSM Scope
     copy new s = do
@@ -670,7 +713,20 @@ copyScope oldc new0 s =
         old  = scopeName s
 
         copyD :: NamesInScope -> WSM NamesInScope
-        copyD = traverse $ mapM $ onName renName
+        copyD = Map.traverseWithKey \ x -> mapM $ onName $ renNameFor x
+
+        -- Andreas, 2026-08-23:
+        -- The pseudo-name @constructor@ bound in a record module
+        -- (see 'bindRecordConstructorPseudoName') is only an alias for the record
+        -- constructor.  If the record has a named constructor, the latter lives
+        -- outside the record module, and copying the alias like an ordinary name
+        -- would produce a second copy of the constructor (plus a spurious copy of
+        -- the module the constructor lives in).  Thus, reuse the existing copy.
+        renNameFor :: C.Name -> A.QName -> WSM A.QName
+        renNameFor x y
+          | x == recordConstructorPseudoName =
+              maybe (renName y) (return . List1.head) =<< findName y
+          | otherwise = renName y
 
         copyM :: ModulesInScope -> WSM ModulesInScope
         copyM = traverse $ mapM $ lensAmodName renMod
@@ -686,20 +742,14 @@ copyScope oldc new0 s =
         addMod  x y rec = modify $ \ i -> i { memoModules = Map.insert x (y, rec) (memoModules i) }
 
         -- Querying the memo structure.
-        findName x = gets (Map.lookup x . memoNames) -- NB:: Defined but not used
+        findName :: A.QName -> WSM (Maybe (List1 A.QName))
+        findName x = gets (Map.lookup x . memoNames)
         findMod  x = gets (Map.lookup x . memoModules)
 
         refresh :: A.Name -> WSM A.Name
         refresh x = do
           i <- lift fresh
           return $ x { A._nameId = i }
-
-        copyRecordConstr :: A.QName -> A.QName -> WSM ()
-        copyRecordConstr from to = getRecordConstructor from >>= \case
-          Just (con, ind) -> do
-            con' <- renName con
-            lift $ setRecordConstructor to (con', ind)
-          Nothing  -> pure ()
 
         -- Change a binding M.x -> old.M'.y to M.x -> new.M'.y
         renName :: A.QName -> WSM A.QName
@@ -737,7 +787,6 @@ copyScope oldc new0 s =
           lift $ reportSLn "scope.copy" 50 $ "  Copying " ++ prettyShow x ++ " to " ++ prettyShow y
           addName x y
           lift (copyName x y)
-          copyRecordConstr x y
           return y
 
         -- Change a binding M.x -> old.M'.y to M.x -> new.M'.y
@@ -1064,6 +1113,7 @@ openModule kwr kind mam cm dir = do
 
   -- Get the scope exported by module to be opened.
   (adir, s') <- applyImportDirectiveM cm dir . inScopeBecause (Opened cm) .
+                dropRecordConstructorPseudoName .
                 noGeneralizedVarsIfLetOpen kind =<< getNamedScope m
   registerModuleOpening kwr current cm dir s' -- For the unused import warning
   let s  = setScopeAccess acc s'

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2510,27 +2510,31 @@ scopeCheckRecDef r o a pc uc forceEta x directives pars fields =
 
       bindModule p x m
 
+      -- Name kind of the record constructor (inductive/coinductive).
+      let conKind = maybe ConName (conKindOfName . rangedThing) ind
+
       -- Bind the record constructor.
       cm' <- case cm of
 
         -- Andreas, 2019-11-11, issue #4189, no longer add record constructor to record module.
-        Just (c, inst) -> NamedRecCon <$> bindRecordConstructorName c kind inst a p
-          where
-            -- Name kind of the record constructor (inductive/coinductive).
-            kind = maybe ConName (conKindOfName . rangedThing) ind
+        Just (c, inst) -> NamedRecCon <$> bindRecordConstructorName c conKind inst a p
 
         -- Amy, 2024-09-25: if the record does not have a named
-        -- constructor, then generate the QName here, and record it in
-        -- the TC state so that 'Record.constructor' can be resolved.
+        -- constructor, then generate the QName here.
         Nothing -> do
-          -- Technically it doesn't matter with what this name is
-          -- qualified since record constructor names have a special
-          -- printing rule in lookupQName.
+          -- The name is qualified by the record module @m@ so that it is
+          -- copied along with the record module by 'copyScope'.
+          -- (Record constructor names have a special printing rule in
+          -- lookupQName, so the qualification does not show up in output.)
           constr <- withCurrentModule m $
             freshAbstractQName noFixity' $ simpleName "constructor"
           pure $ FreshRecCon constr
 
-      setRecordConstructor x' (recordConName cm', fmap rangedThing ind)
+      -- Andreas, 2026-08-23: Make the constructor accessible as @R.constructor@
+      -- by binding the pseudo-name @constructor@ in the record module.
+      -- Note that this is just an alias; the constructor itself does not live
+      -- in the record module (issue #4189).
+      bindRecordConstructorPseudoName m conKind (recordConName cm')
 
       -- Return the translated record definition.
       let inst = caseMaybe cm NotInstanceDef snd

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
@@ -243,8 +243,8 @@ instance EmbPrj Precedence where
     valu _          = malformed
 
 instance EmbPrj ScopeInfo where
-  icod_ (ScopeInfo a b c d e f g h i j k) = icodeN' (\ a b c d e -> ScopeInfo a b c d e f g h i j k) a b c d e
+  icod_ (ScopeInfo a b c d e f g h i j) = icodeN' (\ a b c d e -> ScopeInfo a b c d e f g h i j) a b c d e
 
-  value = valueN (\ a b c d e -> ScopeInfo a b c d e HMap.empty HMap.empty Set.empty Map.empty Map.empty Map.empty)
+  value = valueN (\ a b c d e -> ScopeInfo a b c d e HMap.empty HMap.empty Set.empty Map.empty Map.empty)
 
 instance EmbPrj NameOrModule

--- a/test/Bugs/Issue8182.err
+++ b/test/Bugs/Issue8182.err
@@ -27,7 +27,7 @@ out > {G : Set} → G → P (F (?1 {G = G})) (g (?1 {G = G}))
 out > contype =  Set → Set
 out > gamma = 
 out > adding record type to signature
-out > record constructor is  Issue8182.R.constructor
+out > record constructor is  R.constructor
 out > record section: R (r : R) [], [Issue8182.R.B]
 out >   field tel = (B : Set)
 out > Found interaction point ConcreteDef ?0 : Set

--- a/test/Fail/AnonymousRecConstrModuleApp.agda
+++ b/test/Fail/AnonymousRecConstrModuleApp.agda
@@ -1,0 +1,20 @@
+-- Andreas, 2026-08-24, re issue #8625
+
+module AnonymousRecConstrModuleApp where
+
+-- The Record.constructor syntax refers to the record module Record,
+-- but currently has some special status.
+-- In accordance to #4189, the record constructor does not live in the record module.
+-- Thus, applying the record module to arguments, does not give access to the constructor.
+
+record R : Set₁ where
+  field x : Set
+
+module M = R
+
+_ = M.constructor
+
+-- Fails, although one could image a change of the semantics that makes this work.
+-- error: [NotInScope]
+-- Not in scope:
+--   M.constructor

--- a/test/Fail/AnonymousRecConstrModuleApp.err
+++ b/test/Fail/AnonymousRecConstrModuleApp.err
@@ -1,0 +1,6 @@
+AnonymousRecConstrModuleApp.agda:15.5-18: error: [NotInScope]
+Not in scope:
+  M.constructor
+  at AnonymousRecConstrModuleApp.agda:15.5-18
+    (did you mean 'R.constructor'?)
+when scope checking M.constructor

--- a/test/Fail/AnonymousRecConstrRecordType.agda
+++ b/test/Fail/AnonymousRecConstrRecordType.agda
@@ -1,0 +1,16 @@
+-- Andreas, 2026-08-24, changed semantics for issue #8625
+
+-- The qualification in `R.constructor` is the name of the record MODULE,
+-- so having only the record TYPE in scope does not suffice.
+
+module _ where
+
+module M where
+  record R : Set where
+
+open M using (R) hiding (module R)
+
+_ = R.constructor
+
+-- Should fail, used to work in 2.8.0 because qualification `R`
+-- was interpreted as record type there rather than as record module.

--- a/test/Fail/AnonymousRecConstrRecordType.err
+++ b/test/Fail/AnonymousRecConstrRecordType.err
@@ -1,0 +1,6 @@
+AnonymousRecConstrRecordType.agda:13.5-18: error: [NotInScope]
+Not in scope:
+  R.constructor
+  at AnonymousRecConstrRecordType.agda:13.5-18
+    (did you mean 'M.R.constructor'?)
+when scope checking R.constructor

--- a/test/Succeed/AnonymousRecConstrOpen.agda
+++ b/test/Succeed/AnonymousRecConstrOpen.agda
@@ -1,0 +1,24 @@
+-- Andreas, 2026-08-24, re issue #8625
+
+module AnonymousRecConstrOpen where
+
+-- Opening a record module does not bring the pseudo-name `constructor`
+-- into scope; in particular, it does not add a second name for the
+-- record constructor that would make its notation ambiguous.
+
+open import Agda.Builtin.Nat
+
+record R : Set2 where
+  constructor mk
+  field
+    fst snd : Set1
+
+open R public
+
+syntax mk A B = A ⟶ B
+
+_ : R
+_ = Set ⟶ Set
+
+_ : (A B : Set1) → R
+_ = R.constructor

--- a/test/Succeed/AnonymousRecConstrRecordModule.agda
+++ b/test/Succeed/AnonymousRecConstrRecordModule.agda
@@ -1,0 +1,16 @@
+-- Andreas, 2026-08-24, changed semantics for issue #8625
+
+-- The qualification in `R.constructor` is the name of the record MODULE,
+-- so it is enough to have the record module in scope.
+
+module _ where
+
+module M where
+  record R : Set where
+
+open M using (module R)
+
+_ = R.constructor
+
+-- Should succeed, failed in 2.8.0 because qualification `R`
+-- was interpreted as record type there rather than as record module.

--- a/test/interaction/Issue8625.agda
+++ b/test/interaction/Issue8625.agda
@@ -1,0 +1,4 @@
+record R : Set2 where
+  field A : Set1
+
+-- C-c C-d R.constructor

--- a/test/interaction/Issue8625.in
+++ b/test/interaction/Issue8625.in
@@ -1,0 +1,2 @@
+top_command (cmd_load currentFile [])
+top_command (cmd_infer_toplevel Instantiated "R.constructor")

--- a/test/interaction/Issue8625.out
+++ b/test/interaction/Issue8625.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "Checked")
+(agda2-info-action "*All Done*" "" nil)
+((last . 1) . (agda2-goals-action '()))
+(agda2-status-action "Checked")
+(agda2-info-action "*Inferred Type*" "(A : Set₁) → R" nil)


### PR DESCRIPTION
The current implementation of `R.constructor` looks for a record type `R` rather for a record module `R`, requiring extra infrastructure in the scope.

This commit changes the semantics so that `R` has to be in scope as record module.  This feels more intuitive, given that in qualifications `M.x` the name `M` is always a module, not a type.

As a side effect, this fixes #8625.

Still `R.constructor` is not a first-class qualified name, in particular:
1. `open R` does not bring `constructor` into scope.
2. `module M = R` does not copy `constructor`, so there is no `M.constructor`.

These restrictions were (maybe more naturally) in place already in the previous implementation.  One could think of lifting them if there is some interest in this, however, this is future work.

Doc rendering at: https://agda--8681.org.readthedocs.build/en/8681/language/record-types.html#anonymous-constructors

For the record, here follows the essence of the AI interaction.

Prompt 1
========

test/interaction/Issue8625 fails with an internal error.
[...]
The error could be suppressed by the following change [...].
However, a more principled fix is desired.

The feature to refer to the anonymous record constructor of record `R` by the pseudoname `R.constructor` was introduced in 3ff01aba24826aa3bc9f1c0f5849b47b52b3ffaf (and patched in cb3abeb1f604470529497d3cea18d0feecc0c89a).
However the implementation seems not the best, e.g.
```haskell
getRecordConstructor :: ReadTCState m => A.QName -> m (Maybe (A.QName, Maybe Induction))
getRecordConstructor recr = runMaybeT $ local <|> imported where
  local = do
    recs <- useScope scopeRecords
    MaybeT $ pure $ Map.lookup recr recs
  imported = do
    idefs <- useTC (stImports . sigDefinitions)
    case theDef <$> HMap.lookup recr idefs of
      Just def@I.Record{} -> pure (I.recCon def, I.recInduction def)
      _ -> MaybeT $ pure Nothing
```
queries directly the signature, which should in general be avoided, one should preferably go through the scope.
Also the implementation introduced a new field into the scope:
```haskell
 , _scopeRecords       :: Map A.QName (A.QName, Maybe Induction)
   -- ^ Maps the name of a record to the name of its (co)constructor.
```
It seems one could implement the feature without this extra structure.
The idea would be to treat in `R.constructor` `R` as the name of the record module rather than the record type.  (This would be not entirely backwards compatible, but this semantic change is justifiable.)
Then `constructor` is a concrete name in the module `R` that maps to the (abstract) name of the record constructor.
Note that `constructor` is by itself not parseable as a name, so even after opening module `R` one cannot refer to the constructor by `constructor`.
So one can only refer to the constructor this way by the qualified name `R.constructor`.

The idea is that by restructuring the implementation the issue #8625 automatically disappears, since resolving `R.constructor` then uses the standard mechanisms of scope handling.

Please investigate an implementation of the `R.constructor` feature without the special structure `scopeRecords` and without hacks like accessing the imported signature directly.

Answer 1
========

Root cause
----------

`_scopeRecords` was never serialised — `Serialise/Instances/Abstract.hs` rebuilds `ScopeInfo` with `Map.empty` — and `writeInterface` round-trips the interface through serialisation. So `iInsideScope`, which the interaction top level runs in, always had an empty record map, and `getRecordConstructor`'s signature fallback consults only `stImports`, never the current module. `R.constructor` resolved to nothing and `resolveName'` hit `RecName -> __IMPOSSIBLE__`.

The restructuring
-----------------

`constructor` is now an ordinary name in the record module's scope, so `R.constructor` resolves by plain qualified lookup. Gone: `_scopeRecords` and its lens, `setRecordConstructor`, `getRecordConstructor`, `copyRecordConstr`, and the special case in `tryResolveName`. `isRecordConstructor` survives only to keep the `ConstructorNameOfNonRecord` diagnostics when lookup fails — a diagnosis path, not a resolution path.

Three consequences the design forced, each surfaced by an existing test rather than by inspection:

1. **`module M = R`** copied the alias and gave the constructor the record-module telescope — a wrong type, the modern shape of #4189. `dropRecordConstructorPseudoName` strips the alias when the record module *itself* is the applied scope; copying `R` as a submodule of an applied parent still works, since arguments then come from the enclosing module.
2. **`Fail/Issue7792`** printed `Foo.constructor` for `inc`: copying the alias made a second copy of the named constructor plus a spurious copy of its module. Fixed by having `copyD` reuse the existing copy — which is what the long-dead `findName` memo was for.
3. **`Succeed/IrrelevanceCaseStudyPartialFunctions`** hit an ambiguous parse: `open _⇀_ public` pulled `constructor` in and duplicated the constructor's `syntax` notation. Fixed by dropping the alias in `openModule`, plus a guard in `recomputeInverseNamesAndModules` so bare `constructor` is never offered as a rendering.

Beyond the Agda suite: the full standard library type-checks clean under `--ignore-interfaces`, and 1173 cubical modules check clean.

Two calls worth your review
---------------------------

- The CHANGELOG entry is marked **BREAKING** per your note, but I could not construct a program that actually breaks — import directives carry the record module with the record type (`using (R)` and `renaming (R to S)` both move the module; `hiding (module R)` hides both). Downgrading it to a plain entry would be defensible.
- `C-c C-o` on a record module now lists `constructor : (x : Set) → R` beside the fields, and `whyInScope R.constructor` reports it properly. I let both stand as improvements rather than suppressing them.

Two things about your workspace, unrelated to the change: `Issue8625.in` was staged as `test/Interaction/Issue8625.in`, which your case-insensitive filesystem tolerates but CI would not — I re-staged it under `test/interaction/`. And the cubical `make` exits nonzero because its `Everything.agda` generator sweeps in your untracked `cubical/tmp/Issue7629.agda`, which has no module header. Submodule working trees are exactly as I found them; I temporarily reverted your WIP `Appending/Setoid/Properties.agda` for the std-lib run (it fails on both binaries) and restored it.

Prompt 2
========

Thanks for the fix.

1. Documentation
----------------

In `record-types.lagda.rst` you wrote:
> so applying the record module to arguments (as in ``module M = Anon``) does not give access to ``M.constructor``.

This formulation is not easily understandable by the end user, because ``module M = Anon`` does not visibly apply `Anon` to arguments (if it applies at all).
Try to find a better explanation here, or, if this was in error, drop this part.

2. Breaking change
------------------

You say you did not find cases in which this fix is actually breaking, but they are easy to find.  Here is a case (to be added to test/Succeed) that works now but did not work before:
```agda
module _ where

module M where
  record R : Set where

open M using (module R)

t = R.constructor

-- Should succeed, failed in 2.8.0 because qualification `R`
-- was interpreted as record type there rather than as record module.
```
Likewise, there is a case that used to work but fails now (to be added to test/Fail).
```agda
module _ where

module M where
  record R : Set where

open M using (R) hiding (module R)

t = R.constructor

-- Should fail, used to work in 2.8.0 because qualification `R`
-- was interpreted as record type there rather than as record module.
```
Please add these tests.

Answer 2
========

I need to correct something in my earlier report before going further. [...]

1. Documentation — fixed
------------------------

You were right that `module M = Anon` shows no arguments. Rewritten to explain it in terms the reader can see, leaning on the manual's own framing that a module application copies the instantiated module's definitions:

> Note also that `constructor` is merely an alias. Unlike the projections, the record constructor is not itself a definition of the record module: it does not take an element of the record type as an argument. Since a :ref:`module application <module-application>` copies the definitions of the module it instantiates, no `M.constructor` is available after
> ```agda
> module M = Anon
> ```

2. Tests — added, and the CHANGELOG corrected
---------------------------------------------

- `test/Succeed/AnonymousRecConstrRecordModule.agda` — `open M using (module R)`; passes. I verified `using (module R)` really does *not* bring the record type into scope, so this genuinely exercises module-based resolution.
- `test/Fail/AnonymousRecConstrRecordType.agda` + `.err` — `open M using (R) hiding (module R)`; fails with `Not in scope: R.constructor` (plus a `did you mean 'M.R.constructor'?` hint).

[...]

I also replaced my hedged CHANGELOG paragraph with your two concrete examples, so the breaking change is stated in code rather than asserted.
