### PR TITLE
Fix #8698 named `where` modules: check if parameter refinement changed a type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -520,6 +520,32 @@ Changes to type checker and other components defining the Agda language.
   fields for any cohesion modality which has a left adjoint (currently
   just sharp and continuous).
 
+* (**BREAKING**) Named `where`-modules are now rejected in `with`-clauses
+  in which `with`-abstraction has changed the type of a module parameter,
+  with the new error `NamedWhereModuleInRetypedContext`.
+  This is a soundness fix; accepting these allowed a proof of absurdity
+  (see [#8698](https://github.com/agda/agda/issues/8698)).
+  Example:
+  ```agda
+  F : Bool → Set
+  F true  = ⊥
+  F false = ⊤
+
+  module M (b : Bool) (p : F (not b)) where
+
+    foo : Bool
+    foo with not b
+    ... | true  = true
+    ... | false = false
+      module W where       -- rejected: here p : F false rather than F (not b)
+      val : F (not b)
+      val = p
+  ```
+  Anonymous `where`-blocks are not affected.
+  (This complements the existing restriction on named `where`-modules in
+  contexts refined by pattern matching, see
+  [#2897](https://github.com/agda/agda/issues/2897).)
+
 Reflection
 ----------
 

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -210,6 +210,7 @@ data ErrorName
   | ExplicitPolarityVsPragma_
   | ConstructorNameOfNonRecord_
   | NamedWhereModuleInRefinedContext_
+  | NamedWhereModuleInRetypedContext_
   | NeedOptionAllowExec_
   | NeedOptionCopatterns_
   | NeedOptionCubical_

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1588,6 +1588,20 @@ instance PrettyTCM TypeError where
         , nest 2 $ vcat $ zipWith pr names args
         ]
 
+    NamedWhereModuleInRetypedContext ps -> do
+      let pr (x, actual, expected) = vcat
+            [ text x <+> ":" <+> prettyTCM actual
+            , nest 2 $ "instead of" <+> prettyTCM expected
+            ]
+      vcat
+        [ fsep $ pwords "Named where-modules are not allowed when with-abstraction has changed the type of a module parameter."
+        , "(See" <+> (githubIssue 8698 <> ".)")
+        , text $ "In this case the module parameter" ++
+                  (if length ps > 1 then "s have" else " has") ++
+                  " been given the type"
+        , nest 2 $ vcat $ fmap pr ps
+        ]
+
     CannotGenerateHCompClause ty -> fsep $ concat
         [ pwords "Cannot generate hcomp clause at type"
         , [ prettyTCM ty ]

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -167,6 +167,7 @@ typeErrorName = \case
   MultiplePolarityPragmas                                    {} -> MultiplePolarityPragmas_
   ExplicitPolarityVsPragma                                   {} -> ExplicitPolarityVsPragma_
   NamedWhereModuleInRefinedContext                           {} -> NamedWhereModuleInRefinedContext_
+  NamedWhereModuleInRetypedContext                           {} -> NamedWhereModuleInRetypedContext_
   NeedOptionAllowExec                                        {} -> NeedOptionAllowExec_
   NeedOptionCopatterns                                       {} -> NeedOptionCopatterns_
   NeedOptionCubical                                          {} -> NeedOptionCubical_

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5861,6 +5861,11 @@ data TypeError
         | NamedWhereModuleInRefinedContext [Term] [String]
             -- ^ The lists should have the same length.
             --   TODO: enforce this by construction.
+        | NamedWhereModuleInRetypedContext (List1 (ArgName, Type, Type))
+            -- ^ Module parameters whose type has been changed by
+            --   with-abstraction: name, type in the current context,
+            --   and type according to the module telescope.
+            --   See issue #8698.
         | ComatchingDisabledForRecord QName
     -- Rewriting errors
         | IlltypedRewriteRule Doc

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -1303,11 +1303,24 @@ checkWhere wh@(A.WhereDecls whmod whNamed mds) ret = do
     -- #2897: We can't handle named where-modules in refined contexts.
     ensureNoNamedWhereInRefinedContext Nothing = return ()
     ensureNoNamedWhereInRefinedContext (Just m) = traceCall (CheckNamedWhere m) $ do
-      args <- map' unArg <$> (moduleParamsToApply =<< currentModule)
-      unless (isWeakening args) $ do -- weakened contexts are fine
-        names <- map' (argNameToString . fst . unDom) . telToList <$>
-                (lookupSection =<< currentModule)
-        typeError $ NamedWhereModuleInRefinedContext args names
+      m0   <- currentModule
+      args <- moduleParamsToApply m0
+      tel  <- lookupSection m0
+      unless (isWeakening $ map' unArg args) $ do -- weakened contexts are fine
+        let names = map' (argNameToString . fst . unDom) $ telToList tel
+        typeError $ NamedWhereModuleInRefinedContext (map' unArg args) names
+      -- Andreas, 2026-09-01, issue #8698:
+      -- Even when the module parameters are still just the context variables,
+      -- with-abstraction may have changed their *types*:
+      -- a parameter that is not needed to type the with-expressions ends up in
+      -- the part @Δ₂@ of the clause telescope where the with-expressions are
+      -- abstracted from the types (see 'splitTelForWith').
+      -- The named where-module would then get a telescope that lies about the
+      -- module parameters, while its definitions are still applied to the
+      -- module parameters by position without type checking
+      -- (see 'freeVarsToApply').  This is unsound, so we reject it.
+      List1.unlessNullM (retypedModuleParameters args tel) $ \ ps ->
+        typeError $ NamedWhereModuleInRetypedContext ps
       where
         isWeakening [] = True
         isWeakening (Var i [] : args) = isWk (i - 1) args
@@ -1316,6 +1329,25 @@ checkWhere wh@(A.WhereDecls whmod whNamed mds) ret = do
             isWk i (Var j [] : args) = i == j && isWk (i - 1) args
             isWk _ _ = False
         isWeakening _ = False
+
+        -- Andreas, 2026-09-01, issue #8698.
+        -- Compute the module parameters (given as @args@ living in the current
+        -- context) whose type there differs from the type given to them by the
+        -- module telescope @tel@, returning name, actual and expected type.
+        retypedModuleParameters :: Args -> Telescope -> TCM [(ArgName, Type, Type)]
+        retypedModuleParameters []           _        = return []
+        retypedModuleParameters _            EmptyTel = return []
+        retypedModuleParameters (arg : args) (ExtendTel dom tel) = do
+          let v        = unArg arg
+              expected = unDom dom
+          rest <- retypedModuleParameters args $ absApp tel v
+          case v of
+            -- Since @args@ is a weakening (see above), it consists of variables.
+            Var i [] -> do
+              actual <- typeOfBV i
+              ifM (tryConversion $ equalType actual expected) {-then-} (return rest) {-else-}
+                $ return $ (absName tel, actual, expected) : rest
+            _ -> return rest
 
 
 -- | Enter a new section during type-checking.

--- a/test/Fail/Issue8698.agda
+++ b/test/Fail/Issue8698.agda
@@ -1,0 +1,49 @@
+-- Andreas, 2026-09-01, issue #8698, found and MWE by Claude, reported by bdrisc-ant.
+--
+-- With-abstraction can change the type of a module parameter
+-- (namely of a parameter that is not needed to type the with-expressions
+-- but whose type mentions them).
+-- A named where-module in such a with-clause would get a telescope
+-- that lies about the module parameters, giving us a proof of absurdity.
+
+{-# OPTIONS --safe --without-K #-}
+
+module Issue8698 where
+
+data ⊥ : Set where
+
+data ⊤ : Set where
+  tt : ⊤
+
+data Bool : Set where
+  true  : Bool
+  false : Bool
+
+neg : Bool → Bool
+neg true  = false
+neg false = true
+
+F : Bool → Set
+F true  = ⊥
+F false = ⊤
+
+module M (b : Bool) (p : F (neg b)) where
+
+  get : F (neg b)
+  get = p
+
+  -- The with-abstraction gives p the type F w,
+  -- so in the following clause p : F false rather than F (neg b).
+  foo : Bool
+  foo with neg b
+  ... | true  = true
+  ... | false = false
+    module W where
+    val : F (neg b)   -- elaborated via the ill-typed application  get b p
+    val = get
+
+-- Without the check, M.W would get the telescope (b : Bool) (p : F false),
+-- so the following would be a proof of ⊥:
+
+boom : ⊥
+boom = M.W.val false tt

--- a/test/Fail/Issue8698.err
+++ b/test/Fail/Issue8698.err
@@ -1,0 +1,8 @@
+Issue8698.agda:41.12-13: error: [NamedWhereModuleInRetypedContext]
+Named where-modules are not allowed when with-abstraction has
+changed the type of a module parameter.
+(See https://github.com/agda/agda/issues/8698.)
+In this case the module parameter has been given the type
+  p : F false
+    instead of F (neg b)
+when checking the named where block W

--- a/test/Succeed/Issue8698.agda
+++ b/test/Succeed/Issue8698.agda
@@ -1,0 +1,49 @@
+-- Andreas, 2026-09-01, issue #8698.
+--
+-- The check for named where-modules in with-clauses that re-type
+-- a module parameter (error NamedWhereModuleInRetypedContext)
+-- must not fire when nothing has been re-typed.
+
+{-# OPTIONS --safe --without-K #-}
+
+module Issue8698 where
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Unit
+
+data ⊥ : Set where
+
+neg : Bool → Bool
+neg true  = false
+neg false = true
+
+F : Bool → Set
+F true  = ⊥
+F false = ⊤
+
+module M (b : Bool) (p : F (neg b)) where
+
+  get : F (neg b)
+  get = p
+
+  -- Here the with-expression does not mention b,
+  -- so the type of p survives the with-abstraction.
+  bar : Bool → Bool
+  bar x with neg x
+  ... | c = c
+    module W where
+    val : F (neg b)
+    val = get
+
+  -- Anonymous where-blocks are never restricted.
+  foo : Bool
+  foo with neg b
+  ... | true  = true
+  ... | false = aux
+    where
+    aux : Bool
+    aux = false
+
+-- W honestly gets the telescope (b : Bool) (p : F (neg b)) (x c : Bool).
+test : ⊤
+test = M.W.val true tt true true


### PR DESCRIPTION
This fix modeled after the fix of #2897 adds a new check for named `where` modules under a `with` whether the parameter substitution induced by the `with` changed types of its inherited parameters.

The fix is generated by Claude and I am not sure this is the right way to address the problem.

In general, named `where` modules under a `with` seems a questionable feature, because it might be very hard to tell from a look at the source code what types its parameters actually have.
(This is more severe than for unnamed where modules because these are local in scope while named `where` modules can be instantiated in other scopes.)

We might opt to deprecate and remove that questionable feature in the future, but maybe investigate first how prevalent its use is.

Closes #8698.

<details>
<summary>Claude's analysis and fix description (abbreviated)</summary>

The bug
-------

In `module M Γ`, a `with`-clause's telescope is `Δ₁ · (w : A) · Δ₂′`, where `Δ₂′` is `Δ₂` with the with-expression abstracted to `w` **inside the types**. A module parameter that the with-expression doesn't mention, but whose *type* does, lands in `Δ₂` and gets re-typed: `p : F (neg b)` becomes `p : F w`, i.e. `p : F false` after matching.

Meanwhile the module-parameter substitution for `M` is still `b ↦ b, p ↦ p` — a plain weakening — so `Agda.TypeChecking.Monad.Signature.freeVarsToApply` keeps applying `M`'s definitions to `p` by position with no type check. A named `where` module in that clause then gets a telescope `(b : Bool) (p : F false)` while exporting `val : F (neg b)`, and instantiating it honestly from outside yields `⊥`.

The existing guard for this class of problem (`ensureNoNamedWhereInRefinedContext`, issue #2897) only tested that the parameter substitution is a *weakening* — it is here — and never checked that the *types* still match.

The fix
-------

`src/full/Agda/TypeChecking/Rules/Def.hs`: after the weakening test, `ensureNoNamedWhereInRefinedContext` now also verifies that each module parameter's type in the current context is convertible to its type in the module telescope, and rejects the named `where` module otherwise with a new error `NamedWhereModuleInRetypedContext` (constructor + rendering + error name added in `Monad/Base.hs`, `Errors.hs`, `Errors/Names.hs`, `Options/Errors.hs`).

```
Issue8698.agda:37.12-13: error: [NamedWhereModuleInRetypedContext]
Named where-modules are not allowed when with-abstraction has
changed the type of a module parameter.
(See https://github.com/agda/agda/issues/8698.)
In this case the module parameter has been given the type
  p : F false
    instead of F (neg b)
when checking the named where block W
```

Anonymous `where`-blocks and named `where`-modules in clauses that don't re-type a parameter are unaffected.

What I tried first, and why I abandoned it
-------------------------------------------

I first fixed the root cause: force module parameters into `Δ₁` (never abstract their types) by seeding `splitTelForWith`'s free-variable set with the module-parameter variables. That closed the hole cleanly and passed the whole test suite and the standard library — but it **broke the cubical library** (`Cubical/CW/Homology/Groups/CofibFinSphereBouquetMap.agda`: the generated with-function type became ill-typed, because `pathlemma` genuinely relies on the parameters of its enclosing anonymous module being re-typed). So that route isn't viable, and I reverted it.

Consequence worth flagging: the deeper defect — a clause referencing sibling definitions of `M` produces internally ill-typed applications — is *not* fixed. It stays confined to the with-clause context, which is only reachable through the honest instantiation `w := <with-expression>`, so it doesn't produce a closed proof of `⊥` on its own. Named `where` modules were the escape hatch, and that's now closed.

</details>
