### PR TITLE
[ fix #8694 ] Take relevance into account for cycle rule in LHS unifier

### DIFF
--- a/src/full/Agda/TypeChecking/Free.hs
+++ b/src/full/Agda/TypeChecking/Free.hs
@@ -264,7 +264,7 @@ data SingleVarOcc = SingleVarOcc !Int !VarOcc
 
 instance LensFlexRig SingleVarOcc MetaSet where
   {-# INLINE lensFlexRig #-}
-  lensFlexRig f (SingleVarOcc x fr) = SingleVarOcc x <$> lensFlexRig f fr
+  lensFlexRig f (SingleVarOcc x occ) = SingleVarOcc x <$> lensFlexRig f occ
 
 data CollectSingleVarOcc = CSVarOccNothing | CSVarOccJust !VarOcc
 
@@ -277,16 +277,16 @@ instance LensModality SingleVarOcc where
   mapModality f (SingleVarOcc x occ) = SingleVarOcc x (mapModality f occ)
 
 instance Semigroup CollectSingleVarOcc where
-  CSVarOccJust fr <> CSVarOccJust fr' = CSVarOccJust (fr <> fr')
-  CSVarOccNothing <> s            = s
-  s               <> CSVarOccNothing  = s
+  CSVarOccJust occ <> CSVarOccJust occ' = CSVarOccJust (occ <> occ')
+  CSVarOccNothing  <> s                 = s
+  s                <> CSVarOccNothing   = s
 
 instance ComputeFree SingleVarOcc where
   type Collect SingleVarOcc = Endo CollectSingleVarOcc
   {-# INLINE underBinders' #-}
-  underBinders' n (SingleVarOcc x fr) = SingleVarOcc (n + x) fr
+  underBinders' n (SingleVarOcc x occ) = SingleVarOcc (n + x) occ
   {-# INLINE variable' #-}
-  variable' x' (SingleVarOcc x fr) = Endo \acc -> if x == x' then acc <> CSVarOccJust fr else acc
+  variable' x' (SingleVarOcc x occ) = Endo \acc -> if x == x' then acc <> CSVarOccJust occ else acc
   underConstructor' = defaultUnderConstructor; {-# INLINE underConstructor' #-}
   underFlexRig'     = defaultUnderFlexRig;     {-# INLINE underFlexRig' #-}
   underModality'    = defaultUnderModality;    {-# INLINE underModality' #-}

--- a/src/full/Agda/TypeChecking/Free.hs
+++ b/src/full/Agda/TypeChecking/Free.hs
@@ -72,7 +72,7 @@ module Agda.TypeChecking.Free
     , anyFreeVar
     , anyFreeVarIgnoreAll
     , closed
-    , flexRigOccurrenceIn
+    , varOccurrenceIn
     , freeIn
     , freeInIgnoringSorts
     , freeVarCounts
@@ -260,35 +260,45 @@ allFreeVarIgnoreAll f = allFreeVarIgnoreAll# (\n -> f (I# n))
 -- ** Flex-rigid occurrence for a single variable
 --------------------------------------------------------------------------------
 
-data SingleFR = SingleFR !Int !FlexRig
+data SingleVarOcc = SingleVarOcc !Int !VarOcc
 
-instance LensFlexRig SingleFR MetaSet where
+instance LensFlexRig SingleVarOcc MetaSet where
   {-# INLINE lensFlexRig #-}
-  lensFlexRig f (SingleFR x fr) = SingleFR x <$> f fr
+  lensFlexRig f (SingleVarOcc x fr) = SingleVarOcc x <$> lensFlexRig f fr
 
-data CollectSingleFR = CSFRNothing | CSFRJust !FlexRig
+data CollectSingleVarOcc = CSVarOccNothing | CSVarOccJust !VarOcc
 
-instance Semigroup CollectSingleFR where
-  CSFRJust fr <> CSFRJust fr' = CSFRJust (addFlexRig fr fr')
-  CSFRNothing <> s            = s
-  s           <> CSFRNothing  = s
+instance LensRelevance SingleVarOcc where
 
-instance ComputeFree SingleFR where
-  type Collect SingleFR = Endo CollectSingleFR
+instance LensModality SingleVarOcc where
+  {-# INLINE getModality #-}
+  getModality (SingleVarOcc _ occ) = getModality occ
+  {-# INLINE mapModality #-}
+  mapModality f (SingleVarOcc x occ) = SingleVarOcc x (mapModality f occ)
+
+instance Semigroup CollectSingleVarOcc where
+  CSVarOccJust fr <> CSVarOccJust fr' = CSVarOccJust (fr <> fr')
+  CSVarOccNothing <> s            = s
+  s               <> CSVarOccNothing  = s
+
+instance ComputeFree SingleVarOcc where
+  type Collect SingleVarOcc = Endo CollectSingleVarOcc
   {-# INLINE underBinders' #-}
-  underBinders' n (SingleFR x fr) = SingleFR (n + x) fr
+  underBinders' n (SingleVarOcc x fr) = SingleVarOcc (n + x) fr
   {-# INLINE variable' #-}
-  variable' x' (SingleFR x fr) = Endo \acc -> if x == x' then acc <> CSFRJust fr else acc
+  variable' x' (SingleVarOcc x fr) = Endo \acc -> if x == x' then acc <> CSVarOccJust fr else acc
   underConstructor' = defaultUnderConstructor; {-# INLINE underConstructor' #-}
-  underFlexRig'     = defaultUnderFlexRig; {-# INLINE underFlexRig' #-}
+  underFlexRig'     = defaultUnderFlexRig;     {-# INLINE underFlexRig' #-}
+  underModality'    = defaultUnderModality;    {-# INLINE underModality' #-}
+  underRelevance'   = defaultUnderRelevance;   {-# INLINE underRelevance' #-}
 
-{-# SPECIALIZE flexRigOccurrenceIn :: Nat -> Term -> Maybe FlexRig #-}
-{-# SPECIALIZE flexRigOccurrenceIn :: Nat -> Sort' Term -> Maybe FlexRig #-}
--- | Compute 'FlexRig' for a single variable.
-flexRigOccurrenceIn :: Free a => Nat -> a -> Maybe FlexRig
-flexRigOccurrenceIn x a = case appEndo (runReader (freeVars a) (SingleFR x Unguarded)) CSFRNothing of
-  CSFRNothing -> Nothing
-  CSFRJust fr -> Just fr
+{-# SPECIALIZE varOccurrenceIn :: Nat -> Term -> Maybe VarOcc #-}
+{-# SPECIALIZE varOccurrenceIn :: Nat -> Sort' Term -> Maybe VarOcc #-}
+-- | Compute 'VarOcc' for a single variable.
+varOccurrenceIn :: Free a => Nat -> a -> Maybe VarOcc
+varOccurrenceIn x a = case appEndo (runReader (freeVars a) (SingleVarOcc x oneVarOcc)) CSVarOccNothing of
+  CSVarOccNothing  -> Nothing
+  CSVarOccJust occ -> Just occ
 
 -- ** Plain free occurrence
 --------------------------------------------------------------------------------

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -367,8 +367,8 @@ dataStrategy k s = do
         -- Call forceNotFree to reduce u as far as possible
         -- around any occurrences of i
         (_ , u) <- liftReduce $ forceNotFree (singleton i) u
-        case flexRigOccurrenceIn i u of
-          Just StronglyRigid -> ret
+        case varOccurrenceIn i u of
+          Just (VarOcc StronglyRigid mod) | isRelevant mod -> ret
           _ -> mzero
 
 checkEqualityStrategy :: Int -> UnifyStrategy

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1907,9 +1907,9 @@ funSortM a b = do
 -- * `inferPiSort` in Agda.TypeChecking.Sort
 piSort' :: Dom Term -> Sort -> Abs Sort -> Either Blocker Sort
 piSort' a s1       (NoAbs _ s2) = Right $ FunSort s1 s2
-piSort' a s1 s2Abs@(Abs   _ s2) = case flexRigOccurrenceIn 0 s2 of
+piSort' a s1 s2Abs@(Abs   _ s2) = case varOccurrenceIn 0 s2 of
   Nothing -> Right $ FunSort s1 $ noabsApp __IMPOSSIBLE__ s2Abs
-  Just o  -> piSortAbs a s1 s2Abs o CodomainNotNormalised
+  Just o  -> piSortAbs a s1 s2Abs (varFlexRig o) CodomainNotNormalised
 
 data IsCodomainNormalised = CodomainNormalised | CodomainNotNormalised
 

--- a/test/Fail/Issue8694-prop.agda
+++ b/test/Fail/Issue8694-prop.agda
@@ -1,0 +1,19 @@
+{-# OPTIONS --safe --prop #-}
+-- Variant of Issue8694.agda using Prop instead of irrelevance
+
+open import Agda.Builtin.Equality
+
+data ⊥ : Set where
+
+data Squash (A : Set) : Prop where
+  squash : A → Squash A
+
+data T : Set where
+  w : T
+  t : Squash T → T
+
+f : (x : T) → x ≡ t (squash x) → ⊥
+f x ()
+
+boom : ⊥
+boom = f (t (squash w)) refl

--- a/test/Fail/Issue8694-prop.err
+++ b/test/Fail/Issue8694-prop.err
@@ -1,0 +1,4 @@
+Issue8694-prop.agda:16.5-7: error: [UnsolvedConstraints]
+Failed to solve the following constraints:
+  Is empty: x ≡ t _ (stuck)
+      [ at Issue8694-prop.agda:16.5-7 ]

--- a/test/Fail/Issue8694.agda
+++ b/test/Fail/Issue8694.agda
@@ -1,0 +1,22 @@
+{-# OPTIONS --safe #-}
+-- Issue found by Claude and reported by bdrisc-ant
+
+-- The constructor t takes its argument irrelevantly, so the conversion
+-- checker identifies  t a  and  t b  for all a and b.  In particular
+-- x ≡ t x  is inhabited (take x = t w; then t w ≡ t (t w) by refl), yet the
+-- left-hand-side unifier reports a cycle for  x ≟ t x  and accepts the
+-- absurd clause of f.
+
+open import Agda.Builtin.Equality
+
+data ⊥ : Set where
+
+data T : Set where
+  w : T
+  t : .T → T
+
+f : (x : T) → x ≡ t x → ⊥
+f x ()
+
+boom : ⊥
+boom = f (t w) refl

--- a/test/Fail/Issue8694.err
+++ b/test/Fail/Issue8694.err
@@ -1,0 +1,4 @@
+Issue8694.agda:19.5-7: error: [UnsolvedConstraints]
+Failed to solve the following constraints:
+  Is empty: x ≡ t _ (stuck)
+      [ at Issue8694.agda:19.5-7 ]


### PR DESCRIPTION
Fixing #8694 by properly computing the relevance as well as the rigidity. Written by my own hands.