### PR TITLE
Fix for #8700

### DIFF
--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -12,6 +12,7 @@ import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 
 import Agda.Syntax.Common
+import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
 
@@ -50,6 +51,11 @@ instance Null (Match a) where
   empty = Yes empty empty
   null (Yes simpl as) = null simpl && null as
   null _              = False
+
+instance P.Pretty a => P.Pretty (Match a) where
+  pretty (Yes simp xs) = "Yes" P.<+> P.pretty (IntMap.toList xs)
+  pretty (No _) = "No"
+  pretty (DontKnow _ _ b) = "DontKnow" P.<+> P.pretty b
 
 matchedArgs :: Empty -> Int -> IntMap (Arg a) -> [Arg a]
 matchedArgs err n vs = map (fromMaybe (absurd err)) $ matchedArgs' n vs
@@ -221,8 +227,8 @@ matchPatterns ps vs = do
 
   traceSDoc "tc.match" 50
     (vcat [ "matchPatterns"
-          , nest 2 $ "ps =" <+> fsep (punctuate comma $ map (text . show) ps)
-          , nest 2 $ "vs =" <+> fsep (punctuate comma $ map prettyTCM vs)
+          , nest 2 $ "ps =" <+> fsep (punctuate comma $ map pretty ps)
+          , nest 2 $ "vs =" <+> fsep (punctuate comma $ map pretty vs)
           ]) $ do
   -- Buggy, see issue 1124:
   -- (ms,vs) <- unzip <$> zipWithM' (matchPattern . namedArg) ps vs
@@ -291,11 +297,11 @@ matchPattern p u = debugMatchPattern $ case (p, u) of
             , nest 2 $ "u =" <+> prettyTCM u
             ]
     reportSDoc "tc.match" 60 $
-       vcat [ nest 2 $ "p (raw) =" <+> (text . show) p
+       vcat [ nest 2 $ "p (raw) =" <+> pretty p
             ]
     (m, t) <- go
-    reportSDoc "tc.match" 50 $
-      vcat [ nest 2 $ "result = " <+> (text . show) m ]
+    reportSDoc "tc.match" 60 $
+      vcat [ nest 2 $ "result = " <+> pretty m ]
     -- reportSDoc "tc.match" 20 $
     --   vcat [ nest 2 $ "result = " <+> prettyTCM m ]
     return (m, t)
@@ -353,6 +359,10 @@ matchPattern p u = debugMatchPattern $ case (p, u) of
                _ -> return w
         let v = ignoreBlocking w
             arg = Arg info v  -- the reduced argument
+
+        reportSDoc "tc.match" 40 $ vcat
+          [ "  v = " <+> prettyTCM v <?> pretty (void w)
+          ]
 
         case w of
           b | Just t <- isMatchable b ->

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -314,18 +314,14 @@ matchPattern p u = debugMatchPattern $ case (p, u) of
         f _                         = Nothing
     fallback' f prio lazy ps v
 
-  -- Regardless of blocking, constructors and a properly applied @hcomp@
-  -- can be matched on.
-  isMatchable' :: HasBuiltins m => m (Blocked Term -> Maybe Term)
-  isMatchable' = do
-    mhcomp <- getName' builtinHComp
-    return $ \ r ->
+  -- Regardless of blocking, constructors can be matched on.
+  -- Since hcomp clauses are only computed during coverage checking
+  -- and clause-based reduction is only used *before* coverage checking,
+  -- we do not consider hcomp patterns here (see issue #8700).
+  isMatchable :: Blocked Term -> Maybe Term
+  isMatchable r =
       case ignoreBlocking r of
         t@Con{} -> Just t
-        t@(Def q [l,a,phi,u,u0]) | Just q == mhcomp
-                -> Just t
-        -- TODO this covers the transpIx functions, but it's a hack.
-        t@(Def q _) | NotBlocked{blockingStatus = MissingClauses _} <- r -> Just t
         _       -> Nothing
 
   -- DefP hcomp and ConP matching.
@@ -337,7 +333,6 @@ matchPattern p u = debugMatchPattern $ case (p, u) of
             -> Arg Term
             -> m (Match Term, Arg Term)
   fallback' mtc prio lazy ps (Arg info v) = do
-        isMatchable <- isMatchable'
 
         w <- reduceB v
         -- Unfold delayed (corecursive) definitions one step. This is

--- a/test/Fail/Issue8700a.agda
+++ b/test/Fail/Issue8700a.agda
@@ -1,0 +1,36 @@
+{-# OPTIONS --safe --without-K #-}
+
+-- Issue found by Claude and reported by bdrisc-ant on Github
+
+-- While the clauses of a function are being checked, the function reduces
+-- via the clauses checked so far.  A call that is stuck because the
+-- remaining clauses are still missing is treated by the clause matcher as a
+-- *definite* mismatch against a constructor pattern, so an enclosing call
+-- reduces by a later clause to a value that the completed definition
+-- contradicts.
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+
+data ⊥ : Set where
+
+f : Bool → Bool → Bool
+f true  true  = false
+f x     true  = true
+f false false = true
+  module M where
+    -- Checked when only the first two clauses of f are in the signature.
+    -- The inner call  f false false  is stuck (no clause yet); the matcher
+    -- reports a definite mismatch against the pattern  true  of the first
+    -- clause, and the outer call reduces by the second clause to  true.
+    lem : f (f false false) true ≡ true
+    lem = refl
+f true  false = false
+
+-- Once f is complete,  f (f false false) true = f true true = false.
+
+discr : false ≡ true → ⊥
+discr ()
+
+boom : ⊥
+boom = discr M.lem

--- a/test/Fail/Issue8700a.err
+++ b/test/Fail/Issue8700a.err
@@ -1,0 +1,8 @@
+Issue8700a.agda:27.11-15: error: [UnequalTerms]
+The terms
+  f (f false false) true
+and
+  true
+are not equal at type Bool
+when checking that the expression refl has type
+f (f false false) true ≡ true

--- a/test/Fail/Issue8700b.agda
+++ b/test/Fail/Issue8700b.agda
@@ -1,0 +1,31 @@
+{-# OPTIONS --safe --without-K #-}
+
+-- Issue found by Claude and reported by bdrisc-ant on Github
+
+-- Same mechanism, observed without any where module: the result type of
+-- f's own third clause is computed (via T) by reducing f while only its
+-- first two clauses are in the signature.
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+
+data ⊥ : Set where
+
+T : Bool → Bool → Set
+f : (x y : Bool) → T x y
+
+T x     true  = Bool
+T true  false = Bool
+T false false = f (f true false) true ≡ true
+
+f true  true  = false
+f x     true  = true
+f false false = refl      -- checked at  T false false  with only clauses 1-2 of f known:
+                          -- f (f true false) true  reduces to  true  there
+f true  false = true      -- now  f (f true false) true = f true true = false
+
+discr : false ≡ true → ⊥
+discr ()
+
+boom : ⊥
+boom = discr (f false false)

--- a/test/Fail/Issue8700b.err
+++ b/test/Fail/Issue8700b.err
@@ -1,0 +1,7 @@
+Issue8700b.agda:23.17-21: error: [UnequalTerms]
+The terms
+  f (f true false) true
+and
+  true
+are not equal at type Bool
+when checking that the expression refl has type T false false

--- a/test/Fail/Issue8700c.agda
+++ b/test/Fail/Issue8700c.agda
@@ -1,0 +1,46 @@
+{-# OPTIONS --safe --cubical #-}
+
+-- Issue found by Claude and reported by bdrisc-ant on Github
+
+-- Cubical variant: the clause matcher treats any properly applied
+-- primHComp as matchable "regardless of blocking", so an hcomp in Bool with
+-- an *open* base x is a definite mismatch against the pattern  true  and the
+-- catch-all second clause fires while f's last clause is being checked.
+-- That mismatch is not stable: at x = true the hcomp computes to true and
+-- the completed f answers by its first clause, so  M.bad true : true ≡ false.
+-- (No hcomp clause is generated for Bool; for the HIT case see ...HCompHIT.)
+
+open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive.Cubical
+  renaming (primIMin to _∧_; primIMax to _∨_; primINeg to ~_;
+            primHComp to hcomp; primTransp to transp; itIsOne to 1=1)
+open import Agda.Builtin.Cubical.Path
+open import Agda.Builtin.Bool
+
+data ⊥ : Type where
+record ⊤ : Type where
+  constructor tt
+
+f : Bool → Bool → Bool
+f true  _     = true
+f x     true  = false
+f false false = false
+  module M where
+    -- Checked when only the first two clauses of f are in the signature.
+    bad : (x : Bool) → f (hcomp {φ = i0} (λ _ → isOneEmpty) x) true ≡ false
+    bad x = λ _ → false
+
+boom : true ≡ false
+boom = M.bad true
+
+T : Bool → Type
+T true  = ⊤
+T false = ⊥
+
+-- (Extraction through a variable path, so that  T (p i0)  reduces by the
+-- endpoint rule on both the fast and the slow reducer.)
+coerce : true ≡ false → ⊤ → ⊥
+coerce p x = transp (λ i → T (p i)) i0 x
+
+absurd : ⊥
+absurd = coerce boom tt

--- a/test/Fail/Issue8700c.err
+++ b/test/Fail/Issue8700c.err
@@ -1,0 +1,8 @@
+Issue8700c.agda:31.19-24: error: [UnequalTerms]
+The terms
+  false
+and
+  f (hcomp (λ i → isOneEmpty) x) true
+are not equal at type Bool
+when checking that the expression λ _ → false has type
+f (hcomp (λ _ → isOneEmpty) x) true ≡ false


### PR DESCRIPTION
As explained in the issue discussion, this fixes https://github.com/agda/agda/issues/8700 by not considering `Def`s with missing clauses or applications as matchable for clause-based matching.