### PR TITLE
Fix #8697 by indexing the memo map for Double by their Word64 representation

### DIFF
--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -54,6 +54,8 @@ import qualified Data.List as List
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 
+import GHC.Float (castWord64ToDouble)
+
 import qualified Codec.Compression.Zstd as Z
 
 import Agda.Interaction.Options.ProfileOptions qualified as Profile
@@ -78,7 +80,7 @@ import Agda.Utils.Impossible
 #include "MachDeps.h"
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20260828 * 10 + 0
+currentInterfaceVersion = 20260829 * 10 + 0
 
 ifaceVersionSize :: Int
 ifaceVersionSize = SIZEOF_WORD64
@@ -120,7 +122,7 @@ encode a = do
                <*!> toArray (sTextD newD)
                <*!> toArray (integerD newD)
                <*!> toArray (varSetD newD)
-               <*!> toArray (doubleD newD)
+               <*!> toArrayWith castWord64ToDouble (doubleD newD)
 
   -- Record reuse statistics.
   whenProfile Profile.Sharing $ do
@@ -144,10 +146,15 @@ encode a = do
   pure (root, nodeA, stringA, lTextA, sTextA, integerA, varSetA, doubleA)
   where
     toArray :: H.HashTableLU k Word32 -> IO (AL.Array k)
-    toArray tbl = do
+    toArray = toArrayWith id
+
+    -- The 'Double' dictionary is keyed by bit patterns (see 'icodeDouble'),
+    -- so its keys have to be converted back to 'Double's here.
+    toArrayWith :: (k -> a) -> H.HashTableLU k Word32 -> IO (AL.Array a)
+    toArrayWith f tbl = do
       size <- H.size tbl
       arr <- ML.new size undefined
-      H.forAssocs tbl \k v -> ML.write arr (fromIntegral v) k
+      H.forAssocs tbl \k v -> ML.write arr (fromIntegral v) $! f k
       ML.unsafeFreeze arr
 
     statistics :: String -> FreshAndReuse -> TCM ()

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -41,12 +41,13 @@ import Control.Monad.Reader
 
 import Data.Proxy
 import Data.Hashable
-import Data.Word (Word32)
+import Data.Word (Word32, Word64)
 import Data.Maybe
 import qualified Data.Text      as T
 import qualified Data.Text.Lazy as TL
 import Data.Typeable (Typeable, TypeRep, typeRep, typeRepFingerprint)
 import GHC.Exts
+import GHC.Float (castDoubleToWord64)
 import GHC.Fingerprint.Type
 import GHC.Generics (Generic)
 import Unsafe.Coerce
@@ -180,7 +181,13 @@ data Dict = Dict
   , sTextD       :: !(HashTableLU T.Text  Word32)    -- ^ Written to interface file.
   , integerD     :: !(HashTableLU Integer Word32)    -- ^ Written to interface file.
   , varSetD      :: !(HashTableLU VarSet Word32)    -- ^ Written to interface file.
-  , doubleD      :: !(HashTableLU Double  Word32)    -- ^ Written to interface file.
+    -- Andreas, 2026-08-29, issue #8697:
+    -- The 'Double' dictionary is keyed by the /bit pattern/ of the 'Double',
+    -- because the 'Eq Double' instance identifies @0.0@ and @-0.0@, which
+    -- would make hash-consing conflate these two distinct literals.
+    -- (This is the inconsistency of issue #2169, which is why 'Eq Literal'
+    -- compares 'Double's bitwise.)
+  , doubleD      :: !(HashTableLU Word64  Word32)    -- ^ Written to interface file (as 'Double's).
   -- Dicitionaries which are not serialized, but provide
   -- short cuts to speed up serialization:
   -- Andreas, Makoto, AIM XXI
@@ -376,7 +383,8 @@ icodeDouble key = do
   d <- asks doubleD
   c <- asks doubleC
   liftIO $
-    H.insertingIfAbsent d key
+    -- Key on the bit pattern, not on the 'Double' itself, see 'doubleD'.
+    H.insertingIfAbsent d (castDoubleToWord64 key)
       (\i -> do
 #ifdef DEBUG_SERIALISATION
         bumpReuse c

--- a/test/Succeed/Issue8697.agda
+++ b/test/Succeed/Issue8697.agda
@@ -1,0 +1,36 @@
+-- Andreas, 2026-08-29, issue #8697
+-- The serializer hash-consed the Doubles of an interface (Float literals
+-- and fixity levels) in a dictionary keyed by Double with Haskell's Eq,
+-- under which 0.0 == -0.0.  Thus, only the zero encountered first was
+-- stored and the other one was read back with the opposite sign.
+-- Yet the conflation of positive and negative zero leads to inconsistency
+-- (issue #2169).
+
+{-# OPTIONS --safe #-}
+
+module Issue8697 where
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Float
+
+open import Issue8697.Zeros
+
+-- The signs of the zeros have to survive the round trip through the interface.
+
+pos-is-positive : primFloatIsNegativeZero +zero ≡ false
+pos-is-positive = refl
+
+neg-is-negative : primFloatIsNegativeZero -zero ≡ true
+neg-is-negative = refl  -- This failed in Agda < 2.9.
+
+-- The other special values also have to survive.
+
+nan-is-nan : primFloatIsNaN nan ≡ true
+nan-is-nan = refl
+
+inf-is-infinite : primFloatIsInfinite inf ≡ true
+inf-is-infinite = refl
+
+infinities-differ : primFloatLess -inf inf ≡ true
+infinities-differ = refl

--- a/test/Succeed/Issue8697/Zeros.agda
+++ b/test/Succeed/Issue8697/Zeros.agda
@@ -1,0 +1,29 @@
+-- Andreas, 2026-08-29, issue #8697
+-- Auxiliary module: exports both zeros through its interface.
+
+{-# OPTIONS --safe #-}
+
+module Issue8697.Zeros where
+
+open import Agda.Builtin.Float
+
+-- A fixity level is also a Double in the interface,
+-- and fixities are serialized before the definitions.
+infix 0 _!
+_! : Float → Float
+x ! = x
+
++zero : Float
++zero = 0.0
+
+-zero : Float
+-zero = -0.0
+
+nan : Float
+nan = primFloatDiv 0.0 0.0
+
+inf : Float
+inf = primFloatDiv 1.0 0.0
+
+-inf : Float
+-inf = primFloatDiv -1.0 0.0


### PR DESCRIPTION
`Eq Double` conflates the negative and positive zero, which can be exploited for inconsistency (#2169).
Thus we `castDoubleToWord64` in the memoization map of the serializer to get raw bit-equality which keeps the zeros separate.

Closes #8697.

AI disclosure: I offloaded this (boring) issue to Claude and just polished the result a bit.
