### PR TITLE
Fix #8699 by masking irrelevant/Prop-sorted subterms in dot patterns in the termination checker

### DIFF
--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -679,7 +679,6 @@ instance TermToPattern Term DeBruijnPattern where
         suc <- terGetSizeSuc
         if Just s == suc then ConP (ConHead s IsData Inductive []) noConPatternInfo . map' (fmap unnamed) <$> termToPattern [arg]
          else fallback
-      DontCare t  -> termToPattern t
       -- Leaves.
       -- Any (not coinductively) projected variable becomes a variable pattern.
       Var i es -> case mapM isProjElim es of
@@ -687,9 +686,17 @@ instance TermToPattern Term DeBruijnPattern where
           All True -> varP . (`DBPatVar` i) . prettyShow <$> nameOfBV i
           _        -> fallback
         _ -> fallback
-      Lit l       -> return $ litP l
-      Dummy s _   -> __IMPOSSIBLE_VERBOSE__ (show s)
-      _           -> fallback
+      Lit l      -> return $ litP l
+      Dummy s _  -> __IMPOSSIBLE_VERBOSE__ (show s)
+      Def{}      -> fallback
+      Lam{}      -> fallback
+      Pi{}       -> fallback
+      Sort{}     -> fallback
+      Level{}    -> fallback
+      MetaV{}    -> fallback
+      -- Andreas, 2026-08-27, going under DontCare causes issue #8699.
+      -- See test/Fail/Issue8699Prop.
+      DontCare{} -> fallback
 
 
 -- | Masks all non-data/record type patterns if --without-K.

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -638,12 +638,13 @@ targetElem ds = terGetTarget <&> \case
 class TermToPattern a b where
   termToPattern :: a -> TerM b
 
-  default termToPattern :: (TermToPattern a' b', Traversable f, a ~ f a', b ~ f b') => a -> TerM b
-  termToPattern = traverse termToPattern
+-- UNUSED default instances (Andreas, 2026-08-29):
+  -- default termToPattern :: (TermToPattern a' b', Traversable f, a ~ f a', b ~ f b') => a -> TerM b
+  -- termToPattern = traverse termToPattern
 
-instance TermToPattern a b => TermToPattern [a] [b] where
-instance TermToPattern a b => TermToPattern (Arg a) (Arg b) where
-instance TermToPattern a b => TermToPattern (Named c a) (Named c b) where
+-- instance TermToPattern a b => TermToPattern [a] [b] where
+-- instance TermToPattern a b => TermToPattern (Arg a) (Arg b) where
+-- instance TermToPattern a b => TermToPattern (Named c a) (Named c b) where
 
 instance TermToPattern Term DeBruijnPattern where
   termToPattern t = do
@@ -674,10 +675,10 @@ instance TermToPattern Term DeBruijnPattern where
     case t of
       -- Constructors.
       Con c _ args -> ifNotConsOfHIT c $
-        ConP c noConPatternInfo . map' (fmap unnamed) <$> termToPattern (mustAllApplyElims args)
+        ConP c noConPatternInfo . map' (fmap unnamed) <$> mapM argToPattern (mustAllApplyElims args)
       Def s [Apply arg] -> do
         suc <- terGetSizeSuc
-        if Just s == suc then ConP (ConHead s IsData Inductive []) noConPatternInfo . map' (fmap unnamed) <$> termToPattern [arg]
+        if Just s == suc then ConP (ConHead s IsData Inductive []) noConPatternInfo . singleton . fmap unnamed <$> argToPattern arg
          else fallback
       -- Leaves.
       -- Any (not coinductively) projected variable becomes a variable pattern.
@@ -697,6 +698,15 @@ instance TermToPattern Term DeBruijnPattern where
       -- Andreas, 2026-08-27, going under DontCare causes issue #8699.
       -- See test/Fail/Issue8699Prop.
       DontCare{} -> fallback
+
+-- | Convert an argument into a pattern, but don't descent into irrelevant (sub)terms.
+-- (See issue #8699).
+argToPattern :: Arg Term -> TerM (Arg DeBruijnPattern)
+argToPattern arg
+  -- Andreas, 2026-08-29: irrelevant parts of dot patterns do not provide evidence for termination
+  -- since their specific form is not forced (by matches on other patterns) but arbitrary.
+  | isIrrelevant arg = return $ fmap dotP arg
+  | otherwise = traverse termToPattern arg
 
 
 -- | Masks all non-data/record type patterns if --without-K.

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -134,8 +134,7 @@ equalType = compareType CmpEq
 -- | Ignore errors in irrelevant context.
 convError :: TypeError -> TCM ()
 convError err =
-  ifM (isIrrelevant <$> viewTC eRelevance)
-    (return ())
+  unlessM (isIrrelevant <$> viewTC eRelevance)
     (typeError err)
 
 

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -403,13 +403,14 @@ checkDotPattern (Dot e v dom@(unDom -> a)) =
         ]
   applyDomToContext dom $ do
     u <- checkExpr e a
-    reportSDoc "tc.lhs.dot" 50 $
-      sep [ "equalTerm"
-          , nest 2 $ pretty a
-          , nest 2 $ pretty u
-          , nest 2 $ pretty v
-          ]
-    equalTerm a u v
+    unless (isIrrelevant dom) do
+      reportSDoc "tc.lhs.dot" 50 $
+        sep [ "equalTerm"
+            , nest 2 $ pretty a
+            , nest 2 $ pretty u
+            , nest 2 $ pretty v
+            ]
+      equalTerm a u v
 
 checkAbsurdPattern :: AbsurdPattern -> TCM ()
 checkAbsurdPattern (Absurd r a) = ensureEmptyType r a

--- a/test/Fail/DotPatternIrrelevantGarbage.agda
+++ b/test/Fail/DotPatternIrrelevantGarbage.agda
@@ -1,0 +1,23 @@
+-- Andreas, 2026-08-28
+-- Irrelevant dot pattern should not be allowed to contain arbitrary garbage.
+
+{-# OPTIONS --show-irrelevant #-}
+
+data Nat : Set where
+  zero : Nat
+  suc : (n : Nat) → Nat
+
+data D : .Nat → Set where
+  c : .(m : Nat) → D (suc m)
+
+f : .(n : Nat) → D n → Set
+f .(suc Nat) (c m) = Nat
+  -- This dot pattern is garbage and should be flagged by the LHS checker,
+  -- even though it is in irrelevant position.
+
+-- Expected error: [UnequalTypes]
+-- The type
+--   Set
+-- is not a subtype of
+--   Nat
+-- when checking that the expression Nat has type Nat

--- a/test/Fail/DotPatternIrrelevantGarbage.err
+++ b/test/Fail/DotPatternIrrelevantGarbage.err
@@ -1,0 +1,6 @@
+DotPatternIrrelevantGarbage.agda:14.9-12: error: [UnequalTypes]
+The type
+  Set
+is not a subtype of
+  Nat
+when checking that the expression Nat has type Nat

--- a/test/Fail/Issue8699.agda
+++ b/test/Fail/Issue8699.agda
@@ -1,0 +1,38 @@
+-- Andreas, 2026-08-27, issue #8699
+-- Reported and test case by @bdrisc-ant attributed to Claude
+-- Termination checker wrongly accepts decent in irrelevant fields in dot patterns.
+
+-- {-# OPTIONS -v tc.cc:20 #-}
+-- {-# OPTIONS -v tc.inj.check:50 #-}
+-- {-# OPTIONS -v tc.inj:50 #-}
+-- {-# OPTIONS -v tc:20 #-}
+
+{-# OPTIONS --show-irrelevant #-}
+
+data Nat : Set where
+  zero : Nat
+  suc : (n : Nat) → Nat
+
+data ⊥ : Set where
+
+record SqNat : Set where
+  constructor sq
+  field .unsq : Nat
+
+data PseudoFin : SqNat → Set where
+  fzero : (m : Nat) → PseudoFin (sq (suc m))
+  fsuc  : (m : Nat) → PseudoFin (sq m) → PseudoFin (sq (suc m))
+
+f : (s : SqNat) → PseudoFin s → ⊥
+f .(sq (suc m)) (fzero m)  = f (sq m) (fzero m)
+f .(sq (suc m)) (fsuc m x) = f (sq m) (fsuc m x)
+  -- WAS: Removing this case (and constructor fsuc) makes Agda loop
+
+boom : ⊥
+boom = f (sq (suc zero)) (fzero zero)
+
+-- Expected error: [TerminationIssue]
+-- Termination checking failed for the following function:
+--   f
+-- Problematic call:
+--   f (sq m) (fsuc m x)

--- a/test/Fail/Issue8699.err
+++ b/test/Fail/Issue8699.err
@@ -1,0 +1,6 @@
+Issue8699.agda:26.1-28.49: error: [TerminationIssue]
+Termination checking failed for the following function:
+  f
+Problematic call:
+  f (sq m) (fsuc m x)
+    (at Issue8699.agda:28.30-31)

--- a/test/Fail/Issue8699IrrelevantIndex.agda
+++ b/test/Fail/Issue8699IrrelevantIndex.agda
@@ -1,0 +1,26 @@
+-- Andreas, 2026-08-27, issue #8699
+-- Variant of test case by @bdrisc-ant attributed to Claude.
+-- Termination checker wrongly accepts decent in irrelevant fields in dot patterns.
+
+{-# OPTIONS --show-irrelevant #-}
+
+data Nat : Set where
+  zero : Nat
+  suc : (n : Nat) → Nat
+
+data ⊥ : Set where
+
+data PseudoFin : .Nat → Set where
+  fzero : .(m : Nat) → PseudoFin (suc m)
+
+f : .(s : Nat) → PseudoFin s → ⊥
+f .(suc m) (fzero m) = f m (fzero m)
+
+boom : ⊥
+boom = f (suc zero) (fzero zero)
+
+-- Expected error: [TerminationIssue]
+-- Termination checking failed for the following function:
+--   f
+-- Problematic call:
+--   f m (fzero m)

--- a/test/Fail/Issue8699IrrelevantIndex.err
+++ b/test/Fail/Issue8699IrrelevantIndex.err
@@ -1,0 +1,6 @@
+Issue8699IrrelevantIndex.agda:16.1-17.37: error: [TerminationIssue]
+Termination checking failed for the following function:
+  f
+Problematic call:
+  f m (fzero m)
+    (at Issue8699IrrelevantIndex.agda:17.24-25)

--- a/test/Fail/Issue8699Prop.agda
+++ b/test/Fail/Issue8699Prop.agda
@@ -1,0 +1,36 @@
+-- Andreas, 2026-08-27, issue #8699
+-- Reported and test case by @bdrisc-ant attributed to Claude
+-- Termination checker wrongly accepts decent in Prop-sorted subterms in dot patterns.
+
+{-# OPTIONS --prop #-}
+{-# OPTIONS --show-irrelevant #-}
+
+data ⊥ : Set where
+
+data Nat : Prop where
+  zero : Nat
+  suc : (n : Nat) → Nat
+
+record SqNat : Set where
+  constructor sq
+  field unsq : Nat
+
+data PseudoFin : SqNat → Set where
+  fzero : (m : Nat) → PseudoFin (sq (suc m))
+  -- fsuc  : (m : Nat) → PseudoFin (sq m) → PseudoFin (sq (suc m))
+
+f : (s : SqNat) → PseudoFin s → ⊥
+f .(sq (suc m)) (fzero m)  = f (sq m) (fzero m)
+-- f .(sq (suc m)) (fsuc m x) = f (sq m) (fsuc m x)
+  -- WAS: Removing this case (and constructor fsuc) makes Agda loop in the injectivity test
+
+boom : ⊥
+boom = f (sq (suc zero)) (fzero zero)
+
+-- f should not termination check
+
+-- Expected error: [TerminationIssue]
+-- Termination checking failed for the following function:
+--   f
+-- Problematic call:
+--   f (sq m) (fzero m)

--- a/test/Fail/Issue8699Prop.err
+++ b/test/Fail/Issue8699Prop.err
@@ -1,0 +1,6 @@
+Issue8699Prop.agda:22.1-23.48: error: [TerminationIssue]
+Termination checking failed for the following function:
+  f
+Problematic call:
+  f (sq m) (fzero m)
+    (at Issue8699Prop.agda:23.30-31)

--- a/test/Succeed/DotPatternIrrelevantIndex.agda
+++ b/test/Succeed/DotPatternIrrelevantIndex.agda
@@ -1,0 +1,36 @@
+-- Andreas, 2026-08-28, while working on issue #8699.
+-- Irrelevant dot pattern rejected without reason.
+-- The corresponding Prop versions were not rejected, see
+-- test/Succeed/DotPatternPropIndex.agda
+
+{-# OPTIONS --show-irrelevant #-}
+
+data Nat : Set where
+  zero : Nat
+  suc : (n : Nat) → Nat
+
+data D : .Nat → Set where
+  c : .(m : Nat) → D (suc m)
+
+f : .(n : Nat) → D n → Set
+f .(suc m) (c m) = Nat
+
+-- WAS: rejected with error: [UnequalTerms]
+-- The terms
+--   suc m
+-- and
+--   n
+-- are not equal at type Nat
+-- when checking that the given dot pattern suc m matches the inferred value n
+
+-- Should succeed.
+
+-- In fact, any correctly typed dot pattern is acceptable in an irrelevant position.
+
+g : .(n : Nat) → D n → Set
+g .(suc (suc m)) (c m) = Nat
+
+h : .(n : Nat) → D n → Set
+h .zero (c m) = Nat
+
+-- Should succeed.

--- a/test/Succeed/DotPatternPropIndex.agda
+++ b/test/Succeed/DotPatternPropIndex.agda
@@ -1,0 +1,26 @@
+-- Andreas, 2026-08-28, while working on issue #8699.
+-- Status quo: Prop dot pattern accepted even if it does not "make sense".
+
+{-# OPTIONS --prop --show-irrelevant #-}
+
+data N : Prop where
+  zero : N
+  suc : (n : N) → N
+
+data D : N → Set where
+  c : (m : N) → D (suc m)
+
+f : (n : N) → D n → Set₁
+f .(suc m) (c m) = Set
+
+-- The following dot pattern are also accepted even though
+-- they are not literally the expected one, namely `suc m`,
+-- because all `N`s are equal (is a Prop).
+
+g : (n : N) → D n → Set₁
+g .(suc (suc m)) (c m) = Set
+
+h : (n : N) → D n → Set₁
+h  .zero (c m) = Set
+
+-- Should succeed.


### PR DESCRIPTION
~~WIP: does not fix the termination problem with irrelevant dot patterns yet, just the Prop case.~~

~~WIP: this is a breaking change, needs a CHANGELOG and fixes in the standard library~~.

This implements the solution discussed with @jespercockx : don't traverse into irrelevant or Prop-sorted subterms in dot patterns when converting them to proper patterns in the termination checker.
(No changes to the unifier.)
There are also some tests included here documenting the status quo (things working correctly already before the fix).  I added the tests to map out the solution space.
There are also some refactorings inspired by me reading through the code in search of solutions.
Finally, I rectified the situation that an irrelevant dot pattern was rejected by the type checker while a corresponding Prop-sorted dot pattern was accepted.
The commits can be reviewed separately and have meaningful commit messages.

~~TODO: remove "WIP" from title and last commit message~~

Closes #8699.
  