### PR TITLE
Fix #8680 (pattern syn) by removing spurious `__IMPOSSIBLE__`

### DIFF
--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2249,11 +2249,17 @@ instance ToAbstract NiceDeclaration where
               | otherwise -> return $ WithHiding h a
             ConstructorName _ ys -> err $ PatternSynonymArgumentShadows IsConstructor x ys
             PatternSynResName ys -> err $ PatternSynonymArgumentShadows IsPatternSynonym x ys
-            UnknownName -> err $ UnusedVariableInPatternSynonym x
-            -- Other cases are impossible because parsing the pattern syn rhs would have failed.
-            _ -> __IMPOSSIBLE__
+            -- In the remaining cases, the name has not been bound by the pattern syn rhs.
+            DefinedName{}         -> failure
+            FieldName{}           -> failure
+            VarName _ LambdaBound -> failure
+            VarName _ LetBound    -> failure
+            VarName _ WithBound   -> failure
+            VarName _ MacroBound  -> failure
+            UnknownName           -> failure
           where
             err = setCurrentRange x . typeError
+            failure = err $ UnusedVariableInPatternSynonym x
 
     d@NiceLoneConstructor{} -> [] <$ do
       declarationWarning $ InvalidConstructorBlock $ getRange d

--- a/test/Fail/Issue8680Field.agda
+++ b/test/Fail/Issue8680Field.agda
@@ -1,0 +1,16 @@
+-- Andreas, 2026-08-24, issue #8680
+-- Report and test case by Artem Shinkarov.
+
+open import Agda.Builtin.Nat
+
+record R : Set where
+  field x : Nat
+open R
+
+pattern fails x y = suc y
+
+-- WAS: Internal error
+-- Expected error: [UnusedVariableInPatternSynonym]
+-- Unused variable in pattern synonym: x
+-- when scope checking the declaration
+--   pattern fails x y = suc y

--- a/test/Fail/Issue8680Field.err
+++ b/test/Fail/Issue8680Field.err
@@ -1,0 +1,4 @@
+Issue8680Field.agda:10.15-16: error: [UnusedVariableInPatternSynonym]
+Unused variable in pattern synonym: x
+when scope checking the declaration
+  pattern fails x y = suc y

--- a/test/Fail/Issue8680Postulate.agda
+++ b/test/Fail/Issue8680Postulate.agda
@@ -1,0 +1,15 @@
+-- Andreas, 2026-08-24, issue #8680
+-- Report and test case by Artem Shinkarov.
+
+open import Agda.Builtin.Nat
+
+postulate
+  x : Nat
+
+pattern fails x y = suc y
+
+-- WAS: Internal error
+-- Expected error: [UnusedVariableInPatternSynonym]
+-- Unused variable in pattern synonym: x
+-- when scope checking the declaration
+--   pattern fails x y = suc y

--- a/test/Fail/Issue8680Postulate.err
+++ b/test/Fail/Issue8680Postulate.err
@@ -1,0 +1,4 @@
+Issue8680Postulate.agda:9.15-16: error: [UnusedVariableInPatternSynonym]
+Unused variable in pattern synonym: x
+when scope checking the declaration
+  pattern fails x y = suc y

--- a/test/Fail/Issue8680Variable.agda
+++ b/test/Fail/Issue8680Variable.agda
@@ -1,0 +1,15 @@
+-- Andreas, 2026-08-24, issue #8680
+-- Report and test case by Artem Shinkarov.
+
+open import Agda.Builtin.Nat
+
+variable
+  x : Nat
+
+pattern fails x y = suc y
+
+-- WAS: Internal error
+-- Expected error: [UnusedVariableInPatternSynonym]
+-- Unused variable in pattern synonym: x
+-- when scope checking the declaration
+--   pattern fails x y = suc y

--- a/test/Fail/Issue8680Variable.err
+++ b/test/Fail/Issue8680Variable.err
@@ -1,0 +1,4 @@
+Issue8680Variable.agda:9.15-16: error: [UnusedVariableInPatternSynonym]
+Unused variable in pattern synonym: x
+when scope checking the declaration
+  pattern fails x y = suc y


### PR DESCRIPTION
The `__IMPOSSIBLE__` triggering #8680 was entirely unjustified, so I remove it.

Closes #8680.
