### PR TITLE
Fix #8688: positivity checker now also descends into Sort

### DIFF
--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NondecreasingIndentation #-}
 
 -- | Check that a datatype is strictly positive.
+
 module Agda.TypeChecking.Positivity where
 
 import Prelude hiding ( null, (!!) )
@@ -45,8 +46,6 @@ import Agda.Utils.Null
 import Agda.Utils.Size
 
 import Agda.Utils.Impossible
-
-----------------------------------------------------------------------------------------------------
 
 -- | Check that the datatypes in the mutual block containing the given
 --   declarations are strictly positive.
@@ -344,6 +343,7 @@ instance PrettyTCM (Seq W.OccursWhere) where
         W.InClause i   -> pwords "in the" ++ nth i ++ pwords "clause"
         W.Matched      -> pwords "as matched against"
         W.InIndex      -> pwords "as an index"
+        W.InSort       -> pwords "in a sort"
         W.InDefOf d    -> pwords "in the definition of" ++ [prettyTCM d]
 
       adjustLeftOfArrow :: W.OccursWhere -> W.OccursWhere

--- a/src/full/Agda/TypeChecking/Positivity/Occurrence.hs
+++ b/src/full/Agda/TypeChecking/Positivity/Occurrence.hs
@@ -126,6 +126,7 @@ data OccursPath
   | InClause !OccursPath !Nat           -- ^ in the nth clause of a defined function
   | Matched !OccursPath                 -- ^ matched against in a clause of a defined function
   | InIndex !OccursPath                 -- ^ is an index of an inductive family
+  | InSort !OccursPath                  -- ^ in a sort, e.g. in the level of a universe
   | InDefOf !OccursPath !QName          -- ^ in the definition of a constant
   deriving Eq
 
@@ -148,6 +149,7 @@ instance Show OccursPath where
       InClause p i    -> go p $ " InClause "    ++ P.prettyShow i ++ acc
       Matched p       -> go p $ " Matched" ++ acc
       InIndex p       -> go p $ " InIndex" ++ acc
+      InSort p        -> go p $ " InSort" ++ acc
       InDefOf p q     -> go p $ " InDefOf " ++ P.prettyShow q ++ acc
 
 instance P.Pretty OccursPath where

--- a/src/full/Agda/TypeChecking/Positivity/OccurrenceAnalysis.hs
+++ b/src/full/Agda/TypeChecking/Positivity/OccurrenceAnalysis.hs
@@ -100,7 +100,7 @@ import Data.Bits
 import Control.Exception
 import System.IO.Unsafe
 
-import Agda.Interaction.Options.Base (optOccurrence, optPolarity)
+import Agda.Interaction.Options.Base (optCumulativity, optOccurrence, optPolarity)
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
 import Agda.Syntax.Position (HasRange(..), noRange, Range)
@@ -308,6 +308,8 @@ data OccEnv = OccEnv {
     topDef     :: QName         -- ^ The definition we're working under (as n-th definition in the mutual block)
   , topDefArgs :: [DefArgInEnv] -- ^ Occurrence info for definition args.
   , inf        :: Maybe QName   -- ^ Name for ∞ builtin.
+  , sortOcc    :: Occurrence    -- ^ Occurrence to compose with when descending into a 'Sort'.
+                                --   See 'sortOccurrence'.
   , locals     :: Int           -- ^ Number of local binders (on the top of the definition args).
   , mutuals    :: Mutuals       -- ^ Set of mutual QName-s in the block.
   , target     :: Node          -- ^ We add occurrences pointing to this node.
@@ -401,6 +403,33 @@ occurrencesInMutDefArg d p i e = expand \ret -> case p of
   Unused -> ret $ pure ()
   p      -> ret $ local (\e -> e {path = MutDefArg (path e) d i, target = ArgNode d i, occ = p}) $
                     occurrences e
+
+-- | The 'Occurrence' to compose with when the analysis descends from a 'Term'
+--   into a 'Sort' (issue #8688).
+--
+--   Without @--cumulativity@, distinct universes are unrelated: @Set x@ and
+--   @Set y@ are neither equal nor in a subtyping relation unless @x@ and @y@ are
+--   equal.  So whatever a sort depends on has to be compared invariantly by the
+--   conversion checker, and we return 'Mixed'.
+--
+--   With @--cumulativity@, universes are monotone in their level
+--   (@Set x =< Set y@ iff @x =< y@, see @leqSort@ in
+--   "Agda.TypeChecking.Conversion"), so a /positive/ occurrence is justified.
+--
+--   We deliberately return 'JustPos' and not 'StrictPos' here.  Both give
+--   'Agda.TypeChecking.Polarity.Covariant' polarity, but only 'StrictPos' would
+--   be accepted by the positivity checker, and an occurrence inside a sort must
+--   not count as strictly positive: a definition like
+--   @data D : Setω where c : Set (f D) → D@ defines @D@ by quantifying over a
+--   universe whose size depends on @D@ itself.
+--
+--   Since @--no-cumulativity@ is a /coinfective/ option, a module that does not
+--   use cumulativity can never import occurrence information that was computed
+--   with cumulativity turned on.
+sortOccurrence :: HasOptions m => m Occurrence
+sortOccurrence = do
+  cumulativity <- optCumulativity <$> pragmaOptions
+  pure $! if cumulativity then JustPos else Mixed
 
 -- | The initial 'Occurrence' when processing a definition.
 mutualDefOcc :: Definition -> Occurrence
@@ -525,11 +554,11 @@ instance ComputeOccurrences Term where
     Level l    -> ret $ occurrences l
     Lit{}      -> ret $ pure ()
     -- Andreas, 2026-08-27, issue #8688: we have to descend into sorts.
-    -- Occurrences in a sort are recorded as 'Mixed': universes are neither
-    -- co- nor contravariant in their level (without @--cumulativity@ they are
-    -- not even related to each other), so anything the sort depends on has to
-    -- be compared invariantly by the conversion checker.
-    Sort s     -> ret $ underPathOcc InSort Mixed $ occurrences s
+    -- How an occurrence inside a sort is counted depends on @--cumulativity@,
+    -- see 'sortOccurrence'.
+    Sort s     -> ret do
+      o <- asks sortOcc
+      underPathOcc InSort o $ occurrences s
     -- Jesper, 2020-01-12: this information is also used for the
     -- occurs check, so we need to look under DontCare (see #4371)
     DontCare t -> ret $ occurrences t
@@ -828,13 +857,14 @@ preprocessMutuals qs mutuals = forM qs \q -> inConcreteOrAbstractMode q \def -> 
 buildOccurrenceGraph :: [QName] -> TCM (OccGraph, Mutuals)
 buildOccurrenceGraph qs = do
   inf <- maybe Nothing (\x -> Just $! nameOfInf x) <$> coinductionKit
+  so  <- sortOccurrence
 
   mutuals <- lift HT.empty
   qs      <- preprocessMutuals qs mutuals
 
   graph <- lift HT.empty
   TCM \st tce -> forM_ qs \(q, clauses) -> do
-    let env = OccEnv q [] inf 0 mutuals (DefNode q) Root StrictPos graph
+    let env = OccEnv q [] inf so 0 mutuals (DefNode q) Root StrictPos graph
     unTCM (runReaderT (computeDefOccurrences q clauses) env) st tce
 
   pure (graph, mutuals)

--- a/src/full/Agda/TypeChecking/Positivity/OccurrenceAnalysis.hs
+++ b/src/full/Agda/TypeChecking/Positivity/OccurrenceAnalysis.hs
@@ -238,6 +238,7 @@ toGenericGraph graph = unsafeDupablePerformIO do
           InClause p i    -> go' p :|> W.InClause i
           Matched p       -> go' p :|> W.Matched
           InIndex p       -> go' p :|> W.InIndex
+          InSort p        -> go' p :|> W.InSort
           InDefOf p x     -> go' p :|> W.InDefOf x
 
         go :: OccursPath -> (Seq W.Where, Seq W.Where)
@@ -257,6 +258,7 @@ toGenericGraph graph = unsafeDupablePerformIO do
           InClause p i    -> (:|> W.InClause i)    <$!> go p
           Matched p       -> (:|> W.Matched)       <$!> go p
           InIndex p       -> (:|> W.InIndex)       <$!> go p
+          InSort p        -> (:|> W.InSort)        <$!> go p
           InDefOf p x     -> (:|> W.InDefOf x)     <$!> go p
 
         in case go path of (s1, s2) -> W.OccursWhere rng s1 s2
@@ -522,7 +524,12 @@ instance ComputeOccurrences Term where
     Lam _ t    -> ret $ occurrences t
     Level l    -> ret $ occurrences l
     Lit{}      -> ret $ pure ()
-    Sort{}     -> ret $ pure ()
+    -- Andreas, 2026-08-27, issue #8688: we have to descend into sorts.
+    -- Occurrences in a sort are recorded as 'Mixed': universes are neither
+    -- co- nor contravariant in their level (without @--cumulativity@ they are
+    -- not even related to each other), so anything the sort depends on has to
+    -- be compared invariantly by the conversion checker.
+    Sort s     -> ret $ underPathOcc InSort Mixed $ occurrences s
     -- Jesper, 2020-01-12: this information is also used for the
     -- occurs check, so we need to look under DontCare (see #4371)
     DontCare t -> ret $ occurrences t
@@ -566,6 +573,33 @@ instance ComputeOccurrences Clause where
       -- process body
       local (\env -> env {topDefArgs = items}) do
         occurrences $ clauseBody cl
+
+-- | Occurrences in a sort.
+--
+--   The traversal stays on the level of sorts: we only descend into
+--   subexpressions that are sorts themselves, or that are part of the identity
+--   of the sort (the 'Level' of a universe, the eliminations of a stuck sort).
+--   In particular we do /not/ descend into the 'Dom' of a 'PiSort': that is the
+--   type of the domain, living one level below, and it is only stored in the
+--   'PiSort' for context extension (see the documentation of 'PiSort').
+instance ComputeOccurrences Sort where
+  occurrences s = expand \ret -> case s of
+    Univ _ l       -> ret $ occurrences l
+    Inf _ _        -> ret $ pure ()
+    SizeUniv       -> ret $ pure ()
+    LockUniv       -> ret $ pure ()
+    LevelUniv      -> ret $ pure ()
+    IntervalUniv   -> ret $ pure ()
+    -- NB: we skip the domain type stored in the 'PiSort', see the note above.
+    PiSort _ s1 s2 -> ret $ underPath LeftOfArrow (occurrences s1) >> occurrences s2
+    FunSort s1 s2  -> ret $ underPath LeftOfArrow (occurrences s1) >> occurrences s2
+    UnivSort s     -> ret $ occurrences s
+    -- @MetaS x es@ and @DefS q es@ are just the applications @x es@ and @q es@
+    -- that happen to be sorts, so we reuse the corresponding 'Term' cases
+    -- rather than duplicating the (subtle) treatment of eliminations.
+    MetaS x es     -> ret $ occurrences $ MetaV x es
+    DefS q es      -> ret $ occurrences $ Def q es
+    DummyS _       -> ret $ pure ()
 
 instance ComputeOccurrences Level where
   occurrences (Max _ as) = occurrences as

--- a/src/full/Agda/TypeChecking/Positivity/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Positivity/Warnings.hs
@@ -60,6 +60,7 @@ data Where
   | InClause Nat           -- ^ in the nth clause of a defined function
   | Matched                -- ^ matched against in a clause of a defined function
   | InIndex                -- ^ is an index of an inductive family
+  | InSort                 -- ^ in a sort, e.g. in the level of a universe
   | InDefOf QName          -- ^ in the definition of a constant
   deriving (Show, Eq, Ord, Generic)
 
@@ -79,6 +80,7 @@ instance Pretty Where where
     InClause i   -> "InClause"   <+> pretty i
     Matched      -> "Matched"
     InIndex      -> "IsIndex"
+    InSort       -> "InSort"
     InDefOf q    -> "InDefOf"    <+> pretty q
 
 instance Pretty OccursWhere where

--- a/test/Fail/Issue8688.agda
+++ b/test/Fail/Issue8688.agda
@@ -1,0 +1,61 @@
+-- Andreas, 2026-08-27, issue #8688
+-- Report and test case by bdrisc-ant
+
+-- Occurrence analysis in the positivity checker did not traverse into sorts,
+-- so functions were falsely declared as NonVariant in level arguments.
+-- This could be exploited to prove Type:Type.
+
+{-# OPTIONS --safe #-}
+
+-- {-# OPTIONS -v tc.pos:45 #-}
+-- {-# OPTIONS -v tc.polarity:20 #-}
+
+open import Agda.Primitive
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.Equality
+
+data ⊥ : Set where
+
+record LiftU {ℓ} (A : Set ℓ) : Setω where
+  constructor liftU
+  field low : A
+
+-- This function was falsely declared NonVariant in the level argument.
+F : Bool → Level → Setω
+F true  l = LiftU (Set l)
+F false l = LiftU (Set l)
+
+cast : (b : Bool) (x y : Level) → F b x → F b y
+cast b x y v = v
+
+-- @cast@ should not be accepted, otherwise we can get Type:Type.
+
+-- Expected error: [UnequalTerms]
+-- The terms
+--   x
+-- and
+--   y
+-- are not equal at type Level
+-- when checking that the expression v has type F b y
+
+shrink : Set₁ → Set
+shrink A = LiftU.low (cast true (lsuc lzero) lzero (liftU A))
+
+data V : Set where
+  sup : shrink (Σ Set (λ A → A → V)) → V
+
+_∈_ : V → V → Set
+x ∈ sup (A , f) = Σ A (λ a → f a ≡ x)
+
+R : V
+R = sup ((Σ V (λ x → x ∈ x → ⊥)) , fst)
+
+out : ∀ {X} → X ∈ R → (X ∈ X → ⊥)
+out ((Y , ny) , refl) = ny
+
+R∉R : R ∈ R → ⊥
+R∉R p = out p p
+
+boom : ⊥
+boom = R∉R ((R , R∉R) , refl)

--- a/test/Fail/Issue8688.err
+++ b/test/Fail/Issue8688.err
@@ -1,0 +1,7 @@
+Issue8688.agda:30.16-17: error: [UnequalTerms]
+The terms
+  x
+and
+  y
+are not equal at type Level
+when checking that the expression v has type F b y

--- a/test/Fail/Issue8688Positivity.agda
+++ b/test/Fail/Issue8688Positivity.agda
@@ -1,0 +1,19 @@
+-- Andreas, 2026-08-27, issue #8688.
+-- The occurrence analysis now also descends into sorts,
+-- so the occurrence of D in the level of the universe Set (g D)
+-- is now seen by the positivity checker.
+
+open import Agda.Primitive
+
+postulate
+  g : Setω → Level
+
+data D : Setω where
+  c : Set (g D) → D
+
+-- Expected error: [NotStrictlyPositive]
+-- D is not strictly positive, because it occurs
+-- in the first argument of g
+-- in a sort
+-- in the type of the constructor c
+-- in the definition of D.

--- a/test/Fail/Issue8688Positivity.err
+++ b/test/Fail/Issue8688Positivity.err
@@ -1,0 +1,6 @@
+Issue8688Positivity.agda:11.1-12.20: error: [NotStrictlyPositive]
+D is not strictly positive, because it occurs
+in the first argument of g
+in a sort
+in the type of the constructor c
+in the definition of D.

--- a/test/Internal/TypeChecking/Positivity/Occurrence.hs
+++ b/test/Internal/TypeChecking/Positivity/Occurrence.hs
@@ -38,6 +38,7 @@ instance Arbitrary Where where
     , ConEndpoint <$> arbitrary
     , InClause <$> arbitrary
     , return Matched
+    , return InSort
     , InDefOf <$> arbitrary
     ]
 
@@ -57,6 +58,7 @@ instance CoArbitrary Where where
   coarbitrary (InClause a)   = variant 7 . coarbitrary a
   coarbitrary Matched        = variant 8
   coarbitrary InIndex        = variant 9
+  coarbitrary InSort         = variant 12
   coarbitrary (InDefOf a)    = variant 10 . coarbitrary a
 
 instance Arbitrary Occurrence where


### PR DESCRIPTION
This fixes the problem of false polarity of level arguments in functions by extending the positivity checker to also find occurrences under the `Sort` constructor.

- The implementation follows the style introduced by @AndrasKovacs (performant).
- No performance regressions have manifested (see report below).


Commits, and details of AI interaction:

- **Fix #8688: positivity checker now also descends into `Sort s`**
  Without considering occurrences in sorts, some level arguments of
  functions might be classified as NonVariant when they are not, leading
  to Type:Type.
  
  Implemented by Claude with some modifications of comments by me.
  (Slightly abridged) transcript of conversation:
  
  The following issue (8688) has been reported:
  [...]
  
  Instructions
  ============
  
  There is a local file test/Fail/Issue8688.agda reproducing the issue.
  
  The positivity checker does not descend under `Sort s` since for the sake of positivity of data types, no interesting occurrences can be found there.
  However, the results of positivity checking are used to construct polarity information, and this is not accurate (as the present issue shows) if occurrences of arguments under `Sort` are excluded.
  
  Please extend the positivity checker by an `instance ComputeOccurrences Sort` that is invoked when going under `Sort`.  Conform to the style of the `instance ComputeOccurrences Term`, in particular the use of `expand` for performance optimization.  Extend the data types that describe occurrences suitably to account for the new cases.
  
  Make sure the occurrence analysis only ever descends into expression of the same "level" (in the sense of term/type/sort).  For instance, in `PiSort dom s1 s2` it should not descend into `dom` since we are currently collecting occurrences in a sort while `dom` is the type whose sort is `s1` and it is only stored here for other purposes (which purpose is not clear to me atm, it would be good if it was documented in the declaration of the `PiSort` constructor).
  As another example of only collecting occurrences from the same "level" not that occurrences in `DomInfo` are not counted when analysing domains (`Dom`), e.g. of a `Pi`-type.
  
  Please try to investigate any performance regressions that could be caused by the fix.
  (To that end, it might be advisable to retain a copy of the current `agda` binary.)
  
  Answer 1
  ========
  
  The fix
  -------
  
  **`ComputeOccurrences Term`** (`Positivity/OccurrenceAnalysis.hs:527`): the `Sort{}` case no longer returns nothing; it descends with `underPathOcc InSort Mixed`. `Mixed` is the right occurrence here because universes are neither co- nor contravariant in their level — with `--cumulativity` off, `Set x` and `Set y` are unrelated for `x ≠ y`, so a co/contravariant reading would just leak cumulativity in one direction. (`otimes Unused _ = Unused`, so positions that were already unused stay unused.)
  
  **New `instance ComputeOccurrences Sort`** (`OccurrenceAnalysis.hs:577`), in the style of the `Term` instance (`expand \ret -> case …`). It stays at the sort level:
  - `Univ _ l` → the level; `Inf`/`SizeUniv`/`LockUniv`/`LevelUniv`/`IntervalUniv`/`DummyS` → nothing.
  - `PiSort _ s1 s2` and `FunSort s1 s2` → both component sorts, `s1` under `LeftOfArrow`. The `Dom` of `PiSort` is *not* visited, as you asked.
  - `MetaS x es` / `DefS q es` → delegated to the `Term` cases for `MetaV x es` / `Def q es`, since those are literally the same applications; this avoids duplicating the elimination handling.
  
  **Occurrence descriptions extended** with `InSort` in `OccursPath` (`Positivity/Occurrence.hs`), `Where` (`Positivity/Warnings.hs`), the `convPath` conversion, the `Pretty` instances, `prettyW` in `Positivity.hs` ("in a sort"), and the QuickCheck `Arbitrary`/`CoArbitrary` instances.
  
  Verification
  ------------
  
  `test/Fail/Issue8688.agda` now fails at `cast` with `x != y at type Level` (golden file added). I also added `test/Fail/Issue8688Positivity.agda`, which exercises the new warning path:
  
  ```
  D is not strictly positive, because it occurs
  in the first argument of g
  in a sort
  in the type of the constructor c
  in the definition of D.
  ```
  
  Performance
  -----------
  
  |                                           | baseline                     | with fix                     |
  | ----------------------------------------- | ---------------------------- | ---------------------------- |
  | std-lib, 731 modules                      | 112.1 s, 356.944 GB alloc    | 107.7 s, 356.938 GB alloc    |
  | cubical subset, 489 modules (2 runs each) | 122.5 / 123.3 s, 394.2529 GB | 123.7 / 123.7 s, 394.2535 GB |
  
  Allocation — the noise-free proxy for work actually done — differs by 0.0001 %. Wall/CPU differences go in both directions and are within run-to-run variance. `Positivity` phase: 3391→3203 ms on std-lib, 1271→1343 ms on cubical. No regression worth acting on.
  
  The reason the impact is so small: `dependentPolarity` already promoted a level parameter to `Invariant` whenever a later non-`Nonvariant` argument's type mentioned it, so `List {a} (A : Set a)` and friends were unaffected. What actually changes is the case with no such later argument — `F : Level → Setω`, and data/record parameters that only appear in field/constructor-argument sorts, which `enablePhantomTypes` had been turning from `Nonvariant` into `Covariant`. I checked `record R (l : Level) : Setω where field f : Set l` and `data D (l : Level) : Setω where c : Set l → D l`: both went `[+]` → `[*]`, so the paradox is closed for records and data types too, not just functions.
  

- **Re #8688: occurrences: descend covariantly into `Sort s` with --cumulativity**
  The universe constructors are covariant in the level when
  `--cumulativity` is on, so the correct `Occurrence` modifier for
  `Sort` is then `JustPos` rather than `Mixed`.
  Atm, this refinement is maybe not observable, but still it should be
  in the code base, for the that case `--cumulativity` is seeing a
  revival.
  
  (Abridged) Claude conversation:
  
  Prompt 2
  ========
  
  I think we want to revise the decision to always treat the `Set` universe constructor as `Mixed`:
  ```haskell
      -- Andreas, 2026-08-27, issue #8688: we have to descend into sorts.
      -- Occurrences in a sort are recorded as 'Mixed': universes are neither
      -- co- nor contravariant in their level (without @--cumulativity@ they are
      -- not even related to each other), so anything the sort depends on has to
      -- be compared invariantly by the conversion checker.
      Sort s     -> ret $ underPathOcc InSort Mixed $ occurrences s
  ```
  With `--cumulativity` it makes sense to treat `Set` as covariant.
  
  So I suggest to put a new field into `OccEnv` that gives the `Occurrence` to be used here, depending on `--cumulativity`.
  
  If possible, add to test/Succeed a case where this covariance can be put to use with `--cumulativity`.
  
  If you see any problems with covariance under `--cumulativity`, please alert me and also come up with a reproducer.
  
  Answer 2
  ========
  
  The change
  ----------
  
  New field `sortOcc :: Occurrence` in `OccEnv`, initialised in `buildOccurrenceGraph` from a new `sortOccurrence :: HasOptions m => m Occurrence`, and read in the `Sort` case of `ComputeOccurrences Term`.
  
  The value under `--cumulativity` is **`JustPos`, not `StrictPos`**. Both map to `Covariant`, but only `StrictPos` would satisfy the positivity checker, and an occurrence inside a sort must not count as strictly positive — `data D : Setω where c : Set (g D) → D` defines `D` by quantifying over a universe whose size depends on `D`. Verified: `test/Fail/Issue8688PositivityCumulativity.agda` is still rejected with `--cumulativity` on.
  
  Polarity of `F : Bool → Level → Setω; F b l = Box (Set l)` is now `[*, +]` with `--cumulativity` and `[*, *]` without, as intended.
  
  `--no-cumulativity` is coinfective, so a non-cumulative module can never import occurrence data computed under cumulativity. The interface-sharing direction is safe.
  
  The finding: the covariance is currently unobservable
  -----------------------------------------------------
  
  I could not write the `test/Succeed` case you asked for, and I believe none exists today.
  
  **Only levels can occur under a `Sort`** — `Univ u l` reaches a `Level`; `PiSort`/`FunSort`/`UnivSort` reach sorts; `MetaS` is forced to `Mixed`; `DefS` is a primitive sort whose arguments are levels. To get a non-`Level`-typed variable into a level you must pass through a neutral `Level`-valued function, which is either a postulate or pattern-matches — both `Mixed`.
  
  **And `Level` arguments ignore the comparison direction.** `Conversion.hs:301-306`, the `Level` case of `compareTerm'`, calls `equalLevel a b` regardless of `cmp`. So `compareWithPol Covariant` and `compareWithPol Invariant` are indistinguishable for level arguments.
  
  Confirmed both ways on the *pre-fix* binary, so this is not something my change introduced:
  
  ```agda
  {-# OPTIONS --cumulativity #-}
  data D (l : Level) : Setω where c : D l   -- polarity [+], phantom-Covariant
  up : D lzero → D (lsuc lzero)
  up x = x    -- rejected: "are not equal at type Level"
  ```
  
  Cumulativity plus covariance *does* work when the argument is a sort term — `Box Set₀ → Box Set₁` with `Box (A : Setω)` is accepted — which isolates `Level` as the blocker.
  
  **No soundness problem found.** Under `--cumulativity` all the sort formers are monotone (`Univ u`, `funSort`/`piSort` in both components, `univSort`), so `JustPos` is justified; and since it is unobservable in conversion, the only live consumer is the positivity checker, where `JustPos` changes nothing. The paradox file with `--cumulativity` added is still rejected.
  
  If you want the covariance to actually do something, the change needed is in `compareTerm'` — using `compareLevel cmp` instead of `equalLevel` for the `Level` case. I did not attempt that: `equalLevel` drives level-metavariable solving, and weakening it to `≤` constraints seems likely to leave metas unsolved. That is a separate decision.
  