### PR TITLE
Fix #8696 by eta-expanding data/recClauses before positivity checking

### DIFF
--- a/src/full/Agda/TypeChecking/Positivity/OccurrenceAnalysis.hs
+++ b/src/full/Agda/TypeChecking/Positivity/OccurrenceAnalysis.hs
@@ -723,7 +723,13 @@ computeDefOccurrences q clauses = inConcreteOrAbstractMode q \def -> do
                                go (i + 1) ps
           go 0 (namedClausePats cl)
 
-    Datatype{dataClause = Just c} -> ret $ occurrences =<< lift (instantiateFull c)
+    -- Andreas, 2026-08-29, issue #8696:
+    -- A data or record type created by a module application (a /copy/) is
+    -- defined by the pattern-less clause  @N.D = M.D args@.  As for function
+    -- clauses (see 'preprocessMutuals') we have to eta-expand it, otherwise
+    -- the analysis sees no occurrence of the parameters and indices of @N.D@
+    -- and wrongly concludes that they are all 'Unused'.
+    Datatype{dataClause = Just c} -> ret $ occurrences =<< lift (etaExpandCopyClause c)
 
     Datatype{dataPars = np0, dataCons = cs, dataTranspIx = trx} -> ret do
       -- Andreas, 2013-02-27 (later edited by someone else): First,
@@ -801,8 +807,9 @@ computeDefOccurrences q clauses = inConcreteOrAbstractMode q \def -> do
               DontCare{} -> __IMPOSSIBLE__  -- not a type
               Dummy{}    -> __IMPOSSIBLE__
 
+    -- See the 'Datatype' case above for why we eta-expand.
     Record{recClause = Just c} -> ret do
-      occurrences =<< lift (instantiateFull c)
+      occurrences =<< lift (etaExpandCopyClause c)
 
     Record{recPars = np, recTel = tel} -> ret do
       let (tel0, tel1) = splitTelescopeAt np tel
@@ -819,6 +826,12 @@ computeDefOccurrences q clauses = inConcreteOrAbstractMode q \def -> do
     PrimitiveSort{}    -> ret mempty
     GeneralizableVar{} -> ret mempty
     AbstractDefn{}     -> ret __IMPOSSIBLE__
+
+-- | Prepare the defining clause of a data or record type copy (issue #8696)
+--   for occurrence analysis by eta-expanding it, so that the parameters and
+--   indices of the copy appear as pattern variables in the clause.
+etaExpandCopyClause :: Clause -> TCM Clause
+etaExpandCopyClause c = snd <$> (etaExpandClause =<< instantiateFull c)
 
 -- | Pre-pass that eta-expands function clauses and records the "formal arity" of the function in
 --   the signature. Any argument beyond this arity is considered to have 'Mixed' polarity.

--- a/test/Fail/Issue8696-interleaved.agda
+++ b/test/Fail/Issue8696-interleaved.agda
@@ -1,0 +1,44 @@
+-- Andreas, 2026-08-29, issue #8696
+-- Issue found by Claude and reported by bdrisc-ant
+-- This is the original reproducer "A".
+
+-- A module application creates, for each data or record type of the applied
+-- module, a copy that is defined by the pattern-less clause  N.F = M.F ⊥.
+-- If the application happens while a mutual block is open, the copy is a
+-- member of that block and its argument occurrences are recomputed.  Since
+-- the copy's clause has no patterns for the parameters of N.F, the analysis
+-- used to find no occurrence of them and overwrite the (correct) inherited
+-- occurrences by Unused.  A later data type could then be negative through the
+-- copy without the positivity checker noticing.
+
+{-# OPTIONS --safe --without-K #-}
+
+data ⊥ : Set where
+
+module M (A : Set) where
+
+  -- X occurs both positively and negatively in F: its occurrence is Mixed.
+  data F (X : Set) : Set where
+    neg : (X → A) → F X
+    pos : X → F X
+
+-- The module application lands inside Dummy's mutual block
+-- (here: between an interleaved signature and its definition).
+data Dummy : Set
+module N = M ⊥
+data Dummy where
+  mkD : Dummy
+
+-- A later block: G wraps the copy, Bad is negative through it.
+G : Set → Set
+data Bad : Set
+G X = N.F X
+data Bad where
+  bad : G Bad → Bad
+
+¬Bad : Bad → ⊥
+¬Bad (bad (N.neg f)) = f (bad (N.neg f))
+¬Bad (bad (N.pos b)) = ¬Bad b
+
+boom : ⊥
+boom = ¬Bad (bad (N.neg ¬Bad))

--- a/test/Fail/Issue8696-interleaved.err
+++ b/test/Fail/Issue8696-interleaved.err
@@ -1,0 +1,10 @@
+Issue8696-interleaved.agda:33.1-37.20: error: [NotStrictlyPositive]
+Bad is not strictly positive, because it occurs
+in the first argument of G
+(in the type of the constructor bad
+ in the definition of Bad), which occurs
+                          in the first argument of N.F
+                          in the first clause
+                          in the definition of G, which occurs
+                                                in the type of the constructor bad
+                                                in the definition of Bad.

--- a/test/Fail/Issue8696-lossy.agda
+++ b/test/Fail/Issue8696-lossy.agda
@@ -1,0 +1,34 @@
+-- Andreas, 2026-08-29, issue #8696
+-- Issue found by Claude and reported by bdrisc-ant
+
+-- The same overwritten occurrence observed through polarity: the index of the
+-- copied N.IsZ became Nonvariant, and --lossy-unification's first-order
+-- shortcut then identified  N.IsZ 0  and  N.IsZ 1.
+
+{-# OPTIONS --safe --without-K --lossy-unification #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+data ⊥ : Set where
+
+module M (A : Set) where
+  data IsZ : Nat → Set where
+    isz : IsZ zero
+
+mutual
+  data Dummy : Set where
+    mkD : Dummy
+  module N = M ⊥
+
+cast : N.IsZ 0 ≡ N.IsZ 1
+cast = refl
+
+coe : {A B : Set} → A ≡ B → A → B
+coe refl x = x
+
+no : N.IsZ 1 → ⊥
+no ()
+
+boom : ⊥
+boom = no (coe cast N.isz)

--- a/test/Fail/Issue8696-lossy.err
+++ b/test/Fail/Issue8696-lossy.err
@@ -1,0 +1,7 @@
+Issue8696-lossy.agda:25.8-12: error: [UnequalTerms]
+The terms
+  0
+and
+  1
+are not equal at type Nat
+when checking that the expression refl has type N.IsZ 0 ≡ N.IsZ 1

--- a/test/Fail/Issue8696-record.agda
+++ b/test/Fail/Issue8696-record.agda
@@ -1,0 +1,33 @@
+-- Andreas, 2026-08-29, issue #8696
+-- Issue found by Claude and reported by bdrisc-ant
+
+-- Same as Issue8696.agda, but the copied type is a record rather than a data
+-- type, exercising the recClause branch of the occurrence analysis.
+
+{-# OPTIONS --safe --without-K #-}
+
+data ⊥ : Set where
+
+module M (A : Set) where
+  record Neg (X : Set) : Set where
+    constructor mk
+    field un : X → A
+
+mutual
+  module N = M ⊥
+
+  G : Set → Set
+  G = N.Neg
+
+  -- This negative data type should be rejected.
+  data D : Set where
+    lam : G D → D
+
+app : D → D → ⊥
+app (lam f) d = N.Neg.un f d
+
+delta : D
+delta = lam (N.mk λ d → app d d)
+
+Omega : ⊥
+Omega = app delta delta

--- a/test/Fail/Issue8696-record.err
+++ b/test/Fail/Issue8696-record.err
@@ -1,0 +1,16 @@
+Issue8696-record.agda:16.1-24.18: error: [NotStrictlyPositive]
+D is not strictly positive, because it occurs
+in the first argument of G
+(in the type of the constructor lam
+ in the definition of D), which occurs
+                        in the first argument of N.Neg
+                        (in the first clause
+                         in the definition of G), which occurs
+                                                in the second argument of M.Neg
+                                                in the definition of N.Neg, which occurs
+                                                                          in the first clause
+                                                                          in the definition of
+                                                                          G, which occurs
+                                                                           in the type of the
+                                                                           constructor lam
+                                                                           in the definition of D.

--- a/test/Fail/Issue8696-where.agda
+++ b/test/Fail/Issue8696-where.agda
@@ -1,0 +1,35 @@
+-- Andreas, 2026-08-29, issue #8696
+-- Issue found by Claude and reported by bdrisc-ant
+
+-- This variant of Issue8689 places the module application in a where block
+-- with the same effect as in a mutual block.
+-- The copy F made in f's where block used to lose the occurrence of its parameter,
+-- hence f's own second argument was judged unused (Nonvariant),
+-- which could be exploited by getting a cast of ⊤ to ⊥.
+
+{-# OPTIONS --safe --without-K #-}
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Unit
+
+data ⊥ : Set where
+
+module M (A : Set) where
+  data F (X : Set) : Set where
+    mk : X → (X → A) → F X
+
+f : Bool → Set → Set
+f true  X = F X
+  module W where
+  open M ⊤ public
+f false X = ⊥
+
+-- This cast function should be rejected.
+cast : (b : Bool) (X Y : Set) → f b X → f b Y
+cast b X Y v = v
+
+get : W.F ⊤ ⊥ → ⊥
+get (W.mk b _) = b
+
+boom : ⊥
+boom = get (cast true ⊤ ⊥ (W.mk {⊤} tt (λ _ → tt)))

--- a/test/Fail/Issue8696-where.err
+++ b/test/Fail/Issue8696-where.err
@@ -1,0 +1,7 @@
+Issue8696-where.agda:29.16-17: error: [UnequalTerms]
+The terms
+  X
+and
+  Y
+are not equal at type Set
+when checking that the expression v has type f b Y

--- a/test/Fail/Issue8696.agda
+++ b/test/Fail/Issue8696.agda
@@ -1,0 +1,39 @@
+-- Andreas, 2026-08-29, issue #8696
+-- Issue found by Claude and reported by bdrisc-ant
+
+-- A data or record type copied by a module application inside an open mutual
+-- block had its argument occurrences recomputed from the pattern-less clause
+-- N.F = M.F ⊥, which made them all Unused, so a negative occurrence through
+-- the copy went unnoticed.
+
+{-# OPTIONS --safe --without-K #-}
+
+data ⊥ : Set where
+
+module M (A : Set) where
+  data Neg (X : Set) : Set where
+    neg : (X → A) → Neg X
+
+mutual
+  module N = M ⊥
+
+  G : Set → Set
+  G = N.Neg
+
+  -- This negative data type should be rejected.
+  data D : Set where
+    lam : G D → D
+
+-- The rest as usual:
+-- we have a representation of untyped lambda calculus which is inconsistent through self-application.
+
+pattern abs f = lam (N.neg f)
+
+app : D → D → ⊥
+app (abs f) = f
+
+delta : D
+delta = abs λ d → app d d
+
+Omega : ⊥
+Omega = app delta delta

--- a/test/Fail/Issue8696.err
+++ b/test/Fail/Issue8696.err
@@ -1,0 +1,16 @@
+Issue8696.agda:17.1-25.18: error: [NotStrictlyPositive]
+D is not strictly positive, because it occurs
+in the first argument of G
+(in the type of the constructor lam
+ in the definition of D), which occurs
+                        in the first argument of N.Neg
+                        (in the first clause
+                         in the definition of G), which occurs
+                                                in the second argument of M.Neg
+                                                in the definition of N.Neg, which occurs
+                                                                          in the first clause
+                                                                          in the definition of
+                                                                          G, which occurs
+                                                                           in the type of the
+                                                                           constructor lam
+                                                                           in the definition of D.


### PR DESCRIPTION
The lack of eta-expansion in positivity checking lead to classification of parameters of data or record types copied by the module system as `Unused` (`NonVariant`).

This commit inserts the missing eta-expansions.

AI disclosure: issue fixed by Claude, I refined some comments and test cases.
