### PR TITLE
Fix #8336 by restoring inferSpine to iteratively construct the self value

### DIFF
--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -35,6 +35,7 @@ import Agda.Utils.Function (applyWhen, applyWhenM)
 import Agda.Utils.Functor (($>))
 import Agda.Utils.Maybe
 import Agda.Utils.Size
+import Agda.Utils.Tuple (snd3, thd3)
 
 import Agda.Utils.Impossible
 
@@ -269,14 +270,14 @@ infer u = do
   case u of
     Var i es -> do
       a <- typeOfBV i
-      fst <$> inferSpine defaultAction a (Var i) es
+      snd3 <$> inferSpine defaultAction a (Var i) es
     Def f es -> do
       whenJustM (isRelevantProjection f) $ \_ -> nonInferable
       a <- defType <$> getConstInfo f
-      fst <$> inferSpine defaultAction a (Def f) es
+      snd3 <$> inferSpine defaultAction a (Def f) es
     MetaV x es -> do -- we assume meta instantiations to be well-typed
       a <- metaType x
-      fst <$> inferSpine defaultAction a (MetaV x) es
+      snd3 <$> inferSpine defaultAction a (MetaV x) es
     _ -> nonInferable
   where
     nonInferable :: MonadDebug m => m a
@@ -286,18 +287,27 @@ infer u = do
       ]
 
 instance CheckInternal Elims where
-  checkInternal' action es cmp (t , hd) = snd <$> inferSpine action t hd es
+  checkInternal' action es cmp (t , hd) = thd3 <$> inferSpine action t hd es
 
 -- | @inferSpine action t hd es@ checks that spine @es@ eliminates
---   value @hd []@ of type @t@ and returns the remaining type
---   (target of elimination) and the transformed eliminations.
-inferSpine :: Action -> Type -> (Elims -> Term) -> Elims -> TCM (Type, Elims)
-inferSpine action t hd es = loop t hd id es
+--   value @hd []@ of type @t@ and returns the eliminated value
+--   @hd []@ applied to @es@, the remaining type (target of elimination)
+--   and the transformed eliminations.
+--
+--   Andreas, 2026-09-01, issue #8336:
+--   Note the difference between the returned value and @hd es@:
+--   @hd@ blindly builds postfix applications @self .f@ also for
+--   projection-/like/ functions @f@, which is only valid syntax as long as
+--   @self@ is neutral.
+--   Just using @hd es@ as the returned value leads to crashes in the reducer.
+--   Thus we construct the returned value instead with 'shouldBeProjectible',
+--   which puts projection-like functions into prefix form @f self@.
+inferSpine :: Action -> Type -> (Elims -> Term) -> Elims -> TCM (Term, Type, Elims)
+inferSpine action t hd es = loop (hd []) t hd id es
   where
-  loop t hd acc = \case
-    [] -> return (t , acc [])
+  loop self t hd acc = \case
+    [] -> return (self , t , acc [])
     (e : es) -> do
-      let self = hd []
       reportSDoc "tc.check.internal" 30 $ sep
         [ "inferring spine: "
         , "type t = " <+> prettyTCM t
@@ -313,17 +323,17 @@ inferSpine action t hd es = loop t hd id es
           x' <- checkInternal' action x CmpLeq (b `absApp` izero)
           y' <- checkInternal' action y CmpLeq (b `absApp` ione)
           let e' = IApply x' y' r'
-          loop (b `absApp` r) (hd . (e:)) (acc . (e':)) es
+          loop (self `applyE` [e]) (b `absApp` r) (hd . (e:)) (acc . (e':)) es
         Apply (Arg ai v) -> do
           (a, b) <- shouldBePi t
           ai <- checkArgInfo action ai $ domInfo a
           v' <- applyDomToContext a $ checkInternal' action v CmpLeq $ unDom a
           let e' = Apply (Arg ai v')
-          loop (b `absApp` v) (hd . (e:)) (acc . (e':)) es
+          loop (self `applyE` [e]) (b `absApp` v) (hd . (e:)) (acc . (e':)) es
         -- case: projection or projection-like
         Proj o f -> do
-          t' <- shouldBeProjectible self t o f
-          loop t' (hd . (e:)) (acc . (e:)) es
+          (self', t') <- shouldBeProjectible self t o f
+          loop self' t' (hd . (e:)) (acc . (e:)) es
 
 checkSpine ::
      Action
@@ -340,14 +350,14 @@ checkSpine action a hd es cmp t = do
                                  , nest 2 $ prettyTCM a ])
                    , nest 4 $ prettyTCM es <+> ":"
                    , nest 2 $ prettyTCM t ] ]
-  (t' , es') <- inferSpine action a hd es
+  (self , t' , es') <- inferSpine action a hd es
   reportSDoc "tc.check.internal" 30 $ sep
     [ "checking if "
     , prettyTCM t'
     , "is a subtype of"
     , prettyTCM t
     ]
-  coerceSize cmp (hd es) t' t
+  coerceSize cmp self t' t
   return $ hd es'
 
 instance CheckInternal Sort where

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -360,18 +360,23 @@ getDefType f t = do
         _       -> Nothing
 
 -- | Apply a projection to an expression with a known type, returning
---   the type of the projected value.
+--   the projected value and its type.
 --   The given type should either be a record type or a type eligible for
 --   the principal argument of a projection-like function.
+--
+--   The projected value is constructed by 'applyDef', so a projection-/like/
+--   function is applied in prefix form (@f v@); only a proper projection
+--   gives rise to a postfix 'Proj' elimination (@v .f@).
+--   (See e.g. issue #8336 why this invariant is important.)
 shouldBeProjectible :: (PureTCM m, MonadTCError m, MonadBlock m)
-                    => Term -> Type -> ProjOrigin -> QName -> m Type
+                    => Term -> Type -> ProjOrigin -> QName -> m (Term, Type)
 -- shouldBeProjectible t f = maybe failure return =<< projectionType t f
 shouldBeProjectible v t o f = do
   t <- abortIfBlocked t
   projectTyped v t o f >>= \case
-    Just (_ , _ , ft) -> return ft
+    Just (_ , u , ft) -> return (u, ft)
     Nothing -> case t of
-      El _ Dummy{} -> return __DUMMY_TYPE__
+      El _ Dummy{} -> return (__DUMMY_TERM__, __DUMMY_TYPE__)
       _ -> typeError $ ShouldBeRecordType t
     -- TODO: more accurate error that makes sense also for proj.-like funs.
 

--- a/test/Succeed/Issue8336.agda
+++ b/test/Succeed/Issue8336.agda
@@ -1,0 +1,51 @@
+-- Andreas, 2026-09-01, issue #8336, reported by onestruggler,
+-- reproducer by ben-dickinson01 (using AI for shrinking).
+--
+-- Regression in 2.6.4, introduced by d6e5c5f7a2 which refactored
+-- 'Agda.TypeChecking.CheckInternal.inferSpine': the eliminated value
+-- threaded through the spine was no longer built by 'applyDef', so
+-- projection-like functions were kept in postfix form when instantiating
+-- the types computed along the spine.
+-- Such ill-formed terms lead to a crash in the fast reducer
+-- that does not expect Proj eliminations that are not proper projections.
+--
+-- The options that trigger the issues are
+-- (we give them explicitly even though they are on by default):
+
+{-# OPTIONS --double-check #-}     -- on by default in the testsuite
+{-# OPTIONS --projection-like #-}  -- on by default
+
+module Issue8336 where
+
+data _≡_ {A : Set} (x : A) : A → Set where
+  refl : x ≡ x
+
+concat : {A : Set} → {x y z : A} → x ≡ y → y ≡ z → x ≡ z
+concat refl refl = refl
+
+data Σ (A : Set) (B : A → Set) : Set where
+  _,_ : (x : A) → B x → Σ A B
+
+-- proj₁ and proj₂ are projection-_like_ functions on a _data_ type.
+
+proj₁ : {A : Set} → {B : A → Set} → Σ A B → A
+proj₁ (x , y) = x
+
+proj₂ : {A : Set} → {B : A → Set} → (z : Σ A B) → B (proj₁ z)
+proj₂ (x , y) = y
+
+_×_ : Set → Set → Set
+A × B = Σ A (λ _ → B)
+
+S : Set → Set
+S A = Σ (A → A) (λ f → (x : A) → f x ≡ x)
+
+p : {X : Set} → (u : X → X) → ((x : X) → u x ≡ x) → (S X → S X) × (S X → S X)
+p u hu = (λ z → (λ x → u (proj₁ z x)) , (λ x → concat (hu (proj₁ z x)) (proj₂ z x))) , (λ z → z)
+
+goal : {X : Set} → (u : X → X) → (hu : (x : X) → u x ≡ x) → (s : S X) → (x : X)
+  → proj₂ (proj₁ (p u hu) s) x ≡ proj₂ (proj₁ (p u hu) s) x
+goal u hu s x = concat refl refl
+
+-- WAS: internal error in Agda.TypeChecking.Reduce.Fast (conApp)
+-- Should succeed.

--- a/test/Succeed/Issue8336NoFastReduce.agda
+++ b/test/Succeed/Issue8336NoFastReduce.agda
@@ -1,0 +1,52 @@
+-- Andreas, 2026-09-01, issue #8336, reported by onestruggler,
+-- reproducer by ben-dickinson01 (using AI for shrinking).
+--
+-- Regression in 2.6.4, introduced by d6e5c5f7a2 which refactored
+-- 'Agda.TypeChecking.CheckInternal.inferSpine': the eliminated value
+-- threaded through the spine was no longer built by 'applyDef', so
+-- projection-like functions were kept in postfix form when instantiating
+-- the types computed along the spine.
+-- Such ill-formed terms lead to a crash in the reducer (`conApp`)
+-- that does not expect Proj eliminations that are not proper projections.
+--
+-- The options that trigger the issues are
+-- (we give them explicitly even though they are on by default):
+
+{-# OPTIONS --double-check #-}     -- on by default in the testsuite
+{-# OPTIONS --projection-like #-}  -- on by default
+{-# OPTIONS --no-fast-reduce #-}   -- different location of crash
+
+module Issue8336NoFastReduce where
+
+data _≡_ {A : Set} (x : A) : A → Set where
+  refl : x ≡ x
+
+concat : {A : Set} → {x y z : A} → x ≡ y → y ≡ z → x ≡ z
+concat refl refl = refl
+
+data Σ (A : Set) (B : A → Set) : Set where
+  _,_ : (x : A) → B x → Σ A B
+
+-- proj₁ and proj₂ are projection-_like_ functions on a _data_ type.
+
+proj₁ : {A : Set} → {B : A → Set} → Σ A B → A
+proj₁ (x , y) = x
+
+proj₂ : {A : Set} → {B : A → Set} → (z : Σ A B) → B (proj₁ z)
+proj₂ (x , y) = y
+
+_×_ : Set → Set → Set
+A × B = Σ A (λ _ → B)
+
+S : Set → Set
+S A = Σ (A → A) (λ f → (x : A) → f x ≡ x)
+
+p : {X : Set} → (u : X → X) → ((x : X) → u x ≡ x) → (S X → S X) × (S X → S X)
+p u hu = (λ z → (λ x → u (proj₁ z x)) , (λ x → concat (hu (proj₁ z x)) (proj₂ z x))) , (λ z → z)
+
+goal : {X : Set} → (u : X → X) → (hu : (x : X) → u x ≡ x) → (s : S X) → (x : X)
+  → proj₂ (proj₁ (p u hu) s) x ≡ proj₂ (proj₁ (p u hu) s) x
+goal u hu s x = concat refl refl
+
+-- WAS: internal error in Agda.TypeChecking.Substitute (conApp)
+-- Should succeed.


### PR DESCRIPTION
The refactoring d6e5c5f7a2c4f02895ff7c9290254712d4ae4030 of the internal checker changed `inferSpine` so that it produces an ill-formed value of the spine: terms containing `Proj` eliminations containing projection-like functions.  Such terms should only exist temporarily for the sake of type inference and cannot be handled in the reducer (in particular, in `conApp` and the fast reducer).

This commit restores the sound construction of the value of the spine.

Fix by Claude when given the commit that introduced the regression.
(A prior fix attempt by Claude would make the reducer more robust so
it could handle such ill-formed terms, but that would not address the
problem at the root.)

Closes #8336.

<details>
<summary>Transcript (abbreviated) of AI interaction</summary>

Please investigate issue #8336 and come up with a fix if possible.
It seems that `give` produces ill-formed terms here.
The issue does not surface if one directly replaces the goal with a term in the file.

Answer 1
========

Diagnosis
---------

`give` is not producing ill-formed terms — the culprit is the **double check** that `giveExpr` runs (`checkInternal vfull CmpLeq t'`). Both crashes reproduce non-interactively with just `--double-check` on a file where the hole is already filled in:
...

That also explains "the issue does not surface if one replaces the goal by a term directly": plain checking doesn't double-check.

The mechanism:

1. `proj₁`/`proj₂` are **projection-like functions on a *data* type** (`Σ` is `data`, not `record`).
2. `checkInternal` runs `elimView`, which rewrites prefix applications of projection-like functions into postfix `Proj` elims. Its `reduceProjectionLike` prelude only unfolds projections, so `p u hu` stays stuck and we get
   `Def p [Apply u, Apply hu, Proj proj₁, Apply s, Proj proj₁, Apply x]`.
3. `checkSpine` ends with `coerceSize`/`compareType`, which **reduces** that term. `p` unfolds to `Con _,_ [...]`, and now `applyE` applies `Proj proj₁` to a data constructor.
4. `conApp` looks `proj₁` up in `conFields` — for a data constructor those are the generated `_,_-0`, `_,_-1` names, so the lookup fails → `__IMPOSSIBLE__`. The fast evaluator's `doProj` fails the same way.

So a legitimate internal term was hitting a reduction path that only knew about real fields, never about projection-*like* functions.

Fix
---

- `src/full/Agda/TypeChecking/Substitute.hs` (`conApp`): when `f` is not among the constructor's fields, it must be a projection-like function. Rather than crashing, undo the postfix representation and return `f (c args) es`, which `reduce` unfolds by clause matching. Care needed: `go` drops the `Apply` elims preceding the `Proj`, so the constructor has to be rebuilt as `args ++ takeWhile (not . isProj) topEs` — my first attempt omitted this and silently produced wrong terms (`proj₁ (λ y → s) x`), which the fast-reduce test caught.
- `src/full/Agda/TypeChecking/Reduce/Fast.hs` (`doProj`): when the fields run out, `fallbackEval` the state to the slow machinery, which goes through the fixed `conApp`.

The `__IMPOSSIBLE__`s are kept for the genuinely impossible cases (`Proj` inside `Con` args, under-applied constructor whose field elim is missing).
...

Prompt 2
========

Bisection revealed that the issue is a regression released with Agda 2.6.4, first appearing with commit d6e5c5f7a2c4f02895ff7c9290254712d4ae4030.

Please analyse how this commit introduced the issue and develop a fix local to CheckInternal so that your previous fix is no longer needed.

Answer 2
========

How d6e5c5f7a2 introduced the bug
---------------------------------

The commit refactored `inferSpine` in `CheckInternal.hs`. The old version threaded the eliminated value explicitly and built it with `applyDef`:

```haskell
inferSpine' action t self self' (e : es) = case e of
    ...
    Proj o f -> do
      (a, b) <- shouldBePi =<< shouldBeProjectible t f
      u  <- applyDef o f (argFromDom a $> self)   -- <-- proper application
      u' <- applyDef o f (argFromDom a $> self')
      inferSpine' action (b `absApp` self) u u' es
```

`applyDef` is the function that decides the *representation*: only a **proper** projection becomes a postfix `Proj` elim; a projection-**like** function stays in prefix form `Def f [Apply self]`.

The refactor replaced the threaded `self` by a head-builder `hd` that just accumulates elims, and dropped the `applyDef` result:

```haskell
        Proj o f -> do
          (a, b) <- shouldBePi =<< shouldBeProjectible t f
          u <- applyDef o f (argFromDom a $> self)     -- bound but never used
          loop (b `absApp` self) (hd . (e:)) (acc . (e:)) es
```

(today: `t' <- shouldBeProjectible self t o f; loop t' (hd . (e:)) ...`).

So from 2.6.4 on, `self = hd []` is *always* the postfix form `... [Proj o f]`, even for projection-like functions, and that `self` is what `projectTyped` substitutes into the result type (`b absApp v`). For the reproducer this yields the type

```
Def p [Apply u, Apply hu, Proj proj₁, Apply s, Proj proj₁, Apply x]
```

`p` is an ordinary function, so it reduces to the pair constructor while `Proj proj₁` is still attached — and `proj₁` is not among the data constructor's (generated) fields, so `conApp` / the fast machine's `doProj` hit `__IMPOSSIBLE__`. The crash surfaces at `coerceSize`/`compareType` in `checkSpine`, which reduces that type.

`Sort.sortOfE`, `Rewriting.Confluence` and `NonLinMatch` all still use the `applyDef` idiom, so `CheckInternal` was the odd one out.

The fix
-------

`src/full/Agda/TypeChecking/CheckInternal.hs` — restore the threaded, properly-built `self`:

- `inferSpine` now carries `self` alongside `hd`, advancing it with `applyE` for `Apply`/`IApply` and with the projected term for `Proj`; it returns `(Term, Type, Elims)`.
- `checkSpine` passes that `self` to `coerceSize` instead of `hd es`.
- `infer` and the `CheckInternal Elims` instance use `snd3`/`thd3`.

`src/full/Agda/TypeChecking/Records.hs` — `shouldBeProjectible` now returns `(Term, Type)` instead of just the type, i.e. it also hands back the `applyDef`-built term that `projectTyped` already computes. Its only call site is `CheckInternal`; this avoids duplicating `projectTyped` plus its error handling in `CheckInternal` just to recover the domain's `ArgInfo`.

`hd es'` (the term `checkSpine` returns) is deliberately left alone — that is the `elimView`'d shape `checkInternal'` has produced since long before the regression, and changing it would alter what `ReconstructParameters`/`Abstract` see.

`Substitute.hs` and `Reduce/Fast.hs` are untouched — the earlier `conApp` fallback is no longer needed.

</details>
