### PR TITLE
Fix #8686: False via projection-like due to non-injective type of principal argument

### DIFF
--- a/src/full/Agda/TypeChecking/ProjectionLike.hs
+++ b/src/full/Agda/TypeChecking/ProjectionLike.hs
@@ -75,7 +75,7 @@ import Agda.TypeChecking.Positivity
 import Agda.TypeChecking.Positivity.OccurrenceAnalysis qualified as Occ
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records
-import Agda.TypeChecking.Reduce (reduce, abortIfBlocked)
+import Agda.TypeChecking.Reduce (reduce, abortIfBlocked, reduceDefCopies)
 import Agda.TypeChecking.Telescope
 
 import Agda.TypeChecking.DropArgs
@@ -274,7 +274,7 @@ makeProjection x = whenM (optProjectionLike <$> pragmaOptions) $ do
                  funSplitTree = st0, funCompiled = cc0, funInv = NotInjective,
                  funMutual = Just [], -- Andreas, 2012-09-28: only consider non-mutual funs
                  funOpaque = TransparentDef} | not (def ^. funAbstract) -> do
-      ps0 <- filterM validProj $ candidateArgs [] t
+      ps0 <- filterM validProj =<< candidateArgs [] t
       reportSLn "tc.proj.like" 30 $ if null ps0 then "  no candidates found"
                                                 else "  candidates: " ++ prettyShow ps0
       unless (null ps0) $ do
@@ -420,18 +420,31 @@ makeProjection x = whenM (optProjectionLike <$> pragmaOptions) $ do
     -- E.g. f : {x : _}(y : _){z : _} -> D x y z -> ...
     -- will return (D,3) as a candidate (amongst maybe others).
     --
-    candidateArgs :: [Term] -> Type -> [(Arg QName, Int)]
+    -- Precondition: t is in telescope normal form, i.e., all leading @Pi@s are exposed.
+    candidateArgs :: [Term] -> Type -> TCM [(Arg QName, Int)]
     candidateArgs vs t =
       case unEl t of
-        Pi a b
-          | Def d es <- unEl $ unDom a,
-            Just us  <- allApplyElims es,
-            all (not . isIrrelevant) us,
-            vs == map unArg us -> (d <$ argFromDom a, length vs) : candidateRec b
-          | otherwise          -> candidateRec b
-        _                      -> []
+        -- Andreas, 2026-08-26, issue #8686 (2)
+        -- We need to reduce the domain @a@ here otherwise its form (e.g. @D x y z@)
+        -- might not be preserved, violating the promise of projection-likeness that
+        -- the "parameters" can be reconstructed from the type of the principal argument.
+        -- However, full reduction is too expensive, busting test/Succeed/InstanceExpensiveContext.
+        -- Since projection-likeness is just an optimization, and thus need not be complete,
+        -- we have our choice of reduction, as long as we reduce enough to guarantee soundness
+        -- of projection likeness.
+        -- Luckily, reducing copy indirections from module applications should be sufficient,
+        -- because this is the only way heads that are @eligibleForProjectionLike@ can reduce.
+        -- Reducing copy indirections should be cheap.
+        Pi a b -> reduceDefCopies (unEl (unDom a)) >>= \case
+          Def d es
+            | Just us  <- allApplyElims es,
+              all (not . isIrrelevant) us,
+              vs == map unArg us -> ((d <$ argFromDom a, length vs) :) <$> candidateRec b
+            | otherwise          -> candidateRec b
+          _ -> candidateRec b
+        _ -> return []
       where
-        candidateRec NoAbs{}   = []
+        candidateRec NoAbs{}   = return []
         candidateRec (Abs x t) = candidateArgs (var (size vs) : vs) t
 
 {-# SPECIALIZE inferNeutral :: Term -> TCM Type #-}

--- a/src/full/Agda/TypeChecking/ProjectionLike.hs
+++ b/src/full/Agda/TypeChecking/ProjectionLike.hs
@@ -212,6 +212,8 @@ eligibleForProjectionLike d = eligible . theDef <$> getConstInfo d
 --      a name (@Def@) which is 'eligibleForProjectionLike':
 --      @data@ / @record@ / @postulate@.
 --
+--      None of the parameters may be irrelevant (issue #8686).
+--
 --   2. The application of f should only get stuck if the principal argument
 --      is inferable (neutral).  Thus:
 --
@@ -406,8 +408,10 @@ makeProjection x = whenM (optProjectionLike <$> pragmaOptions) $ do
       where badVar x = m - n <= x && x < m
 
     -- @candidateArgs [var 0,...,var(n-1)] t@ adds @(n,d)@ to the output,
-    -- if @t@ is a function-type with domain @t 0 .. (n-1)@
+    -- if @t@ is a function-type with domain @d 0 .. (n-1)@
     -- (the domain of @t@ is the type of the arg @n@).
+    -- Andreas, 2026-08-06, issue #8686:
+    -- The applications @d 0 .. (n-1)@ must be relevant.
     --
     -- This means that from the type of arg @n@ all previous arguments
     -- can be computed by a simple matching.
@@ -422,6 +426,7 @@ makeProjection x = whenM (optProjectionLike <$> pragmaOptions) $ do
         Pi a b
           | Def d es <- unEl $ unDom a,
             Just us  <- allApplyElims es,
+            all (not . isIrrelevant) us,
             vs == map unArg us -> (d <$ argFromDom a, length vs) : candidateRec b
           | otherwise          -> candidateRec b
         _                      -> []

--- a/src/full/Agda/TypeChecking/ProjectionLike.hs
+++ b/src/full/Agda/TypeChecking/ProjectionLike.hs
@@ -182,8 +182,9 @@ elimView loneProjectionLikeToLambda v = do
     NoProjection{} -> return v
 
 {-# SPECIALIZE eligibleForProjectionLike :: QName -> TCM Bool #-}
--- | Which @Def@types are eligible for the principle argument
+-- | Which @Def@ heads are eligible for the principle argument
 --   of a projection-like function?
+--   They need to be injective, which is the case for data, record, and axiom.
 eligibleForProjectionLike :: (HasConstInfo m) => QName -> m Bool
 eligibleForProjectionLike d = eligible . theDef <$> getConstInfo d
   where
@@ -274,7 +275,7 @@ makeProjection x = whenM (optProjectionLike <$> pragmaOptions) $ do
                  funSplitTree = st0, funCompiled = cc0, funInv = NotInjective,
                  funMutual = Just [], -- Andreas, 2012-09-28: only consider non-mutual funs
                  funOpaque = TransparentDef} | not (def ^. funAbstract) -> do
-      ps0 <- filterM validProj =<< candidateArgs [] t
+      ps0 <- candidateArgs [] t
       reportSLn "tc.proj.like" 30 $ if null ps0 then "  no candidates found"
                                                 else "  candidates: " ++ prettyShow ps0
       unless (null ps0) $ do
@@ -360,11 +361,6 @@ makeProjection x = whenM (optProjectionLike <$> pragmaOptions) $ do
       Con _ ConORec _ -> True
       Con _ ConORecWhere _ -> True
       _ -> False
-    -- @validProj (d,n)@ checks whether the head @d@ of the type of the
-    -- @n@th argument is injective in all args (i.d. being name of data/record/axiom).
-    validProj :: (Arg QName, Int) -> TCM Bool
-    validProj (_, 0) = return False
-    validProj (d, _) = eligibleForProjectionLike (unArg d)
 
     recursive = getMutual x >>= \case
       Just []     -> pure False
@@ -414,8 +410,8 @@ makeProjection x = whenM (optProjectionLike <$> pragmaOptions) $ do
     -- The applications @d 0 .. (n-1)@ must be relevant.
     --
     -- This means that from the type of arg @n@ all previous arguments
-    -- can be computed by a simple matching.
-    -- (Provided the @d@ is data/record/postulate, checked in @validProj@).
+    -- can be computed by a simple matching,
+    -- provided the @d@ is a data/record/postulate.
     --
     -- E.g. f : {x : _}(y : _){z : _} -> D x y z -> ...
     -- will return (D,3) as a candidate (amongst maybe others).
@@ -435,13 +431,15 @@ makeProjection x = whenM (optProjectionLike <$> pragmaOptions) $ do
         -- Luckily, reducing copy indirections from module applications should be sufficient,
         -- because this is the only way heads that are @eligibleForProjectionLike@ can reduce.
         -- Reducing copy indirections should be cheap.
-        Pi a b -> reduceDefCopies (unEl (unDom a)) >>= \case
-          Def d es
-            | Just us  <- allApplyElims es,
-              all (not . isIrrelevant) us,
-              vs == map unArg us -> ((d <$ argFromDom a, length vs) :) <$> candidateRec b
-            | otherwise          -> candidateRec b
-          _ -> candidateRec b
+        Pi a b -> if null vs then continue else reduceDefCopies (unEl (unDom a)) >>= \case
+          Def d es -> ifNotM (eligibleForProjectionLike d) continue {-else-}
+            if | Just us  <- allApplyElims es
+               , all (not . isIrrelevant) us
+               , vs == map unArg us
+                 -> ((d <$ argFromDom a, length vs) :) <$> continue
+               | otherwise -> continue
+          _ -> continue
+          where continue = candidateRec b
         _ -> return []
       where
         candidateRec NoAbs{}   = return []

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -10,7 +10,7 @@ module Agda.TypeChecking.Reduce
  , IsMeta, isMeta
  -- Reduction and blocking
  , Reduce, reduce', reduceB', reduce, reduceB, reduceWithBlocker, reduceIApply'
- , reduceDefCopy, reduceDefCopyTCM
+ , reduceDefCopy, reduceDefCopyTCM, reduceDefCopies
  , reduceHead
  , slowReduceTerm
  , unfoldCorecursion, unfoldCorecursionE
@@ -874,6 +874,18 @@ reduceDefCopy f es = do
               NoReduction{}        -> return $ NoReduction ()
       []    -> return $ NoReduction ()  -- copies of generalizable variables have no clauses (and don't need unfolding)
       _:_:_ -> __IMPOSSIBLE__
+
+-- | Recursively apply 'reduceDefCopy' so remove all copy-indirections
+-- but otherwise do not reduce the term.
+reduceDefCopies :: Term -> TCM Term
+reduceDefCopies v = do
+  r <- case v of
+    Def f es -> reduceDefCopy f es
+    Con c _info es -> reduceDefCopy (conName c) es
+    _ -> pure $ NoReduction __IMPOSSIBLE__
+  case r of
+    NoReduction{} -> return v
+    YesReduction _ v' -> reduceDefCopies v'
 
 -- | Reduce simple (single clause) definitions.
 reduceHead :: PureTCM m => Term -> m (Blocked Term)

--- a/test/Fail/Issue8686.agda
+++ b/test/Fail/Issue8686.agda
@@ -1,0 +1,55 @@
+-- Andreas, 2026-08-26, issue #8686
+-- Report and test case by @bdrisc-ant, attributed to Claude.
+-- False with projection-like function where the principal argument
+-- is of a data type with an irrelevant parameter.
+
+{-# OPTIONS --safe --projection-like #-}
+
+-- A function whose principal argument has a data type with an
+-- IRRELEVANT parameter is recognised as projection-like, and the
+-- parameter is dropped from its applications.  But the type of the
+-- principal argument does not determine an irrelevant parameter
+-- (D ⊤ and D Bool are definitionally equal), so the conversion
+-- checker reconstructs the wrong parameter and compares the remaining
+-- arguments at the wrong type.  Result: a closed proof of true ≡ false.
+--
+-- Expected: 'lemma' is rejected (a != b of type Bool), as it is with
+-- --no-projection-like.
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+
+record ⊤ : Set where
+
+data D .(A : Set) : Set where
+  c₁ c₂ : D A
+
+-- Projection-like in its argument of type D A; the hidden A is dropped.
+-- (The λ right-hand sides only serve to keep 'select' out of the
+-- injectivity analysis, which would otherwise exclude it from
+-- projection-likeness.)
+select : {A : Set} → D A → A → A → A
+select c₁ a = λ _ → a
+select c₂ _ = λ b → b
+
+-- x : D ⊤ is accepted at type D Bool because the parameter is irrelevant.
+-- The stuck applications 'select x a' and 'select x b' are then compared
+-- with their arguments typed from x's type D ⊤, i.e. a = b : ⊤, which
+-- holds by η for the unit record although a b : Bool.
+lemma : (x : D ⊤) (a b : Bool) → select {Bool} x a ≡ select {Bool} x b
+lemma x a b = refl
+
+app : {g h : Bool → Bool} → g ≡ h → g true ≡ h true
+app refl = refl
+
+boom : true ≡ false
+boom = app (lemma c₁ true false)
+
+-- Expected error: [UnequalTerms]
+-- The terms
+--   a
+-- and
+--   b
+-- are not equal at type Bool
+-- when checking that the expression refl has type
+-- select x a ≡ select x b

--- a/test/Fail/Issue8686.err
+++ b/test/Fail/Issue8686.err
@@ -1,0 +1,8 @@
+Issue8686.agda:40.15-19: error: [UnequalTerms]
+The terms
+  a
+and
+  b
+are not equal at type Bool
+when checking that the expression refl has type
+select x a ≡ select x b

--- a/test/Fail/Issue8686ModuleApp.agda
+++ b/test/Fail/Issue8686ModuleApp.agda
@@ -1,0 +1,51 @@
+-- Andreas, 2026-08-26, issue #8686
+-- Report and test case by @bdrisc-ant, attributed to Claude.
+-- False with projection-like function where the principal argument
+-- is of a data type with a phantom argument that reduces away.
+
+{-# OPTIONS --safe --projection-like #-}
+
+-- A data type COPIED by a module application reduces to an instance of
+-- the original: here N.D B reduces to M.D ⊤ for every B, so the type
+-- N.D B does not determine B.  A function whose principal argument has
+-- type N.D B must therefore not become projection-like (dropping B):
+-- otherwise B is "reconstructed" from the reduct M.D ⊤ of the principal
+-- argument's type -- i.e. taken to be M's argument ⊤ -- and the
+-- remaining arguments are compared at ⊤ instead of Bool.
+-- No irrelevance is involved, and x has exactly the expected type.
+--
+-- Expected: 'lemma' is rejected (a != b of type Bool), as it is with
+-- --no-projection-like.
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+
+record ⊤ : Set where
+
+module M (A : Set) where
+  data D : Set where
+    c₁ c₂ : D
+
+module N (B : Set) = M ⊤
+
+select : {B : Set} → N.D B → B → B → B
+select N.c₁ a = λ _ → a
+select N.c₂ _ = λ b → b
+
+lemma : (x : N.D Bool) (a b : Bool) → select x a ≡ select x b
+lemma x a b = refl
+
+app : {g h : Bool → Bool} → g ≡ h → g true ≡ h true
+app refl = refl
+
+boom : true ≡ false
+boom = app (lemma (N.c₁ {Bool}) true false)
+
+-- Expected error: [UnequalTerms]
+-- The terms
+--   a
+-- and
+--   b
+-- are not equal at type Bool
+-- when checking that the expression refl has type
+-- select x a ≡ select x b

--- a/test/Fail/Issue8686ModuleApp.err
+++ b/test/Fail/Issue8686ModuleApp.err
@@ -1,0 +1,8 @@
+Issue8686ModuleApp.agda:36.15-19: error: [UnequalTerms]
+The terms
+  a
+and
+  b
+are not equal at type Bool
+when checking that the expression refl has type
+select x a ≡ select x b


### PR DESCRIPTION
Fix problems with a non-injective head `D` of the type `D x y z` of a projection-like function.

Commits:

- **Fix #8686 (1): projection-like: disallow irrelevant parameters in principal arg**
  

- **Fix #8686 (2): projection-like: apply reduceDefCopy on domain of principal argument**
  

- **Refactor ProjectionLike: fuse validProj into candidateArgs**

Closes #8686.
  