### PR TITLE
Fix #8687 by correcting the checkpoint weakening when missing clauses are inferred

### DIFF
--- a/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
@@ -58,7 +58,10 @@ compileClauses' q recpat cs mSplitTree = do
 --   3. Generating a case tree from the split tree.
 --   Phases 1. and 2. are skipped if @Nothing@.
 compileClauses ::
-  Maybe (QName, Type) -- ^ Translate record patterns and coverage check with given type?
+  Maybe (QName, Type, Nat)
+     -- ^ Translate record patterns and coverage check with given type?
+     --   The 'Nat' is the size of the context the definition was created in,
+     --   see 'coverageCheck'.
   -> [Clause]
   -> TCM (Maybe SplitTree, Bool, CompiledClauses)
      -- ^ The 'Bool' indicates whether we turned a record expression into a copattern match.
@@ -67,8 +70,8 @@ compileClauses mt cs = do
   -- Discard de Bruijn indices in patterns.
   case mt of
     Nothing -> (Nothing,False,) . compile . map' unBruijn . zip' [0..] <$> normaliseProjP cs
-    Just (q, t)  -> do
-      splitTree <- coverageCheck q t cs
+    Just (q, t, npars) -> do
+      splitTree <- coverageCheck q t npars cs
 
       reportSDoc "tc.cc.tree" 20 $ vcat
         [ "split tree of " <+> prettyTCM q <+> " from coverage check "

--- a/src/full/Agda/TypeChecking/CompiledClause/Compile.hs-boot
+++ b/src/full/Agda/TypeChecking/CompiledClause/Compile.hs-boot
@@ -2,9 +2,10 @@
 
 module Agda.TypeChecking.CompiledClause.Compile where
 
+import Agda.Syntax.Common (Nat)
 import Agda.Syntax.Internal
 import Agda.TypeChecking.CompiledClause
 import Agda.TypeChecking.Coverage.SplitTree
 import Agda.TypeChecking.Monad.Base
 
-compileClauses :: Maybe (QName, Type) -> [Clause] -> TCM (Maybe SplitTree, Bool, CompiledClauses)
+compileClauses :: Maybe (QName, Type, Nat) -> [Clause] -> TCM (Maybe SplitTree, Bool, CompiledClauses)

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -102,9 +102,11 @@ type CoverM = ExceptT SplitError TCM
 coverageCheck
   :: QName     -- ^ Name @f@ of definition.
   -> Type      -- ^ Absolute type (including the full parameter telescope).
+  -> Nat       -- ^ Size of the context @Γ@ the definition of @f@ was created in;
+               --   the first arguments of @f@ are the variables of @Γ@.
   -> [Clause]  -- ^ Clauses of @f@.  These are the very clauses of @f@ in the signature.
   -> TCM SplitTree
-coverageCheck f t cs = do
+coverageCheck f t npars cs = do
   reportSLn "tc.cover.top" 30 $ "entering coverageCheck for " ++! prettyShow f
   reportSDoc "tc.cover.top" 75 $ "  of type (raw): " <+> (text . prettyShow) t
   reportSDoc "tc.cover.top" 45 $ "  of type: " <+> prettyTCM t
@@ -116,16 +118,23 @@ coverageCheck f t cs = do
       n            = size gamma
       xs           =  map (setOrigin Inserted) $ teleNamedArgs gamma
 
-  reportSLn "tc.cover.top" 30 $ "coverageCheck: getDefFreeVars"
-
-      -- The initial module parameter substitutions need to be weakened by the
-      -- number of arguments that aren't module parameters.
-  fv           <- getDefFreeVars f
-
   reportSLn "tc.cover.top" 30 $ "coverageCheck: getting checkpoints"
 
-  -- TODO: does this make sense? Why are we weakening by n - fv?
-  checkpoints <- applySubst (raiseS (n - fv)) <$> viewTC eCheckpoints
+  -- Andreas, 2026-08-27, issue #8687:
+  -- The checkpoints are substitutions into the context Γ₀ the definition of @f@ was
+  -- created in, and @gamma@ extends Γ₀ by the arguments of @f@ that are not variables
+  -- of Γ₀.  Thus, to move the checkpoints into @gamma@, we weaken them by exactly the
+  -- number of these extra arguments.
+  -- (Weakening by the arity of @f@ minus the number of parameters of the module of
+  -- @f@ instead is wrong whenever @f@ was created in a context that is larger than
+  -- the telescope of its module, e.g. the auxiliary function of a pattern lambda.)
+  --
+  -- Note: for a @with@-function the checkpoints refer to the context of the parent
+  -- clause rather than to its (empty) creation context, so they would have to be
+  -- composed with the with-substitution instead.  This does not matter as long as
+  -- with-clauses cannot have copatterns, since then no missing instance clause
+  -- is inferred for a with-function.
+  checkpoints <- applySubst (raiseS (n - npars)) <$> viewTC eCheckpoints
 
       -- construct the initial split clause
   let sc = SClause gamma xs idS checkpoints $ Just $ defaultDom a

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -405,13 +405,20 @@ checkFunDefS t ai extlam with i name cs = do
         reportSDoc "tc.cc.type" 60 $ "  type   : " <+> (text . prettyShow) t
         reportSDoc "tc.cc.type" 60 $ "  context: " <+> (text . prettyShow =<< getContextTelescope)
 
-        fullType <- flip telePi t <$> getContextTelescope
+        -- Andreas, 2026-08-27, issue #8687:
+        -- @cxt@ is the context the definition of @name@ was created in;
+        -- it is not necessarily the telescope of the module @name@ lives in.
+        -- E.g. the auxiliary function of a copattern pattern-lambda is created
+        -- over the whole context at the lambda.
+        -- The coverage checker needs its size to weaken the checkpoints correctly.
+        cxt <- getContextTelescope
+        let fullType = telePi cxt t
 
         reportSLn  "tc.cc.type" 80 $ show fullType
 
         -- Coverage check and compile the clauses
         (mst, _recordExpressionBecameCopatternLHS, cc) <- Bench.billTo [Bench.Coverage] $
-          unsafeInTopContext $ compileClauses (if isSystem then Nothing else (Just (name, fullType)))
+          unsafeInTopContext $ compileClauses (if isSystem then Nothing else (Just (name, fullType, size cxt)))
                                         cs
         -- Andreas, 2019-10-21 (see also issue #4142):
         -- We ignore whether the clause compilation turned some

--- a/test/Fail/Issue8687.agda
+++ b/test/Fail/Issue8687.agda
@@ -1,0 +1,51 @@
+-- Andreas, 2026-08-27, issue #8687
+-- Report and test case by @bdrisc-ant, attributed to Claude
+
+-- Incorrect context for missing clause inferred by the coverage checker
+-- (wrong weakening).
+
+{-# OPTIONS --safe #-}
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+data ⊥ : Set where
+
+it : {A : Set} {{a : A}} → A
+it {{a}} = a
+
+record C : Set where
+  field
+    k : Nat
+    p : k ≡ 0
+
+record P : Set where
+  field
+    v : Nat
+    ⦃ i ⦄ : C
+
+module M (n : Nat) (q : n ≡ 0) where
+
+  instance
+    c : C
+    c = record { k = n ; p = q }
+
+  f : (b : Bool) → P
+  f b = λ where
+    .P.v → 0
+    -- .P.i case omitted: inferred by instance search
+    -- .P.i → it  -- Adding this clause removes the problem
+
+bad : C.k (P.i (M.f 0 refl true)) ≡ 0 → ⊥  -- the domain normalizes to `true ≡ 0`
+bad ()
+
+boom : ⊥
+boom = bad (C.p (P.i (M.f 0 refl true)))
+
+-- Expected error: [ShouldBeEmpty]
+-- C.k (P.i (M.f 0 refl true)) ≡ 0 should be empty, but the following
+-- constructor patterns are valid:
+--   refl
+-- when checking the clause left hand side
+-- bad ()

--- a/test/Fail/Issue8687.err
+++ b/test/Fail/Issue8687.err
@@ -1,0 +1,6 @@
+Issue8687.agda:41.1-7: error: [ShouldBeEmpty]
+C.k (P.i (M.f 0 refl true)) ≡ 0 should be empty, but the following
+constructor patterns are valid:
+  refl
+when checking the clause left hand side
+bad ()

--- a/test/Succeed/Issue8687.agda
+++ b/test/Succeed/Issue8687.agda
@@ -1,0 +1,215 @@
+-- Andreas, 2026-08-27, issue #8687, reported by @bdrisc-ant
+--
+-- When a definition by copattern matching omits an instance field,
+-- the coverage checker infers the missing clause by running instance
+-- search in the telescope of the split clause, under the module
+-- parameter substitutions ("checkpoints") of the definition site.
+-- These need to be weakened into that telescope.
+--
+-- Agda used to weaken them by the arity of the function minus the
+-- number of parameters of the module the function lives in, which is
+-- only correct if the function was created over exactly the telescope
+-- of its module.  The auxiliary function of a copattern
+-- pattern-lambda is created over the whole context at the lambda, so
+-- its checkpoints were shifted too far to the left: instance search
+-- then elaborated the instances of the module against the wrong
+-- variables, or Agda crashed.
+--
+-- Below, the field `.P.i` is always omitted and thus inferred by
+-- instance search; each `check` verifies that the inferred instance is
+-- the correct one.  Before the fix, each of these variants made Agda
+-- crash.  See test/Fail/Issue8687.agda for a variant that was unsound.
+
+{-# OPTIONS --safe #-}
+
+module Issue8687 where
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+record C : Set where
+  field
+    k : Nat
+    p : k ≡ 0
+
+record P : Set where
+  field
+    v : Nat
+    ⦃ i ⦄ : C
+
+-- A single pattern variable already makes the context of the pattern
+-- lambda larger than the telescope of module M.
+
+module Variable where
+
+  module M (n : Nat) (q : n ≡ 0) where
+
+    instance
+      c : C
+      c = record { k = n ; p = q }
+
+    f : (b : Bool) → P
+    f b = λ where .P.v → 0
+
+  check : C.k (P.i (M.f 0 refl true)) ≡ 0
+  check = refl
+
+-- Same with a dot pattern.
+
+module DotPattern where
+
+  data D : Nat → Set where
+    d : D 0
+
+  module M (n : Nat) (q : n ≡ 0) where
+
+    instance
+      c : C
+      c = record { k = n ; p = q }
+
+    f : (m : Nat) (b : Bool) → D m → P
+    f .0 b d = λ where .P.v → 0
+
+  check : C.k (P.i (M.f 0 refl 0 true d)) ≡ 0
+  check = refl
+
+-- `rewrite` (which is `with` in disguise) reorders the telescope.
+
+module Rewrite where
+
+  record P′ (x : Nat) : Set where
+    field
+      v : Nat
+      ⦃ i ⦄ : C
+
+  module M (n : Nat) (q : n ≡ 0) where
+
+    instance
+      c : C
+      c = record { k = n ; p = q }
+
+    f : (b : Bool) (m : Nat) → m ≡ 0 → P′ m
+    f b m e rewrite e = λ where .P′.v → 0
+
+  check : C.k (P′.i (M.f 0 refl true 0 refl)) ≡ 0
+  check = refl
+
+-- A where-function two levels deep: the pattern lambda is created over
+-- the telescope of the innermost where-module plus its pattern variable.
+
+module Where where
+
+  module M (n : Nat) (q : n ≡ 0) where
+
+    instance
+      c : C
+      c = record { k = n ; p = q }
+
+    f : (b : Bool) → P
+    f b = g b
+      where
+        g : Bool → P
+        g w = h w
+          where
+            h : Bool → P
+            h u = λ where .P.v → 0
+
+  check : C.k (P.i (M.f 0 refl true)) ≡ 0
+  check = refl
+
+-- Nested copattern lambdas: the inner one is created under the binder
+-- of the outer one.
+
+module NestedLambdas where
+
+  record R : Set where
+    field out : Bool → P
+
+  module M (n : Nat) (q : n ≡ 0) where
+
+    instance
+      c : C
+      c = record { k = n ; p = q }
+
+    f : R
+    f = λ where .R.out b → λ where .P.v → 0
+
+  check : C.k (P.i (R.out (M.f 0 refl) true)) ≡ 0
+  check = refl
+
+-- An applied `open` in a `let`: the checkpoint of module N maps its
+-- parameters to variables of the clause.
+
+module LetOpen where
+
+  module N (m : Nat) (r : m ≡ 0) where
+
+    instance
+      c : C
+      c = record { k = m ; p = r }
+
+  module M where
+
+    f : (b : Nat) (e : b ≡ 0) → P
+    f b e = let open N b e in λ where .P.v → 0
+
+  check : C.k (P.i (M.f 0 refl)) ≡ 0
+  check = refl
+
+-- An applied `open` at the module level.
+
+module AppliedOpen where
+
+  module N (m : Nat) (r : m ≡ 0) where
+
+    instance
+      c : C
+      c = record { k = m ; p = r }
+
+  module M (n : Nat) (q : n ≡ 0) where
+
+    open N n q
+
+    f : (b : Bool) → P
+    f b = λ where .P.v → 0
+
+  check : C.k (P.i (M.f 0 refl true)) ≡ 0
+  check = refl
+
+-- The module of a record: its telescope also contains the record value.
+
+module RecordModule where
+
+  record S (n : Nat) (q : n ≡ 0) : Set where
+
+    instance
+      c : C
+      c = record { k = n ; p = q }
+
+    f : (b : Bool) → P
+    f b = λ where .P.v → 0
+
+  s : S 0 refl
+  s = record {}
+
+  check : C.k (P.i (S.f s true)) ≡ 0
+  check = refl
+
+-- Same for a coinductive record.
+
+module CoinductiveRecordModule where
+
+  record S (n : Nat) (q : n ≡ 0) : Set where
+    coinductive
+    field force : Bool
+
+    instance
+      c : C
+      c = record { k = n ; p = q }
+
+    f : (b : Bool) → P
+    f b = λ where .P.v → 0
+
+  check : (s : S 0 refl) → C.k (P.i (S.f s true)) ≡ 0
+  check s = refl


### PR DESCRIPTION
This is a not very invasive fix of #8687 which proves false from a wrong weakening applied to a checkpoint when inferring missing clauses by instance search.

It does introduce a new `Nat` argument to `coverageCheck` and `compileClauses` so one might wonder if there is a more principled fix (e.g. in the checkpoint mechanism).

Claude interaction:

Instructions
============

Please locate, explain, and fix the bug.

Also try to add the indicated variants of the reproducer:
>  `with` is incidental — it is merely the shortest way to get a module parameter's image onto another variable; a dot pattern does it too, and so do `rewrite`, a where-function of such a clause two levels deep, nested copattern lambdas, a `let`, an applied `open`, records, coinductive records.

Answer
======

The bug
-------

`coverageCheck` (Coverage.hs:102) sets up the initial split clause for `f`. Its telescope `gamma` is the telescope of `f`'s *full* type, i.e. the creation context Γ followed by `f`'s remaining arguments. The module-parameter substitutions ("checkpoints") taken from the environment are substitutions **into Γ**, so they must be weakened by `size gamma − |Γ|` to be usable in `gamma`. The old code guessed `|Γ|` as `getDefFreeVars f`, the parameter count of `f`'s *module* — hence the `-- TODO: does this make sense?`.

That guess is right only when `f` was created over exactly its module's telescope. The auxiliary function of a copattern pattern-lambda is a constant of the enclosing module but is created over the *whole* context at the lambda (module parameters **plus** the enclosing clause's variables, in the `with`-telescope's order inside a `with`-clause). Every checkpoint was therefore shifted `|Γ| − |Γ_M|` binders too far left, and `inferMissingClause` — which runs instance search (or the `@tactic`) under exactly these checkpoints — elaborated the module's instances against the wrong variables:

- image lands on another variable → a silently wrong (ill-typed) instance, e.g. `M.c b w` in the reproducer, giving `C.k … = true` at type `Nat` and a "proof" that `true ≡ 0` — hence `boom : ⊥`;
- image leaves the telescope → `__IMPOSSIBLE__` in `Monad/Context.hs:744`.

`with` was indeed incidental: the minimal trigger is one ordinary pattern variable (`f b = λ where .P.v → 0`), which crashed.

The fix
-------

`checkFunDefS` already has the creation context in hand (it builds `fullType` from it), so it now passes its size down:

- `Rules/Def.hs`: `cxt <- getContextTelescope`, `compileClauses (Just (name, fullType, size cxt))`.
- `CompiledClause/Compile.hs` (+ `.hs-boot`): the coverage payload is now `Maybe (QName, Type, Nat)`.
- `Coverage.hs`: `coverageCheck f t npars cs` weakens by `n - npars`; the `getDefFreeVars` call is gone.

For a `with`-function the checkpoints refer to the parent clause's context and would need composing with `withSub` rather than weakening; since with-clauses cannot carry copatterns, no missing clause is ever inferred there. I left a comment saying so instead of silently relying on it.

Tests
-----

- `test/Fail/Issue8687.agda` — the reporter's file; added the golden `Issue8687.err`: `bad ()` is now rejected (`[ShouldBeEmpty]`, `C.k (P.i (M.f 0 refl true)) ≡ 0` … `refl` is valid), i.e. `⊥` is no longer provable.
- `test/Succeed/Issue8687.agda` (new) — the requested variants, each omitting `.P.i` and checking by `refl` that the *correct* instance was inferred: plain pattern variable, dot pattern, `rewrite`, a where-function two levels deep, nested copattern lambdas, `let open` (applied open in a `let`), module-level applied `open`, a record module, and a coinductive record module. I split the file into nine standalone files and verified each one individually: **all nine give an internal error with the pre-fix binary and pass with the fixed one**.
