### PR TITLE
Refactor: store information isPathCons at constructor rather than datatype

### DIFF
--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -740,7 +740,6 @@ definition def@Defn{defName = q, defType = ty, theDef = d} = do
       Function{} -> function pragma $ functionViaTreeless def q
 
       Datatype{ dataPars = np, dataIxs = ni, dataClause = cl
-              , dataPathCons = pcs
               } | Just hsdata@(HsData r ty hsCons) <- pragma ->
         setCurrentRange r $ do
         reportSDoc "compile.ghc.definition" 40 $ hsep $
@@ -757,7 +756,6 @@ definition def@Defn{defName = q, defType = ty, theDef = d} = do
               ]
         retDecls result
       Datatype{ dataPars = np, dataIxs = ni, dataClause = cl
-              , dataPathCons = pcs
               } -> do
         liftTCM $ computeErasedConstructorArgs q
         cs <- liftTCM $ getNotErasedConstructors q

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -173,7 +173,7 @@ instance NamesIn Defn where
       -> namesAndMetasIn' sg (cl, cs, s, trX, trD)
     Record _ cl c _ fs recTel _ _ _ _ _ _ _ comp
       -> namesAndMetasIn' sg (cl, c, fs, recTel, comp)
-    Constructor _ _ c d _ kit fs _ _ _ _
+    Constructor _ _ c d _ _ kit fs _ _ _ _
       -> namesAndMetasIn' sg (c, d, kit, fs)
     Primitive _ _ cl _ cc _
       -> namesAndMetasIn' sg (cl, cc)

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -73,6 +73,7 @@ import Agda.TypeChecking.Warnings
 
 import Agda.Interaction.Options
 
+import Agda.Utils.Boolean ( toBool )
 import Agda.Utils.Either
 import Agda.Utils.Function
 import Agda.Utils.Functor
@@ -750,7 +751,7 @@ splitStrategy bs tel = return $ updateLast setBlockingVarOverlap xs
 -- the data type must be inductive.
 isDatatype :: (MonadTCM tcm, MonadError SplitError tcm) =>
               Induction -> Dom Type ->
-              tcm (DataOrRecord, QName, Sort, Args, Args, [QName], Bool)
+              tcm (DataOrRecord, QName, Sort, Args, Args, [QName], IsHIT)
 isDatatype ind at = do
   let t       = unDom at
       throw f = throwError . f =<< do liftTCM $ buildClosure t
@@ -762,22 +763,22 @@ isDatatype ind at = do
     Def d [Apply phi] | Just d == mIsOne -> do
                 xs <- liftTCM $ decomposeInterval =<< reduce (unArg phi)
                 if null xs
-                   then return $ (IsData, d, mkSSet 0, [phi], [], [], False)
+                   then return $ (IsData, d, mkSSet 0, [phi], [], [], NotHIT)
                    else throw NotADatatype
     Def d es -> do
       let ~(Just args) = allApplyElims es
       def <- liftTCM $ getConstInfo d
       case theDef def of
-        Datatype{dataSort = s, dataPars = np, dataCons = cs}
+        Datatype{dataSort = s, dataPars = np, dataCons = cs, dataHIT = hit}
           | otherwise -> do
               let (ps, is) = splitAt np args
-              return (IsData, d, s, ps, is, cs, not $ null (dataPathCons $ theDef def))
+              return (IsData, d, s, ps, is, cs, hit)
         Record{recPars = np, recConHead = con, recInduction = i, recEtaEquality'}
           | i == Just CoInductive && ind /= CoInductive ->
               throw CoinductiveDatatype
           | otherwise -> do
               s <- liftTCM $ shouldBeSort =<< defType def `piApplyM` args
-              return (IsRecord InductionAndEta { recordInduction=i, recordEtaEquality=recEtaEquality' }, d, s, args, [], [conName con], False)
+              return (IsRecord InductionAndEta { recordInduction=i, recordEtaEquality=recEtaEquality' }, d, s, args, [], [conName con], NotHIT)
         _ -> throw NotADatatype
     _ -> throw NotADatatype
 
@@ -1300,7 +1301,8 @@ split' checkEmpty ind allowPartialCover inserttrailing
     return (fst $ unDom dom, snd <$> dom, telFromList tel1, telFromList tel2)
 
   -- Compute the neighbourhoods for the constructors
-  let computeNeighborhoods = do
+  let computeNeighborhoods :: ExceptT SplitError TCM (DataOrRecord, Sort, Bool, Int, [(SplitTag, (SplitClause, IInfo))])
+      computeNeighborhoods = do
         -- Check that t is a datatype or a record
         -- Andreas, 2010-09-21, isDatatype now directly throws an exception if it fails
         -- cons = constructors of this datatype
@@ -1311,7 +1313,7 @@ split' checkEmpty ind allowPartialCover inserttrailing
           NoCheckEmpty -> pure cons'
         mns  <- forM cons $ \ con -> fmap (SplitCon con,) <$>
           computeNeighbourhood delta1 n delta2 d pars ixs x tel ps cps con
-        hcompsc <- if isFib && (isHIT || not (null ixs)) && not (null mns) && inserttrailing == DoInsertTrailing
+        hcompsc <- if isFib && (isHIT == YesHIT || not (null ixs)) && not (null mns) && inserttrailing == DoInsertTrailing
                    then computeHCompSplit delta1 n delta2 d pars ixs x tel ps cps
                    else return Nothing
         let ns = catMaybes mns
@@ -1322,6 +1324,7 @@ split' checkEmpty ind allowPartialCover inserttrailing
                , ns ++! catMaybes ([fmap (fmap (,NoInfo)) hcompsc | not $ null $ ns])
                )
 
+      computeLitNeighborhoods :: ExceptT SplitError TCM (DataOrRecord, Sort, Bool, Int, [(SplitTag, (SplitClause, IInfo))])
       computeLitNeighborhoods = do
         typeOk <- liftTCM $ do
           t' <- litType $ headWithDefault {-'-} __IMPOSSIBLE__ plits

--- a/src/full/Agda/TypeChecking/Datatypes.hs
+++ b/src/full/Agda/TypeChecking/Datatypes.hs
@@ -16,6 +16,7 @@ import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Pretty
 
+import Agda.Utils.Boolean ( toBool )
 import Agda.Utils.CallStack
 import Agda.Utils.Either
 import Agda.Utils.Functor
@@ -69,20 +70,24 @@ getConstructorData c = do
 --   Precondition: The argument must refer to a constructor of a datatype or record.
 consOfHIT :: (HasCallStack, HasConstInfo m) => QName -> m Bool
 consOfHIT c = do
-  d <- getConstructorData c
-  def <- theDef <$> getConstInfo d
-  case def of
-    Datatype {dataPathCons = xs} -> return $ not $ null xs
-    Record{} -> return False
+  theDef <$> getConstInfo c >>= \case
+    -- A path constructor is always a constructor of a HIT,
+    -- so we only need to consult the data type for point constructors.
+    Constructor{ conPathCons = PathCons } -> return True
+    Constructor{ conPathCons = PointCons, conData = d } ->
+      theDef <$> getConstInfo d >>= \case
+        Datatype{ dataHIT = hit } -> return $ toBool hit
+        Record{} -> return False
+        _  -> __IMPOSSIBLE__
     _  -> __IMPOSSIBLE__
 
+-- | Is this a path constructor (of a higher inductive type)?
+--   Precondition: The argument must refer to a constructor of a datatype or record.
 isPathCons :: (HasCallStack, HasConstInfo m) => QName -> m Bool
 isPathCons c = do
-  d <- getConstructorData c
-  def <- theDef <$> getConstInfo d
+  def <- theDef <$> getConstInfo c
   case def of
-    Datatype {dataPathCons = xs} -> return $ c `elem` xs
-    Record{} -> return False
+    Constructor{ conPathCons = p } -> return $ p == PathCons
     _  -> __IMPOSSIBLE__
 
 -- | @getFullyAppliedConType c t@ computes the constructor parameters

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -969,6 +969,7 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = noMutualBlock $ d
                 , conSrcCon = genRecCon
                 , conData   = genRecName
                 , conAbstr  = ConcreteDef
+                , conPathCons = PointCons
                 , conComp   = emptyCompKit
                 , conProj   = Nothing
                 , conForced = []

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -131,7 +131,7 @@ import Agda.Interaction.Library.Base ( ExeName, ExeMap, LibCache, LibErrors )
 import Agda.Utils.Benchmark (MonadBench(..))
 import Agda.Utils.BiMap (BiMap, HasTag(..))
 import Agda.Utils.BiMap qualified as BiMap
-import Agda.Utils.Boolean   ( fromBool, toBool )
+import Agda.Utils.Boolean   ( Boolean, IsBool, fromBool, toBool )
 import Agda.Utils.CallStack ( CallStack, HasCallStack, withCallerCallStack )
 import Agda.Utils.ExpandCase
 import Agda.Utils.FileId    ( FileDictBuilder, GetFileId(getFileId), GetIdFile(getIdFile) )
@@ -2854,6 +2854,24 @@ data CompKit = CompKit
 emptyCompKit :: CompKit
 emptyCompKit = CompKit Nothing Nothing
 
+-- | Is a constructor of a data type a path constructor (HIT constructor)
+--   or an ordinary "point" constructor?
+data IsPathCons = PathCons | PointCons
+  deriving (Eq, Show, Generic)
+
+-- | Does a data type have path constructors,
+--   i.e., is it a higher inductive type (HIT)?
+data IsHIT = YesHIT | NotHIT
+  deriving (Eq, Show, Generic)
+
+instance Boolean IsHIT where
+  fromBool True  = YesHIT
+  fromBool False = NotHIT
+
+instance IsBool IsHIT where
+  toBool YesHIT = True
+  toBool NotHIT = False
+
 defaultAxiom :: Defn
 defaultAxiom = Axiom False
 
@@ -3029,8 +3047,9 @@ data DatatypeData = DatatypeData
   , _dataPositivityCheck:: PositivityCheck
       -- ^ Should positivity errors be reported for this data type?
   , _dataAbstr          :: IsAbstract
-  , _dataPathCons       :: [QName]
-      -- ^ Path constructor names (subset of @dataCons@).
+  , _dataHIT            :: !IsHIT
+      -- ^ Does this data type have any path constructors,
+      --   i.e., is it a higher inductive type (HIT)?
   , _dataTranspIx       :: Maybe QName
       -- ^ If indexed datatype, name of the "index transport" function.
   , _dataTransp         :: Maybe QName
@@ -3046,7 +3065,7 @@ pattern Datatype
   -> Maybe [QName]
   -> PositivityCheck
   -> IsAbstract
-  -> [QName]
+  -> IsHIT
   -> Maybe QName
   -> Maybe QName
   -> Defn
@@ -3060,7 +3079,7 @@ pattern Datatype
   , dataMutual
   , dataPositivityCheck
   , dataAbstr
-  , dataPathCons
+  , dataHIT
   , dataTranspIx
   , dataTransp
   } = DatatypeDefn (DatatypeData
@@ -3072,7 +3091,7 @@ pattern Datatype
     dataMutual
     dataPositivityCheck
     dataAbstr
-    dataPathCons
+    dataHIT
     dataTranspIx
     dataTransp
   )
@@ -3180,6 +3199,9 @@ data ConstructorData = ConstructorData
   , _conData   :: QName
       -- ^ Name of datatype or record type.
   , _conAbstr  :: IsAbstract
+  , _conPathCons :: !IsPathCons
+      -- ^ Is this a path constructor (HIT constructor)
+      --   or an ordinary "point" constructor?
   , _conComp   :: CompKit
       -- ^ Cubical composition.
   , _conProj   :: Maybe [QName]
@@ -3206,6 +3228,7 @@ pattern Constructor
   -> ConHead
   -> QName
   -> IsAbstract
+  -> IsPathCons
   -> CompKit
   -> Maybe [QName]
   -> [IsForced]
@@ -3219,6 +3242,7 @@ pattern Constructor
   , conSrcCon
   , conData
   , conAbstr
+  , conPathCons
   , conComp
   , conProj
   , conForced
@@ -3231,6 +3255,7 @@ pattern Constructor
     conSrcCon
     conData
     conAbstr
+    conPathCons
     conComp
     conProj
     conForced
@@ -3419,7 +3444,7 @@ instance Pretty DatatypeData where
       dataMutual
       _dataPositivityCheck
       _dataAbstr
-      _dataPathCons
+      dataHIT
       _dataTranspIx
       _dataTransp
     ) =
@@ -3431,6 +3456,7 @@ instance Pretty DatatypeData where
       , "dataSort       =" <?> pretty dataSort
       , "dataMutual     =" <?> pshow dataMutual
       , "dataAbstr      =" <?> pshow dataAbstr
+      , "dataHIT        =" <?> pshow dataHIT
       ] <?> "}"
 
 instance Pretty RecordData where
@@ -3470,6 +3496,7 @@ instance Pretty ConstructorData where
       conSrcCon
       conData
       conAbstr
+      conPathCons
       _conComp
       _conProj
       _conForced
@@ -3478,14 +3505,15 @@ instance Pretty ConstructorData where
       conInline
     ) =
     "Constructor {" <?> vcat
-      [ "conPars    =" <?> pshow conPars
-      , "conArity   =" <?> pshow conArity
-      , "conSrcCon  =" <?> pretty conSrcCon
-      , "conData    =" <?> pretty conData
-      , "conAbstr   =" <?> pshow conAbstr
-      , "conErased  =" <?> pshow conErased
-      , "conErasure =" <?> pshow conErasure
-      , "conInline  =" <?> pshow conInline
+      [ "conPars     =" <?> pshow conPars
+      , "conArity    =" <?> pshow conArity
+      , "conSrcCon   =" <?> pretty conSrcCon
+      , "conData     =" <?> pretty conData
+      , "conAbstr    =" <?> pshow conAbstr
+      , "conPathCons =" <?> pshow conPathCons
+      , "conErased   =" <?> pshow conErased
+      , "conErasure  =" <?> pshow conErasure
+      , "conInline   =" <?> pshow conInline
       ] <?> "}"
 
 instance Pretty PrimitiveData where
@@ -7278,6 +7306,12 @@ instance KillRange FunctionFlag where
 instance KillRange CompKit where
   killRange = id
 
+instance KillRange IsPathCons where
+  killRange = id
+
+instance KillRange IsHIT where
+  killRange = id
+
 instance KillRange ProjectionLikenessMissing where
   killRange = id
 
@@ -7299,7 +7333,7 @@ instance KillRange Defn where
         killRangeN Function a b c d e f g h i j k l m n
       Datatype a b c d e f g h i j k -> killRangeN Datatype a b c d e f g h i j k
       Record a b c d e f g h i j k l m n -> killRangeN Record a b c d e f g h i j k l m n
-      Constructor a b c d e f g h i j k -> killRangeN Constructor a b c d e f g h i j k
+      Constructor a b c d e f g h i j k l -> killRangeN Constructor a b c d e f g h i j k l
       Primitive a b c d e f          -> killRangeN Primitive a b c d e f
       PrimitiveSort a b              -> killRangeN PrimitiveSort a b
 
@@ -7438,6 +7472,8 @@ instance NFData AxiomData
 instance NFData DataOrRecSigData
 instance NFData ProjectionLikenessMissing
 instance NFData FunctionData
+instance NFData IsPathCons
+instance NFData IsHIT
 instance NFData DatatypeData
 instance NFData RecordData
 instance NFData ConstructorData

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -38,6 +38,7 @@ import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Telescope
 
+import Agda.Utils.Boolean ( toBool )
 import Agda.Utils.Either
 import Agda.Utils.Function
 import Agda.Utils.Functor
@@ -570,9 +571,10 @@ primTransHComp cmd ts nelims = do
               -- For data types, if this data type is indexed and/or a
               -- higher inductive type, then hcomp is normal; But
               -- compData knows what to do for the general cases.
-              Datatype{dataPars = pars, dataIxs = ixs, dataPathCons = pcons, dataTransp = mtrD}
-                | and [null pcons && ixs == 0 | DoHComp  <- [cmd]], Just as <- allApplyElims es ->
-                  compData mtrD (not (null pcons) || ixs > 0) (pars + ixs) cmd l (as <$ t) sbA sphi u u0
+              Datatype{dataPars = pars, dataIxs = ixs, dataHIT = hit, dataTransp = mtrD}
+                | and [ hit == NotHIT && ixs == 0 | DoHComp <- [cmd] ]
+                , Just as <- allApplyElims es ->
+                  compData mtrD (hit == YesHIT || ixs > 0) (pars + ixs) cmd l (as <$ t) sbA sphi u u0
 
               -- Is this an axiom with constant transport? Then. Well. Transport is constant.
               Axiom constTransp | constTransp, [] <- es, DoTransp <- cmd -> redReturn $ unArg u0

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -999,6 +999,7 @@ bindBuiltinNoDef b q = inTopContext $ do
               , conSrcCon = ch
               , conData   = d
               , conAbstr  = ConcreteDef
+              , conPathCons = PointCons
               , conComp   = emptyCompKit
               , conProj   = Nothing
               , conForced = []
@@ -1025,7 +1026,7 @@ bindBuiltinNoDef b q = inTopContext $ do
               , dataAbstr      = ConcreteDef
               , dataMutual     = Nothing
               , dataPositivityCheck = NoPositivityCheck
-              , dataPathCons   = []
+              , dataHIT        = NotHIT
               , dataTranspIx   = Nothing -- Id has custom transp def.
               , dataTransp     = Nothing
               }

--- a/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
@@ -102,6 +102,7 @@ bindBuiltinSharp x =
                     , conSrcCon = ConHead sharp (IsRecord CopatternMatching) CoInductive [] -- flat is added as field later
                     , conData   = defName infDefn
                     , conAbstr  = ConcreteDef
+                    , conPathCons = PointCons
                     , conComp   = emptyCompKit
                     , conProj   = Nothing
                     , conForced = []

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -153,7 +153,7 @@ checkDataDef i name pc uc (A.DataDefParams gpars ps) cs =
                   , _dataAbstr      = Info.defAbstract i
                   , _dataMutual     = Nothing
                   , _dataPositivityCheck = pc
-                  , _dataPathCons   = []     -- Path constructors are added later
+                  , _dataHIT        = NotHIT -- Computed later from the constructors
                   , _dataTranspIx   = Nothing -- Generated later if nofIxs > 0.
                   , _dataTransp     = Nothing -- Added later
                   }
@@ -162,11 +162,10 @@ checkDataDef i name pc uc (A.DataDefParams gpars ps) cs =
               addConstant' name defaultArgInfo t $ DatatypeDefn dataDef
                 -- polarity and argOcc.s determined by the positivity checker
 
-            -- Check the types of the constructors
-            pathCons <- forM cs $ \ c -> do
-              isPathCons <- checkConstructor name uc tel' nofIxs s c
-              return $ if isPathCons == PathCons then Just (A.axiomName c) else Nothing
-
+            -- Check the types of the constructors.
+            -- The data type is a HIT if at least one of them is a path constructor.
+            hit <- or <$> forM cs \ c ->
+              (PathCons ==) <$> checkConstructor name uc tel' nofIxs s c
 
             -- cubical: the interval universe does not contain datatypes
             -- similar: SizeUniv, ...
@@ -184,7 +183,7 @@ checkDataDef i name pc uc (A.DataDefParams gpars ps) cs =
                 checkIndexSorts s' ixTel
 
             -- Return the data definition
-            return dataDef{ _dataPathCons = catMaybes pathCons
+            return dataDef{ _dataHIT = fromBool hit
                           }
 
         let cons   = map' A.axiomName cs  -- get constructor names
@@ -195,7 +194,7 @@ checkDataDef i name pc uc (A.DataDefParams gpars ps) cs =
               checkNoLocalRewrites name
               mtranspix <- defineTranspIx name
               transpFun <- defineTranspFun name mtranspix cons $
-                           _dataPathCons dataDef
+                           _dataHIT dataDef
               return (mtranspix, transpFun))
             (return (Nothing, Nothing))
 
@@ -337,6 +336,7 @@ checkConstructor d uc tel nofIxs s con@(A.Axiom _ i ai Nothing c e) =
               , conSrcCon = con
               , conData   = d
               , conAbstr  = Info.defAbstract i
+              , conPathCons = isPathCons
               , conComp   = comp
               , conProj   = projNames
               , conForced = forcedArgs
@@ -841,9 +841,9 @@ defineTranspIx d = do
 defineTranspFun :: QName -- ^ datatype
                 -> Maybe QName -- ^ transpX "constructor"
                 -> [QName]     -- ^ constructor names
-                -> [QName]     -- ^ path cons
+                -> IsHIT       -- ^ is this a HIT, i.e., are there path constructors?
                 -> TCM (Maybe QName) -- transp function for the datatype.
-defineTranspFun d mtrX cons pathCons = do
+defineTranspFun d mtrX cons isHIT = do
   def <- getConstInfo d
   case theDef def of
     Datatype { dataPars = npars
@@ -909,7 +909,7 @@ defineTranspFun d mtrX cons pathCons = do
               reportSDoc "tc.data.transp" 20 $ addContext ("i" :: String, __DUMMY_DOM__) $
                 "could not transp" <+> prettyTCM (absBody t)
         -- TODO: if no params nor indexes trD phi u0 = u0.
-        ecs <- tryTranspError $ (clause:) <$> defineConClause trD (not $ null pathCons) mtrX npars nixs ixs telI sigma dTs cons
+        ecs <- tryTranspError $ (clause:) <$> defineConClause trD (toBool isHIT) mtrX npars nixs ixs telI sigma dTs cons
         caseEitherM (pure ecs) (\ cl -> debugNoTransp cl >> return Nothing) $ \ cs -> do
         (mst, _, cc) <- compileClauses Nothing cs
         fun <- emptyFunctionData <&> \fun -> fun
@@ -1837,9 +1837,6 @@ checkIndexSorts s = \case
 -- | Return the parameters that share variables with the indices
 -- nonLinearParameters :: Int -> Type -> TCM [Int]
 -- nonLinearParameters nPars t =
-
-data IsPathCons = PathCons | PointCons
-  deriving (Eq,Show)
 
 -- | Check that a type constructs something of the given datatype. The first
 --   argument is the number of parameters to the datatype and the second the

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -267,6 +267,7 @@ checkRecDef i name pc uc forceEta (RecordDirectives ind eta0 pat con) (A.DataDef
               , conSrcCon = con
               , conData   = name
               , conAbstr  = Info.defAbstract i
+              , conPathCons = PointCons
               , conComp   = emptyCompKit  -- filled in later
               , conProj   = Nothing       -- filled in later
               , conForced = []

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 #include "MachDeps.h"
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20260819 * 10 + 0
+currentInterfaceVersion = 20260828 * 10 + 0
 
 ifaceVersionSize :: Int
 ifaceVersionSize = SIZEOF_WORD64

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -390,6 +390,22 @@ instance EmbPrj IsForced where
   value 1 = return NotForced
   value _ = malformed
 
+instance EmbPrj IsPathCons where
+  icod_ PathCons  = return 0
+  icod_ PointCons = return 1
+
+  value 0 = return PathCons
+  value 1 = return PointCons
+  value _ = malformed
+
+instance EmbPrj IsHIT where
+  icod_ YesHIT = return 0
+  icod_ NotHIT = return 1
+
+  value 0 = return YesHIT
+  value 1 = return NotHIT
+  value _ = malformed
+
 instance EmbPrj NumGeneralizableArgs where
   icod_ NoGeneralizableArgs       = icodeN' NoGeneralizableArgs
   icod_ (SomeGeneralizableArgs a) = icodeN' SomeGeneralizableArgs a
@@ -463,7 +479,7 @@ instance EmbPrj Defn where
   icod_ (Function    a b s t u c d e f g h i j k)       = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k
   icod_ (Datatype    a b c d e f g h i j k)             = icodeN 2 Datatype a b c d e f g h i j k
   icod_ (Record      a b c d e f g h i j k l m n)       = icodeN 3 Record a b c d e f g h i j k l m n
-  icod_ (Constructor a b c d e f g h i j k)             = icodeN 4 Constructor a b c d e f g h i j k
+  icod_ (Constructor a b c d e f g h i j k l)           = icodeN 4 Constructor a b c d e f g h i j k l
   icod_ (Primitive   a b c d e f)                       = icodeN 5 Primitive a b c d e f
   icod_ (PrimitiveSort a b)                             = icodeN 6 PrimitiveSort a b
   icod_ AbstractDefn{}                                  = __IMPOSSIBLE__
@@ -478,7 +494,7 @@ instance EmbPrj Defn where
                                                       a b s u c d e f g h i j k
     N6 2 a b c d e (N6 f g h i j k N0)       -> valuN Datatype a b c d e f g h i j k
     N6 3 a b c d e (N6 f g h i j k (N3 l m n)) -> valuN Record a b c d e f g h i j k l m n
-    N6 4 a b c d e (N6 f g h i j k N0)       -> valuN Constructor a b c d e f g h i j k
+    N6 4 a b c d e (N6 f g h i j k (N1 l))   -> valuN Constructor a b c d e f g h i j k l
     N6 5 a b c d e (N1 f)                    -> valuN Primitive a b c d e f
     N3 6 a b                                 -> valuN PrimitiveSort a b
     N2 7 a                                   -> valuN GeneralizableVar a


### PR DESCRIPTION
This replaces the sublist `dataPathCons` of `dataCons` by a flag `dataHIT` indicating whether we are dealing with a higher inductive type, and instead stores at each `Constructor` whether it is a path constructor (`conPathCons`).

The refactoring allows some minor optimizations in `isPathCons` and `consOfHIT`.  But it is mostly motivated by eliminating redundancy that relies on invariants that are not checked ("sublist").

The refactoring was partially implemented by Claude given a precise task description.
It states that the refactoring fixed some potential bug, but we'll not try to get a reproducer since it would not be of interest anymore.
> Worth flagging: the old `isPathCons` looks like it was **wrong for data types copied by module application**. `applySection` (`Monad/Signature.hs:720-724`) renames `dataCons` with `copyName` but never touched `dataPathCons`, so a copied data type kept the *original* path-constructor names while queries passed *copied* names — `c `elem` xs` would be `False`. `consOfHIT` was unaffected (it only tested non-emptiness, which copying preserves). The per-constructor field travels with the constructor's own `Defn` (which `applySection` does copy), so this is now correct by construction. I did not build a failing repro for the old behaviour; this is read off the copy code.
