### PR TITLE
Fix #8683: check cubical side conditions also in inference mode

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -262,13 +262,18 @@ inferApplication exh hd args e = postponeInstanceConstraints $ do
     A.Proj o p | isAmbiguous p -> inferProjApp e o p hd args
     A.Def' x s | Just (sz, u) <- isNameOfUniv x -> inferUniv sz u e x s args
     _ -> do
+      -- Issue #8683: the side conditions on the arguments of the cubical
+      -- primitives have to be checked in inference mode as well.
+      mk <- cubicalPrimitiveArgsCheck hd
       (f, t0) <- inferHead hd
       res <- runExceptT $ checkArgumentsE CmpEq exh hd args t0 Nothing
       case res of
-        Right st@(ACState{acType = t1}) -> fmap (,t1) $ unfoldInlined =<< checkHeadConstraints f st
+        Right st@(ACState{acType = t1}) -> fmap (,t1) $
+          unfoldInlined =<< checkHeadConstraints f =<< checkCubicalPrimitiveArgs mk st
         Left problem -> do
           t <- workOnTypes $ newTypeMeta_
-          v <- postponeArgs problem CmpEq exh hd args t0 t $ \ st -> unfoldInlined =<< checkHeadConstraints f st
+          v <- postponeArgs problem CmpEq exh hd args t0 t $ \ st ->
+                 unfoldInlined =<< checkHeadConstraints f =<< checkCubicalPrimitiveArgs mk st
           return (v, t)
 
 -----------------------------------------------------------------------------
@@ -416,12 +421,6 @@ checkHeadApplication :: Comparison -> A.Expr -> Type -> A.Expr -> [NamedArg A.Ex
 checkHeadApplication cmp e t hd args = do
   SortKit{ isNameOfUniv } <- sortKit
   sharp <- fmap nameOfSharp <$> coinductionKit
-  pOr    <- getNameOfConstrained builtinPOr
-  pComp  <- getNameOfConstrained builtinComp
-  pHComp <- getNameOfConstrained builtinHComp
-  pTrans <- getNameOfConstrained builtinTrans
-  mglue  <- getNameOfConstrained builtin_glue
-  mglueU  <- getNameOfConstrained builtin_glueU
   case hd of
     A.Def' c s | Just (sz, u) <- isNameOfUniv c -> checkUniv sz u cmp e t c s args
 
@@ -429,33 +428,62 @@ checkHeadApplication cmp e t hd args = do
     -- sharp we generate in the body of the wrapper is a Con.
     A.Def c | Just c == sharp -> checkSharpApplication e t c args
 
-    -- Cubical primitives
-    A.Def c | Just c == pComp -> defaultResult' $ Just $ checkPrimComp c
-    A.Def c | Just c == pHComp -> defaultResult' $ Just $ checkPrimHComp c
-    A.Def c | Just c == pTrans -> defaultResult' $ Just $ checkPrimTrans c
-    A.Def c | Just c == pOr   -> defaultResult' $ Just $ checkPOr c
-    A.Def c | Just c == mglue -> defaultResult' $ Just $ check_glue c
-    A.Def c | Just c == mglueU -> defaultResult' $ Just $ check_glueU c
-
-    _ -> defaultResult
+    -- The cubical primitives get their side conditions checked here as well.
+    _ -> defaultResult' =<< cubicalPrimitiveArgsCheck hd
   where
-  defaultResult :: TCM Term
-  defaultResult = defaultResult' Nothing
   defaultResult' :: Maybe (ArgRanges -> Args -> Type -> TCM Args) -> TCM Term
   defaultResult' mk = do
     (f, t0) <- inferHead hd
     expandLast <- viewTC eExpandLast
-    checkArguments cmp expandLast hd args t0 t $ \ st@(ACState cas _fun t1 checkedTarget) -> do
-      let check :: Maybe (TCM Args)
-          check = do
-            k <- mk
-            vs <- allApplyElims $ map' caElim cas
-            pure $ k (map' caRange cas) vs t1
-      st' <- case check of
-               Just ck -> (`setACElims` st) . map' Apply <$> ck
-               Nothing -> pure st
+    checkArguments cmp expandLast hd args t0 t $ \ st@(ACState _cas _fun t1 checkedTarget) -> do
+      st' <- checkCubicalPrimitiveArgs mk st
       v <- unfoldInlined =<< checkHeadConstraints f st'
       coerce' cmp checkedTarget v t1 t
+
+-- | Which cubical primitive is this head, if any, and how are the side
+--   conditions on its arguments checked?
+--
+--   These side conditions have to be verified wherever such a primitive is
+--   elaborated.  In particular also in inference mode (see 'inferApplication'),
+--   which is used e.g. for the scrutinee of a @with@, the right-hand side of a
+--   pattern-matching @let@, the principal argument of an ambiguous projection,
+--   and the first argument of the reflection primitive @unify@.  (Issue #8683.)
+cubicalPrimitiveArgsCheck ::
+     A.Expr
+       -- ^ The head of the application.
+  -> TCM (Maybe (ArgRanges -> Args -> Type -> TCM Args))
+cubicalPrimitiveArgsCheck hd = case unScope hd of
+    A.Def c -> loop c
+      [ (builtinComp  , checkPrimComp )
+      , (builtinHComp , checkPrimHComp)
+      , (builtinTrans , checkPrimTrans)
+      , (builtinPOr   , checkPOr      )
+      , (builtin_glue , check_glue    )
+      , (builtin_glueU, check_glueU   )
+      ]
+    _ -> return Nothing
+  where
+    loop _ [] = return Nothing
+    loop c ((b, k) : bks) = getNameOfConstrained b >>= \case
+      Just c' | c' == c -> return $ Just $ k c
+      _ -> loop c bks
+
+-- | Check the side conditions on the arguments of a cubical primitive
+--   (if the head is one), and return the possibly updated (blocked) arguments.
+checkCubicalPrimitiveArgs ::
+     Maybe (ArgRanges -> Args -> Type -> TCM Args)
+       -- ^ Result of 'cubicalPrimitiveArgsCheck' for the head of the application.
+  -> ArgsCheckState a
+  -> TCM (ArgsCheckState a)
+checkCubicalPrimitiveArgs mk st@(ACState cas _fun t1 _) = do
+  let check :: Maybe (TCM Args)
+      check = do
+        k <- mk
+        vs <- allApplyElims $ map' caElim cas
+        pure $ k (map' caRange cas) vs t1
+  case check of
+    Just ck -> (`setACElims` st) . map' Apply <$> ck
+    Nothing -> pure st
 
 -- Issue #3019 and #4170: Don't insert trailing implicits when checking arguments to existing
 -- metavariables.

--- a/test/Fail/Issue8683.agda
+++ b/test/Fail/Issue8683.agda
@@ -1,0 +1,25 @@
+{-# OPTIONS --cubical --safe #-}
+
+open import Agda.Primitive.Cubical renaming (primTransp to transp; primHComp to hcomp)
+open import Agda.Builtin.Cubical.Path
+open import Agda.Builtin.Nat
+
+-- The with-expression is an hcomp whose base (1) disagrees with its
+-- side (constantly 0) on φ = j.  Its type is inferred, and the side
+-- condition  u i0 ≡ λ _ → 1  on φ  is never checked.
+bad : I → Nat
+bad j with hcomp {A = Nat} {φ = j} (λ i _ → 0) 1
+... | w = w
+
+-- bad i0 = hcomp {φ = i0} _ 1 = 1  and  bad i1 = (λ i _ → 0) i1 1=1 = 0.
+path : 1 ≡ 0
+path j = bad j
+
+data ⊥ : Set where
+
+D : Nat → Set
+D zero    = ⊥
+D (suc _) = Nat
+
+boom : ⊥
+boom = transp (λ i → D (path i)) i0 0

--- a/test/Fail/Issue8683.err
+++ b/test/Fail/Issue8683.err
@@ -1,0 +1,7 @@
+Issue8683.agda:11.48-49: error: [UnequalTerms]
+The terms
+  1
+and
+  0
+are not equal at type Nat
+when inferring the type of hcomp {A = Nat} {φ = j} (λ i _ → 0) 1

--- a/test/Fail/Issue8683Let.agda
+++ b/test/Fail/Issue8683Let.agda
@@ -1,0 +1,17 @@
+{-# OPTIONS --cubical --safe #-}
+
+-- Andreas, 2026-08-25, issue #8683, variant without `with`.
+-- The rhs of a pattern-matching `let` is elaborated in inference mode,
+-- which used to skip the side conditions of the cubical primitives.
+
+open import Agda.Primitive.Cubical renaming (primHComp to hcomp)
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Sigma
+
+P : Set
+P = Σ Nat (λ _ → Nat)
+
+-- The hcomp's base (1 , 1) disagrees with its side (constantly (0 , 0))
+-- on φ = j, so this must be rejected.
+bad : I → Nat
+bad j = let (w , _) = hcomp {A = P} {φ = j} (λ i _ → (0 , 0)) (1 , 1) in w

--- a/test/Fail/Issue8683Let.err
+++ b/test/Fail/Issue8683Let.err
@@ -1,0 +1,8 @@
+Issue8683Let.agda:17.64-69: error: [UnequalTerms]
+The terms
+  1
+and
+  0
+are not equal at type Nat
+when inferring the type of
+hcomp {A = P} {φ = j} (λ i _ → 0 , 0) (1 , 1)

--- a/test/Fail/Issue8683Proj.agda
+++ b/test/Fail/Issue8683Proj.agda
@@ -1,0 +1,24 @@
+{-# OPTIONS --cubical --safe #-}
+
+-- Andreas, 2026-08-25, issue #8683, variant without `with`.
+-- The principal argument of an ambiguous projection is elaborated in
+-- inference mode, which used to skip the side conditions of the
+-- cubical primitives.
+
+open import Agda.Primitive.Cubical renaming (primHComp to hcomp)
+open import Agda.Builtin.Nat
+
+record R : Set where
+  constructor mk
+  field fst : Nat
+open R
+
+record S : Set where
+  constructor mk'
+  field fst : Nat
+open S
+
+-- The hcomp's base (mk 1) disagrees with its side (constantly (mk 0))
+-- on φ = j, so this must be rejected.
+bad : I → Nat
+bad j = fst (hcomp {A = R} {φ = j} (λ i _ → mk 0) (mk 1))

--- a/test/Fail/Issue8683Proj.err
+++ b/test/Fail/Issue8683Proj.err
@@ -1,0 +1,8 @@
+Issue8683Proj.agda:24.52-56: error: [UnequalTerms]
+The terms
+  1
+and
+  0
+are not equal at type Nat
+when inferring the type of
+hcomp {A = R} {φ = j} (λ i _ → mk 0) (mk 1)

--- a/test/Fail/Issue8683Unify.agda
+++ b/test/Fail/Issue8683Unify.agda
@@ -1,0 +1,38 @@
+{-# OPTIONS --cubical --safe #-}
+
+-- Andreas, 2026-08-25, issue #8683, variant without `with`.
+-- The first argument of the reflection primitive `unify` is elaborated in
+-- inference mode, which used to skip the side conditions of the
+-- cubical primitives.
+
+open import Agda.Primitive using (lzero)
+open import Agda.Primitive.Cubical
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Unit
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection
+
+vis : Term → Arg Term
+vis = arg (arg-info visible (modality relevant quantity-ω))
+
+hid : Term → Arg Term
+hid = arg (arg-info hidden (modality relevant quantity-ω))
+
+-- The reflected term  primHComp {lzero} {Nat} {var n} (λ i o → 0) 1.
+-- Its base 1 disagrees with its side (constantly 0) on var n,
+-- so this must be rejected.
+badTerm : Nat → Term
+badTerm n = def (quote primHComp)
+  ( hid (def (quote lzero) [])
+  ∷ hid (def (quote Nat) [])
+  ∷ hid (var n [])
+  ∷ vis (lam visible (abs "i" (lam visible (abs "o" (lit (nat 0))))))
+  ∷ vis (lit (nat 1))
+  ∷ [] )
+
+macro
+  bad : Term → TC ⊤
+  bad hole = unify (badTerm 0) hole
+
+f : I → Nat
+f j = bad

--- a/test/Fail/Issue8683Unify.err
+++ b/test/Fail/Issue8683Unify.err
@@ -1,0 +1,8 @@
+Issue8683Unify.agda:38.7-10: error: [UnequalTerms]
+The terms
+  1
+and
+  0
+are not equal at type Nat
+when inferring the type of
+primHComp {lzero} {Nat} {j} (λ i o → 0) 1


### PR DESCRIPTION
The side conditions on the arguments of the cubical primitives (primComp, primHComp, primTransp, primPOr, prim^glue and prim^glueU) were only checked by checkHeadApplication, not by inferApplication.
Terms elaborated in inference mode thus escaped the check, making False provable.  This affects the scrutinee of a with, the rhs of a pattern-matching let, the principal argument of an ambiguous projection, and the first argument of the reflection primitive unify.

Factor the dispatch out of checkHeadApplication into cubicalPrimitiveArgsCheck / checkCubicalPrimitiveArgs and call it from inferApplication as well, on both the success and the postponed arguments branch.

Closes #8683.
