### PR TITLE
Compile constructors to string-tagged JS arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,6 +563,11 @@ Backends
 * The JS backend's CJS & AMD module styles are now deprecated.
   Please use ES6 module style instead (`--js-es6`).
 
+* The JS backend now compiles constructors to string-tagged arrays.
+  This change is **breaking** for hand-written JS code relying on the previous Scott-Encoding.
+  Constructors for types with `COMPILE JS` pragmas are not affected.
+  (see [#8720](https://github.com/agda/agda/pull/8720))
+
 Issues closed
 -------------
 

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -65,13 +65,14 @@ import Agda.Utils.Singleton ( singleton )
 import Agda.Utils.Size (size)
 
 import Agda.Compiler.Common as CC
-import Agda.Compiler.ToTreeless
-import Agda.Compiler.Treeless.EliminateDefaults
-import Agda.Compiler.Treeless.EliminateLiteralPatterns
-import Agda.Compiler.Treeless.GuardsToPrims
-import Agda.Compiler.Treeless.Erase ( computeErasedConstructorArgs, isErasable )
-import Agda.Compiler.Treeless.Subst ()
 import Agda.Compiler.Backend (Backend,Backend_boot(..), Backend',Backend'_boot(..), Recompile(..))
+
+import qualified Agda.Compiler.ToTreeless as T
+import qualified Agda.Compiler.Treeless.EliminateDefaults as T
+import qualified Agda.Compiler.Treeless.EliminateLiteralPatterns as T
+import qualified Agda.Compiler.Treeless.GuardsToPrims as T
+import qualified Agda.Compiler.Treeless.Erase as T
+import qualified Agda.Compiler.Treeless.Subst as T
 
 import Agda.Compiler.JS.Syntax
   ( Exp(Self,Local,Global,Undefined,Null,String,Char,Integer,Double,Lambda,Object,Array,Apply,Lookup,If,BinOp,PlainJS),
@@ -405,7 +406,7 @@ checkCompilerPragmas q =
   setCurrentRange r do
     -- Issue #3545: Warn user about ignored COMPILE pragma for defined functions.
     getConstInfo q <&> theDef >>= \case
-      FunctionDefn{} -> whenM (isErasable q) $ warning $ PragmaCompileErased jsBackendName q
+      FunctionDefn{} -> whenM (T.isErasable q) $ warning $ PragmaCompileErased jsBackendName q
       _ -> return()
     -- If the pragma is not of the form "q = bla", complain.
     when (listToMaybe (words s) /= Just "=") do
@@ -446,12 +447,12 @@ definition' kit q d t ls =
     Function{} | otherwise -> do
 
       reportSDoc "compile.js" 5 $ "compiling fun:" <+> prettyTCM q
-      let mTreeless = toTreeless T.EagerEvaluation q
+      let mTreeless = T.toTreeless T.EagerEvaluation q
       caseMaybeM mTreeless (pure Nothing) $ \ treeless -> do
         used <- fromMaybe [] <$> getCompiledArgUse q
-        funBody <- eliminateCaseDefaults =<<
-          eliminateLiteralPatterns
-          (convertGuards treeless)
+        funBody <- T.eliminateCaseDefaults =<<
+          T.eliminateLiteralPatterns
+          (T.convertGuards treeless)
         reportSDoc "compile.js" 30 $ " compiled treeless fun:" <+> pretty funBody
         reportSDoc "compile.js" 40 $ " argument usage:" <+> (text . show) used
 
@@ -481,10 +482,10 @@ definition' kit q d t ls =
     PrimitiveSort{} -> return Nothing
 
     Datatype{} -> do
-        computeErasedConstructorArgs q
+        T.computeErasedConstructorArgs q
         ret emp
     Record{} -> do
-        computeErasedConstructorArgs q
+        T.computeErasedConstructorArgs q
         return Nothing
 
     Constructor{} | Just e <- defJSDef d -> plainJS e

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -46,9 +46,7 @@ import qualified Agda.Syntax.Treeless as T
 
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Reduce ( instantiateFull )
-import Agda.TypeChecking.Substitute as TC ( TelV(..), raise, subst )
 import Agda.TypeChecking.Pretty
-import Agda.TypeChecking.Telescope ( telViewPath )
 import Agda.TypeChecking.Warnings  ( warning )
 
 import Agda.Utils.FileName ( isNewerThan )
@@ -493,14 +491,12 @@ definition' kit q d t ls =
     Constructor{} | Just e <- defJSDef d -> plainJS e
     -- Implements Scott-Encoding of constructor definitions
     -- (see the note "Implementing data types")
-    Constructor{conData = p, conPars = nc} -> do
-      TelV tel _ <- telViewPath t
-      let nargs = length (telToList tel) - nc
-          args = [ Local $ LocalId $ nargs - i | i <- [0 .. nargs-1] ]
+    Constructor{conData = p, conArity = conArity} -> do
+      let args = [ Local $ LocalId $ conArity - i | i <- [0 .. conArity-1] ]
       d <- getConstInfo p
       let l = List1.last ls
       ret
-        $ curriedLambda nargs
+        $ curriedLambda conArity
         $ (case theDef d of
               Record {} -> Object . Map.singleton l
               dt -> id)

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -75,9 +75,8 @@ import Agda.Compiler.Backend (Backend,Backend_boot(..), Backend',Backend'_boot(.
 
 import Agda.Compiler.JS.Syntax
   ( Exp(Self,Local,Global,Undefined,Null,String,Char,Integer,Double,Lambda,Object,Array,Apply,Lookup,If,BinOp,PlainJS),
-    LocalId(LocalId), GlobalId(GlobalId), MemberId(MemberId,MemberIndex), Export(Export), Module(Module, modName, callMain), Comment(Comment),
-    modName, expName, uses
-  , JSQName
+    LocalId(LocalId), GlobalId(GlobalId), MemberId(MemberId,MemberIndex), Export(Export), Module(Module, modName, callMain),
+    modName, expName, uses, JSQName
   )
 import Agda.Compiler.JS.Substitution
   ( curriedLambda, curriedApply, emp, apply, substShift )

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -531,7 +531,7 @@ definition' kit q d t ls =
 --        exports["Foo"]["c2"] = x => y => k => k["c2"](x,y)
 --
 --    notice how the data-type parameter A does not become a parameter of the constructor c2.
---    Nor do any module parameters. 
+--    Nor do any module parameters.
 --
 --  * A constructor application, e.g.
 --

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -10,7 +10,7 @@ import Control.DeepSeq
 import Control.Monad.Trans
 
 import Data.Char     ( isSpace )
-import Data.Foldable ( forM_ )
+import Data.Foldable ( forM_, foldrM )
 import Data.Functor  ( (<&>) )
 import Data.List     ( dropWhileEnd, elemIndex, intercalate, partition )
 import Data.Maybe    ( listToMaybe )
@@ -75,12 +75,12 @@ import qualified Agda.Compiler.Treeless.Erase as T
 import qualified Agda.Compiler.Treeless.Subst as T
 
 import Agda.Compiler.JS.Syntax
-  ( Exp(Self,Local,Global,Undefined,Null,String,Char,Integer,Double,Lambda,Object,Array,Apply,Lookup,If,BinOp,PlainJS),
-    LocalId(LocalId), GlobalId(GlobalId), MemberId(MemberId,MemberIndex), Export(Export), Module(Module, modName, callMain),
+  ( Exp(Self,Local,Global,Undefined,Null,String,Char,Integer,Double,Lambda,Object,Array,Apply,Lookup,If,BinOp,PlainJS, MemberIdInString, Ternary),
+    LocalId(LocalId), GlobalId(GlobalId), MemberId(MemberId, MemberIndex), Export(Export), Module(Module, modName, callMain),
     modName, expName, uses, JSQName
   )
 import Agda.Compiler.JS.Substitution
-  ( curriedLambda, curriedApply, emp, apply, substShift )
+  ( curriedLambda, curriedApply, emp, apply, substShift, subst', subst, shiftFrom)
 import qualified Agda.Compiler.JS.Pretty as JSPretty
 import Agda.Compiler.JS.Pretty (JSModuleStyle(..))
 
@@ -282,7 +282,8 @@ jsPostModule opts _ isMain _ defs = do
 
 
 jsCompileDef :: JSOptions -> JSModuleEnv -> IsMain -> Definition -> TCM (Maybe Export)
-jsCompileDef opts kit _isMain def = definition (opts, kit) (defName def, def)
+jsCompileDef opts kit _isMain def = do
+    definition (opts, kit) (defName def, def)
 
 --------------------------------------------------
 -- Naming
@@ -327,6 +328,7 @@ global q = do
   case d of
     Defn { theDef = Constructor { conData = p } } -> do
       getConstInfo p >>= \case
+        -- Lawrence 2026-08-14: TODO: switch to "constructor" now the encoding is changing anyway?
         -- Andreas, 2020-10-27, comment quotes outdated fact.
         -- anon. constructors are now M.R.constructor.
         -- We could simplify/remove the workaround by switching "record"
@@ -448,11 +450,8 @@ definition' kit q d t ls =
 
       reportSDoc "compile.js" 5 $ "compiling fun:" <+> prettyTCM q
       let mTreeless = T.toTreeless T.EagerEvaluation q
-      caseMaybeM mTreeless (pure Nothing) $ \ treeless -> do
+      caseMaybeM mTreeless (pure Nothing) $ \ funBody -> do
         used <- fromMaybe [] <$> getCompiledArgUse q
-        funBody <- T.eliminateCaseDefaults =<<
-          T.eliminateLiteralPatterns
-          (T.convertGuards treeless)
         reportSDoc "compile.js" 30 $ " compiled treeless fun:" <+> pretty funBody
         reportSDoc "compile.js" 40 $ " argument usage:" <+> (text . show) used
 
@@ -489,18 +488,15 @@ definition' kit q d t ls =
         return Nothing
 
     Constructor{} | Just e <- defJSDef d -> plainJS e
-    -- Implements Scott-Encoding of constructor definitions
+    -- Encode constructor definitions to JS functions that construct Tagged Arrays
     -- (see the note "Implementing data types")
-    Constructor{conData = p, conArity = conArity} -> do
-      let args = [ Local $ LocalId $ conArity - i | i <- [0 .. conArity-1] ]
-      d <- getConstInfo p
+    Constructor
+      { conArity = conArity     -- Number of fields stored in the constructor
+      } -> do
       let l = List1.last ls
       ret
         $ curriedLambda conArity
-        $ (case theDef d of
-              Record {} -> Object . Map.singleton l
-              dt -> id)
-        $  Lambda 1 $ Apply (Lookup (Local (LocalId 0)) l) args
+        $ Array $ MemberIdInString l : [Local (LocalId i) | i <- reverse [0..conArity-1]]
 
     AbstractDefn{} -> __IMPOSSIBLE__
   where
@@ -510,9 +506,9 @@ definition' kit q d t ls =
 -- Implementing data types
 --------------------------
 
--- Data types are implemented using a variant of Scott Encoding,
--- which uses JavaScript dicts instead of some lambda-expressions
-
+-- Data constructors are compiled to arrays where the 0th element is a string tag.
+-- Such arrays are called 'Tagged Arrays'
+--
 -- For example, given the data type
 --
 --      data Foo (A : Set) : Set where
@@ -528,34 +524,43 @@ definition' kit q d t ls =
 --
 --    compiles to
 --
---        exports["Foo"]["c2"] = x => y => k => k["c2"](x,y)
+--        exports["Foo"]["c2"] = x => y => ["c2", x, y]
 --
 --    notice how the data-type parameter A does not become a parameter of the constructor c2.
 --    Nor do any module parameters.
 --
 --  * A constructor application, e.g.
 --
---        c2 x y
+--        c2 E1 E2
 --
 --    compiles to
 --
---        exports["Foo"]["c2"](x)(y)
+--        exports["Foo"]["c2"](E1)(E2)
 --
 --  * A case split, e.g.
 --
 --        case p of
 --          (c1    ) -> E1
---          (c2 x y) -> E2
---          (c3 f  ) -> E3
+--          (c2 x y) -> E2          (where E2 = ...x ... y ...)
+--          (c3 f  ) -> E3          (where E3 = ... f ...     )
 --
 --    compiles to
 --
---        p(
---          { "c1": ()    => E1
---          , "c2": (x,y) => E2
---          , "c3": f     => E3
---          })
-
+--          (p[0] == "c1") ? E1
+--        : (p[0] == "c2") ? E2     (where E2 = ... p[1] ... p[2] ...)
+--        : (p[0] == "c3") ? E3     (where E3 = ... p[1] ...         )
+--        : undefined
+--
+--    unless a there is a {-# COMPILE JS Foo = <split> #-} pragma,
+--    in which case this case split compiles to
+--
+--        <split>
+--            { "c1": () => E1
+--            , "c2": (x,y) => E2           (where E2 = ... x ... y ... )
+--            , "c3": (f) => E3             (where E3 = ... f ...)
+--            }
+--
+--  Record types are compiled like single-argument data types
 
 compileTerm :: EnvWithOpts -> T.TTerm -> TCM Exp
 compileTerm kit = go
@@ -586,6 +591,8 @@ compileTerm kit = go
           [(flatName, PlainJS evalThunk)
           ,(MemberId "__flat_helper", Lambda 0 x)]
       T.TApp t xs -> do
+            -- Lawrence 2026-08: evaluating version hangs on Issue7595:
+            -- curriedApply' <$> go t <*> mapM go xs
             curriedApply <$> go t <*> mapM go xs
       T.TLam t -> Lambda 1 <$> go t
       -- `let x = t in e` is compiled to `(x => e[x()/x])(() => t)` so that `t`
@@ -595,26 +602,20 @@ compileTerm kit = go
         e' <- substShift 1 1 [Apply (Local (LocalId 0)) []] <$> go e
         return $ Apply (Lambda 1 e') [t']
       T.TLit l -> return $ literal l
-      -- Implements Scott-Encoding of constructor applications
+      -- Encode constructor applications to Tagged Arrays
       -- (see the note "Implementing data types")
       T.TCon q -> qname q
-    -- Implements Scott-Encoding of case splits
-    -- (see the note "Implementing data types")
-      T.TCase sc ct def alts | T.CTData dt <- T.caseType ct -> do
-        dt <- getConstInfo dt
-        alts' <- traverse (compileAlt kit) alts
-        let obj = Object $ Map.fromListWith __IMPOSSIBLE__ alts'
-        case (theDef dt, defJSDef dt) of
-          (_, Just e) -> do
-            return $ apply (PlainJS e) [Local (LocalId sc), obj]
-          (Record{}, _) -> do
-            memId <- visitorName $ recCon $ theDef dt
-            return $ apply (Lookup (Local $ LocalId sc) memId) [obj]
-          (Datatype{}, _) -> do
-            return $ curriedApply (Local (LocalId sc)) [obj]
-          _ -> __IMPOSSIBLE__
-      T.TCase _ _ _ _ -> __IMPOSSIBLE__
-
+      t@(T.TCase sc ci@(T.CaseInfo{caseType = T.CTData dt}) def alts) -> do
+        pragma <- defJSDef <$> getConstInfo dt
+        let isReachable = not (T.isUnreachable def)
+        case (pragma, isReachable) of
+          -- Recursive case (COMPILE JS pragma present, inexhaustive match): make exhautive & try again
+          (Just _, True) -> go =<< T.eliminateCaseDefaultAtTopLevelIfPresent t
+          -- Base case (COMPILE JS pragma present, all cases handled): emit call to pragma
+          (Just e, False) -> compileCaseWithPragma e kit sc alts
+          -- Base case (no COMPILE JS pragma): compile as usual
+          (Nothing, _) -> compileCaseNoPragma kit sc def alts
+      T.TCase sc ci def alts -> compileCaseNoPragma kit sc def alts
       T.TPrim p -> return $ compilePrim p
       T.TUnit -> unit
       T.TSort -> unit
@@ -625,6 +626,57 @@ compileTerm kit = go
 
     unit = return Null
 
+-- Compiles a case split, without consulting any COMPILE JS pragmas
+-- Returns a chain of ternary expressions
+-- (see the note "Implementing data types")
+compileCaseNoPragma :: EnvWithOpts -> Int -> T.TTerm -> [T.TAlt] -> TCM Exp
+compileCaseNoPragma kit sc def alts = do
+  def' <- compileTerm kit def
+  foldrM (compileAlt kit sc) def' alts
+
+-- Compile a case split, using a COMPILE JS pragma on the data type.
+-- Precondition: cases present for all constructors of data type
+-- Returns a call to the pragma
+-- (see the note "Implementing data types")
+compileCaseWithPragma :: String -> EnvWithOpts -> Int -> [T.TAlt] -> TCM Exp
+compileCaseWithPragma pragmaContents kit sc alts = do
+  let scrutinee = Local (LocalId sc)
+  alts' <- alts & traverse \case
+    T.TACon con nargs body -> do
+      mid <- visitorName con
+      body <- Lambda nargs <$> compileTerm kit body
+      return (mid, body)
+    _ -> __IMPOSSIBLE__
+  return $ apply (PlainJS pragmaContents) [scrutinee, Object $ Map.fromListWith __IMPOSSIBLE__ alts']
+
+-- Compiles a single treeless alternative (+ default case),
+-- to a Ternary expression (see the note "Implementing data types")
+compileAlt :: EnvWithOpts -> Int -> T.TAlt -> Exp -> TCM Exp
+compileAlt kit sc (T.TACon {aCon = aCon, aArity = aArity, aBody = aBody}) def = do
+  let scrutinee = Local (LocalId sc)
+  body <- compileTerm kit aBody
+  -- Lawrence 2026-08: evaluating versions hang on Issue7595:
+  --    let body' = shiftFrom aArity 0 $ subst' aArity [Lookup scrutinee (MemberIndex i) | i <- [1 .. aArity]] body
+  --    let body' = curriedApply' (curriedLambda aArity body) [Lookup scrutinee (MemberIndex i) | i <- [1 .. aArity]]
+  --  but non-evalauting versions OK:
+  -- let body' = curriedApply (curriedLambda aArity body) [Lookup scrutinee (MemberIndex i) | i <- [1 .. aArity]]
+  let body' = shiftFrom aArity 0 $ subst aArity [Lookup scrutinee (MemberIndex i) | i <- [1 .. aArity]] body
+  mid <- visitorName aCon
+  pure $ Ternary (BinOp (Lookup scrutinee (MemberIndex 0)) "==" (MemberIdInString mid)) body' def
+compileAlt kit _ (T.TAGuard {aGuard = aGuard, aBody = aBody}) def = do
+  guard <- compileTerm kit aGuard
+  body <- compileTerm kit aBody
+  pure $ Ternary guard body def
+compileAlt kit sc (T.TALit {aLit = LitQName q, aBody = aBody}) def = do
+  let scrutinee = Local (LocalId sc)
+  body <- compileTerm kit aBody
+  pure $ Ternary (BinOp (Lookup scrutinee (MemberId "name")) "==" (String $ T.pack $ prettyShow q)) body def
+-- Lawrence 2026-08: I suspect the lack of special case for LitMeta is buggy,
+-- but it does not break the existing tests
+compileAlt kit sc (T.TALit {aLit = aLit, aBody = aBody}) def = do
+  let scrutinee = Local (LocalId sc)
+  body <- compileTerm kit aBody
+  pure $ Ternary (BinOp scrutinee "==" (literal aLit)) body def
 
 compilePrim :: T.TPrim -> Exp
 compilePrim p =
@@ -655,16 +707,6 @@ compilePrim p =
   where binOp js = curriedLambda 2 $ apply (PlainJS js) [local 1, local 0]
         unOp js  = curriedLambda 1 $ apply (PlainJS js) [local 0]
         primEq   = curriedLambda 2 $ BinOp (local 1) "===" (local 0)
-
--- Implements Scott-Encoding of case split cases
--- (see the note "Implementing data types")
-compileAlt :: EnvWithOpts -> T.TAlt -> TCM (MemberId, Exp)
-compileAlt kit = \case
-  T.TACon con nargs body -> do
-    memId <- visitorName con
-    body <- Lambda nargs <$> compileTerm kit body
-    return (memId, body)
-  _ -> __IMPOSSIBLE__
 
 visitorName :: QName -> TCM MemberId
 visitorName q = List1.last . snd <$> global q

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -558,7 +558,7 @@ definition' kit q d t ls =
 
 
 compileTerm :: EnvWithOpts -> T.TTerm -> TCM Exp
-compileTerm kit t = go t
+compileTerm kit = go
   where
     go :: T.TTerm -> TCM Exp
     go = \case

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -515,20 +515,23 @@ definition' kit q d t ls =
 
 -- For example, given the data type
 --
---      data Foo : Set where
---        c1 : Foo
---        c2 : X -> Y -> Foo
---        c3 : Foo -> Foo
+--      data Foo (A : Set) : Set where
+--        c1 : Foo A
+--        c2 : X -> Y -> Foo A
+--        c3 : Foo A -> Foo A
 --
 -- here is how "Foo" is compiled:
 --
 --  * A constructor definition, e.g.
 --
---        c2 : X -> Y -> Foo
+--        c2 : X -> Y -> Foo A
 --
 --    compiles to
 --
 --        exports["Foo"]["c2"] = x => y => k => k["c2"](x,y)
+--
+--    notice how the data-type parameter A does not become a parameter of the constructor c2.
+--    Nor do any module parameters. 
 --
 --  * A constructor application, e.g.
 --

--- a/src/full/Agda/Compiler/JS/Pretty.hs
+++ b/src/full/Agda/Compiler/JS/Pretty.hs
@@ -265,6 +265,9 @@ instance Pretty Exp where
     <+> "=>" <+> block (n + x, min, ms) e
   prettyPrec p n (Object o)     = braces $ punctuate "," $ pretties n o
   prettyPrec p n (Array es)     = brackets $ punctuate "," [pretty n e | e <- es]
+  prettyPrec p n (MemberIdInString mid) = pretty n mid
+  prettyPrec p n (Ternary eCond eThen eElse) = (prettyPrec 17 n eCond <+> text "?" <+> prettyPrec 17 n eThen)
+                                            $+$ text ":" <+> prettyPrec 17 n eElse
   prettyPrec p n (Apply f es)   = prettyPrec 17 n f <> parens (punctuate "," $ pretties n es)
   prettyPrec p n (Lookup e l)   = prettyPrec 17 n e <> brackets (pretty n l)
   prettyPrec p n (If e f g)     = mparens (p > 2) $

--- a/src/full/Agda/Compiler/JS/Pretty.hs
+++ b/src/full/Agda/Compiler/JS/Pretty.hs
@@ -258,7 +258,7 @@ instance Pretty Exp where
   prettyPrec p n (Null)         = "null"
   prettyPrec p n (String s)     = "\"" <> unescapes (T.unpack s) <> "\""
   prettyPrec p n (Char c)       = "\"" <> unescapes [c] <> "\""
-  prettyPrec p n (Integer x)    = "agdaRTS.primIntegerFromString(\"" <> text (show x) <> "\")"
+  prettyPrec p n (Integer x)    = text (show x) <> "n"
   prettyPrec p n (Double x)     = text $ show x
   prettyPrec p (n, min, ms) (Lambda x e) = mparens (p > 2) $
     mparens (x /= 1) (punctuate "," (pretties (n + x, min, ms) (map LocalId [x-1, x-2 .. 0])))

--- a/src/full/Agda/Compiler/JS/Pretty.hs
+++ b/src/full/Agda/Compiler/JS/Pretty.hs
@@ -246,12 +246,7 @@ instance Pretty GlobalId where
 
 instance Pretty MemberId where
   pretty _ (MemberId s) = "\"" <> unescapes s <> "\""
-  pretty n (MemberIndex i comment) = text (show i) <> pretty n comment
-
-instance Pretty Comment where
-  pretty _ (Comment "") = mempty
-  pretty (_, True, _) _ = mempty
-  pretty _ (Comment s) = text $ "/* " ++ s ++ " */"
+  pretty n (MemberIndex i) = text (show i)
 
 -- Pretty print expressions
 
@@ -269,7 +264,7 @@ instance Pretty Exp where
     mparens (x /= 1) (punctuate "," (pretties (n + x, min, ms) (map LocalId [x-1, x-2 .. 0])))
     <+> "=>" <+> block (n + x, min, ms) e
   prettyPrec p n (Object o)     = braces $ punctuate "," $ pretties n o
-  prettyPrec p n (Array es)     = brackets $ punctuate "," [pretty n c <> pretty n e | (c, e) <- es]
+  prettyPrec p n (Array es)     = brackets $ punctuate "," [pretty n e | e <- es]
   prettyPrec p n (Apply f es)   = prettyPrec 17 n f <> parens (punctuate "," $ pretties n es)
   prettyPrec p n (Lookup e l)   = prettyPrec 17 n e <> brackets (pretty n l)
   prettyPrec p n (If e f g)     = mparens (p > 2) $

--- a/src/full/Agda/Compiler/JS/Pretty.hs
+++ b/src/full/Agda/Compiler/JS/Pretty.hs
@@ -271,7 +271,6 @@ instance Pretty Exp where
     prettyPrec 3 n e <> "?" <+> prettyPrec 3 n f <> ":" <+> prettyPrec 2 n g
   prettyPrec p n (PreOp op e)   = parens $ text op <> " " <> prettyPrec 17 n e
   prettyPrec p n (BinOp e op f) = parens $ prettyPrec 17 n e <> " " <> text op <> " " <> prettyPrec 17 n f
-  prettyPrec p n (Const c)      = text c
   prettyPrec p n (PlainJS js)   = text js
 
 block :: (Nat, Bool, JSModuleStyle) -> Exp -> Doc

--- a/src/full/Agda/Compiler/JS/Substitution.hs
+++ b/src/full/Agda/Compiler/JS/Substitution.hs
@@ -27,7 +27,7 @@ map m f (Integer i)     = Integer i
 map m f (Double d)      = Double d
 map m f (Lambda i e)    = Lambda i (map (m + i) f e)
 map m f (Object o)      = Object (Map.map (map m f) o)
-map m f (Array es)      = Array (List.map (\(c, e) -> (c, map m f e)) es)
+map m f (Array es)      = Array (List.map (map m f) es)
 map m f (Apply e es)    = Apply (map m f e) (List.map (map m f) es)
 map m f (Lookup e l)    = Lookup (map m f e) l
 map m f (If e e' e'')   = If (map m f e) (map m f e') (map m f e'')
@@ -77,7 +77,7 @@ map' m f (Integer i)     = Integer i
 map' m f (Double d)      = Double d
 map' m f (Lambda i e)    = Lambda i (map' (m + i) f e)
 map' m f (Object o)      = Object (Map.map (map' m f) o)
-map' m f (Array es)      = Array (List.map (\(c, e) -> (c, map' m f e)) es)
+map' m f (Array es)      = Array (List.map (map' m f) es)
 map' m f (Apply e es)    = apply (map' m f e) (List.map (map' m f) es)
 map' m f (Lookup e l)    = lookup (map' m f e) l
 map' m f (If e e' e'')   = If (map' m f e) (map' m f e') (map' m f e'')
@@ -110,7 +110,7 @@ lookup e          l = Lookup e l
 self :: Exp -> Exp -> Exp
 self e (Self)         = e
 self e (Object o)     = Object (Map.map (self e) o)
-self e (Array es)     = Array (List.map (\(c, x) -> (c, self e x)) es)
+self e (Array es)     = Array (List.map (self e) es)
 self e (Apply f es)   = case (self e f) of
   (Lambda n g) -> self e (subst' n es g)
   g            -> Apply g (List.map (self e) es)

--- a/src/full/Agda/Compiler/JS/Substitution.hs
+++ b/src/full/Agda/Compiler/JS/Substitution.hs
@@ -8,7 +8,7 @@ import qualified Data.List as List
 
 import Agda.Syntax.Common ( Nat )
 import Agda.Compiler.JS.Syntax
-  ( Exp(Self,Undefined,Local,Lambda,Object,Array,Apply,Lookup,If,BinOp,PreOp),
+  ( Exp(..),
     MemberId, LocalId(LocalId) )
 import Agda.Utils.Function ( iterate' )
 import Agda.Utils.List ( (!!!) )
@@ -16,7 +16,15 @@ import Agda.Utils.List ( (!!!) )
 -- Map for expressions
 
 map :: Nat -> (Nat -> LocalId -> Exp) -> Exp -> Exp
+map m f (Self)            = Self
 map m f (Local i)       = f m i
+map m f (Global g)      = Global g
+map m f (Undefined)     = Undefined
+map m f (Null)          = Null
+map m f (String s)      = String s
+map m f (Char c)        = Char c
+map m f (Integer i)     = Integer i
+map m f (Double d)      = Double d
 map m f (Lambda i e)    = Lambda i (map (m + i) f e)
 map m f (Object o)      = Object (Map.map (map m f) o)
 map m f (Array es)      = Array (List.map (\(c, e) -> (c, map m f e)) es)
@@ -25,7 +33,8 @@ map m f (Lookup e l)    = Lookup (map m f e) l
 map m f (If e e' e'')   = If (map m f e) (map m f e') (map m f e'')
 map m f (PreOp op e)    = PreOp op (map m f e)
 map m f (BinOp e op e') = BinOp (map m f e) op (map m f e')
-map m f e               = e
+map m f (Const str)     = Const str
+map m f (PlainJS str)   = PlainJS str
 
 -- Shifting
 
@@ -57,7 +66,15 @@ substShift m n es = subst m es . shiftFrom m n
 -- A variant on substitution which performs beta-reduction
 
 map' :: Nat -> (Nat -> LocalId -> Exp) -> Exp -> Exp
+map' m f (Self)          = Self
 map' m f (Local i)       = f m i
+map' m f (Global g)      = Global g
+map' m f (Undefined)     = Undefined
+map' m f (Null)          = Null
+map' m f (String s)      = String s
+map' m f (Char c)        = Char c
+map' m f (Integer i)     = Integer i
+map' m f (Double d)      = Double d
 map' m f (Lambda i e)    = Lambda i (map' (m + i) f e)
 map' m f (Object o)      = Object (Map.map (map' m f) o)
 map' m f (Array es)      = Array (List.map (\(c, e) -> (c, map' m f e)) es)
@@ -66,7 +83,9 @@ map' m f (Lookup e l)    = lookup (map' m f e) l
 map' m f (If e e' e'')   = If (map' m f e) (map' m f e') (map' m f e'')
 map' m f (PreOp op e)    = PreOp op (map' m f e)
 map' m f (BinOp e op e') = BinOp (map' m f e) op (map' m f e')
-map' m f e               = e
+map' m f (Const str)     = Const str
+map' m f (PlainJS str)   = PlainJS str
+
 
 subst' :: Nat -> [Exp] -> Exp -> Exp
 subst' 0 es e = e
@@ -117,13 +136,3 @@ curriedLambda n = iterate' n (Lambda 1)
 
 emp :: Exp
 emp = Object (empty)
-
-union :: Exp -> Exp -> Exp
-union (Object o) (Object p) = Object (unionWith union o p)
-union e          f          = e
-
-vine :: [MemberId] -> Exp -> Exp
-vine ls e = foldr (\ l e -> Object (singleton l e)) e ls
-
-object :: [([MemberId],Exp)] -> Exp
-object = foldr (\ (ls,e) -> (union (vine ls e))) emp

--- a/src/full/Agda/Compiler/JS/Substitution.hs
+++ b/src/full/Agda/Compiler/JS/Substitution.hs
@@ -33,7 +33,6 @@ map m f (Lookup e l)    = Lookup (map m f e) l
 map m f (If e e' e'')   = If (map m f e) (map m f e') (map m f e'')
 map m f (PreOp op e)    = PreOp op (map m f e)
 map m f (BinOp e op e') = BinOp (map m f e) op (map m f e')
-map m f (Const str)     = Const str
 map m f (PlainJS str)   = PlainJS str
 
 -- Shifting
@@ -83,7 +82,6 @@ map' m f (Lookup e l)    = lookup (map' m f e) l
 map' m f (If e e' e'')   = If (map' m f e) (map' m f e') (map' m f e'')
 map' m f (PreOp op e)    = PreOp op (map' m f e)
 map' m f (BinOp e op e') = BinOp (map' m f e) op (map' m f e')
-map' m f (Const str)     = Const str
 map' m f (PlainJS str)   = PlainJS str
 
 

--- a/src/full/Agda/Compiler/JS/Substitution.hs
+++ b/src/full/Agda/Compiler/JS/Substitution.hs
@@ -28,6 +28,8 @@ map m f (Double d)      = Double d
 map m f (Lambda i e)    = Lambda i (map (m + i) f e)
 map m f (Object o)      = Object (Map.map (map m f) o)
 map m f (Array es)      = Array (List.map (map m f) es)
+map m f (MemberIdInString mid) = MemberIdInString mid
+map m f (Ternary e1 e2 e3) = Ternary (map m f e1) (map m f e2) (map m f e3)
 map m f (Apply e es)    = Apply (map m f e) (List.map (map m f) es)
 map m f (Lookup e l)    = Lookup (map m f e) l
 map m f (If e e' e'')   = If (map m f e) (map m f e') (map m f e'')
@@ -77,6 +79,8 @@ map' m f (Double d)      = Double d
 map' m f (Lambda i e)    = Lambda i (map' (m + i) f e)
 map' m f (Object o)      = Object (Map.map (map' m f) o)
 map' m f (Array es)      = Array (List.map (map' m f) es)
+map' m f (MemberIdInString mid) = MemberIdInString mid
+map' m f (Ternary e1 e2 e3) = Ternary (map' m f e1) (map' m f e2) (map' m f e3)
 map' m f (Apply e es)    = apply (map' m f e) (List.map (map' m f) es)
 map' m f (Lookup e l)    = lookup (map' m f e) l
 map' m f (If e e' e'')   = If (map' m f e) (map' m f e') (map' m f e'')
@@ -127,7 +131,10 @@ fix f = e where e = self e f
 -- Some helper functions
 
 curriedApply :: Exp -> [Exp] -> Exp
-curriedApply = foldl (\ f e -> apply f [e])
+curriedApply = foldl (\ f e -> Apply f [e])
+
+curriedApply' :: Exp -> [Exp] -> Exp
+curriedApply' = foldl (\ f e -> apply f [e])
 
 curriedLambda :: Nat -> Exp -> Exp
 curriedLambda n = iterate' n (Lambda 1)

--- a/src/full/Agda/Compiler/JS/Syntax.hs
+++ b/src/full/Agda/Compiler/JS/Syntax.hs
@@ -36,6 +36,11 @@ data Exp =
   Const String |
   PlainJS String -- ^ Arbitrary JS code.
   deriving (Show, Eq)
+-- Code style:
+--  All recursive Exp-traversing functions should list every constructor explicitly.
+--  Do not write a catch-all case to cover all the trivial constructors.
+-- This policy helps catch subtle bugs (randomly failing substitution, missing imports etc.)
+-- due to newly-added constructors silently hitting the catch-all case.
 
 -- Local identifiers are named by De Bruijn indices.
 -- Global identifiers are named by string lists.
@@ -98,6 +103,18 @@ instance Uses Comment where
   uses _ = Set.empty
 
 instance Uses Exp where
+  uses (Self)         = Set.empty
+  uses (Local _)      = Set.empty
+  uses (Global _)     = Set.empty
+  uses (Undefined)    = Set.empty
+  uses (Null)         = Set.empty
+  uses (String _)     = Set.empty
+  uses (Integer _)    = Set.empty
+  uses (Char _)       = Set.empty
+  uses (Double _)     = Set.empty
+  uses (Lambda n _)   = Set.empty
+  -- Lawrence 2026-08: I suspect returning Set.empty for lambdas is a bug,
+  -- but it does not break existing tests
   uses (Object o)     = uses o
   uses (Array es)     = uses es
   uses (Apply e es)   = uses (e, es)
@@ -110,7 +127,8 @@ instance Uses Exp where
   uses (If e f g)     = uses (e, f, g)
   uses (BinOp e op f) = uses (e, f)
   uses (PreOp op e)   = uses e
-  uses e              = Set.empty
+  uses (Const _)      = Set.empty
+  uses (PlainJS _)    = Set.empty
 
 instance Uses Export where
   uses (Export _ e) = uses e
@@ -137,7 +155,15 @@ instance Globals Comment where
   globals _ = Set.empty
 
 instance Globals Exp where
+  globals (Self)         = Set.empty
+  globals (Local _)      = Set.empty
   globals (Global i) = Set.singleton i
+  globals (Undefined)    = Set.empty
+  globals (Null)         = Set.empty
+  globals (String _)     = Set.empty
+  globals (Integer _)    = Set.empty
+  globals (Char _)       = Set.empty
+  globals (Double _)     = Set.empty
   globals (Lambda n e) = globals e
   globals (Object o) = globals o
   globals (Array es) = globals es
@@ -146,7 +172,8 @@ instance Globals Exp where
   globals (If e f g) = globals (e, f, g)
   globals (BinOp e op f) = globals (e, f)
   globals (PreOp op e) = globals e
-  globals _ = Set.empty
+  globals (Const _)      = Set.empty
+  globals (PlainJS _)    = Set.empty
 
 instance Globals Export where
   globals (Export _ e) = globals e

--- a/src/full/Agda/Compiler/JS/Syntax.hs
+++ b/src/full/Agda/Compiler/JS/Syntax.hs
@@ -27,7 +27,7 @@ data Exp =
   Double Double |
   Lambda Nat Exp |
   Object (Map MemberId Exp) |
-  Array [(Comment, Exp)] |
+  Array [Exp] |
   Apply Exp [Exp] |
   Lookup Exp MemberId |
   If Exp Exp Exp |
@@ -54,14 +54,8 @@ newtype GlobalId = GlobalId [String]
 
 data MemberId
     = MemberId String
-    | MemberIndex Int Comment
+    | MemberIndex Int
   deriving (Eq, Ord, Show)
-
-newtype Comment = Comment String
-  deriving (Show, Semigroup, Monoid)
-
-instance Eq Comment where _ == _ = True
-instance Ord Comment where compare _ _ = EQ
 
 -- The top-level compilation unit is a module, which names
 -- the GId of its exports, and a list of definitions
@@ -98,9 +92,6 @@ instance (Uses a, Uses b) => Uses (a, b) where
 
 instance (Uses a, Uses b, Uses c) => Uses (a, b, c) where
   uses (a, b, c) = uses a `Set.union` uses b `Set.union` uses c
-
-instance Uses Comment where
-  uses _ = Set.empty
 
 instance Uses Exp where
   uses (Self)         = Set.empty
@@ -150,9 +141,6 @@ instance (Globals a, Globals b) => Globals (a, b) where
 
 instance (Globals a, Globals b, Globals c) => Globals (a, b, c) where
   globals (a, b, c) = globals a `Set.union` globals b `Set.union` globals c
-
-instance Globals Comment where
-  globals _ = Set.empty
 
 instance Globals Exp where
   globals (Self)         = Set.empty

--- a/src/full/Agda/Compiler/JS/Syntax.hs
+++ b/src/full/Agda/Compiler/JS/Syntax.hs
@@ -28,6 +28,8 @@ data Exp =
   Lambda Nat Exp |
   Object (Map MemberId Exp) |
   Array [Exp] |
+  MemberIdInString MemberId |
+  Ternary Exp Exp Exp |
   Apply Exp [Exp] |
   Lookup Exp MemberId |
   If Exp Exp Exp |
@@ -107,6 +109,8 @@ instance Uses Exp where
   -- but it does not break existing tests
   uses (Object o)     = uses o
   uses (Array es)     = uses es
+  uses (MemberIdInString mid) = Set.empty -- special case of string literals
+  uses (Ternary e1 e2 e3) = Set.unions [uses e1, uses e2, uses e3]
   uses (Apply e es)   = uses (e, es)
   uses (Lookup e l)   = uses' e (List1.singleton l)
     where
@@ -153,6 +157,8 @@ instance Globals Exp where
   globals (Lambda n e) = globals e
   globals (Object o) = globals o
   globals (Array es) = globals es
+  globals (MemberIdInString _) = Set.empty  --special case of string literals
+  globals (Ternary e1 e2 e3) = Set.unions [globals e1, globals e2, globals e3]
   globals (Apply e es) = globals (e, es)
   globals (Lookup e l) = globals e
   globals (If e f g) = globals (e, f, g)

--- a/src/full/Agda/Compiler/JS/Syntax.hs
+++ b/src/full/Agda/Compiler/JS/Syntax.hs
@@ -33,7 +33,6 @@ data Exp =
   If Exp Exp Exp |
   BinOp Exp String Exp |
   PreOp String Exp |
-  Const String |
   PlainJS String -- ^ Arbitrary JS code.
   deriving (Show, Eq)
 -- Code style:
@@ -118,7 +117,6 @@ instance Uses Exp where
   uses (If e f g)     = uses (e, f, g)
   uses (BinOp e op f) = uses (e, f)
   uses (PreOp op e)   = uses e
-  uses (Const _)      = Set.empty
   uses (PlainJS _)    = Set.empty
 
 instance Uses Export where
@@ -160,7 +158,6 @@ instance Globals Exp where
   globals (If e f g) = globals (e, f, g)
   globals (BinOp e op f) = globals (e, f)
   globals (PreOp op e) = globals e
-  globals (Const _)      = Set.empty
   globals (PlainJS _)    = Set.empty
 
 instance Globals Export where

--- a/src/full/Agda/Compiler/Treeless/EliminateDefaults.hs
+++ b/src/full/Agda/Compiler/Treeless/EliminateDefaults.hs
@@ -14,23 +14,35 @@ import Agda.TypeChecking.Substitute
 
 import Agda.Compiler.Treeless.Subst () --instance only
 
+-- Eliminate a case default.
+-- Leaves its argument unchanged if:
+--  * it not a data-type case split.
+--  * the default case is unreachable (this makes the function idempotent)
+eliminateCaseDefaultAtTopLevelIfPresent :: TTerm -> TCM TTerm
+eliminateCaseDefaultAtTopLevelIfPresent (TCase sc ci@CaseInfo{caseType = CTData qn} def alts)
+  | not (isUnreachable def) = do
+    dtCons <- defConstructors . theDef <$> getConstInfo qn
+    let missingCons = dtCons List.\\ map aCon alts
+    newAlts <- forM missingCons $ \con -> do
+      Constructor {conArity = ar} <- theDef <$> getConstInfo con
+      return $ TACon con ar (TVar ar)
+
+    alts' <- (++ newAlts) <$> mapM (trAlt . raise 1) alts
+
+    return $ TLet def $ TCase (sc + 1) ci tUnreachable alts'
+eliminateCaseDefaultAtTopLevelIfPresent t = pure t
+
+trAlt :: TAlt -> TCM TAlt
+trAlt = \case
+  TAGuard g b -> TAGuard <$> eliminateCaseDefaults g <*> eliminateCaseDefaults b
+  TACon q a b -> TACon q a <$> eliminateCaseDefaults b
+  TALit l b   -> TALit l <$> eliminateCaseDefaults b
+
 eliminateCaseDefaults :: TTerm -> TCM TTerm
 eliminateCaseDefaults = tr
   where
     tr :: TTerm -> TCM TTerm
-    tr = \case
-      TCase sc ct@CaseInfo{caseType = CTData qn} def alts
-        | not (isUnreachable def) -> do
-        dtCons <- defConstructors . theDef <$> getConstInfo qn
-        let missingCons = dtCons List.\\ map aCon alts
-        def <- tr def
-        newAlts <- forM missingCons $ \con -> do
-          Constructor {conArity = ar} <- theDef <$> getConstInfo con
-          return $ TACon con ar (TVar ar)
-
-        alts' <- (++ newAlts) <$> mapM (trAlt . raise 1) alts
-
-        return $ TLet def $ TCase (sc + 1) ct tUnreachable alts'
+    tr = eliminateCaseDefaultAtTopLevelIfPresent >=> \case
       TCase sc ct def alts -> TCase sc ct <$> tr def <*> mapM trAlt alts
 
       t@TVar{}    -> return t
@@ -48,8 +60,3 @@ eliminateCaseDefaults = tr
       TApp a bs               -> TApp <$> tr a <*> mapM tr bs
       TLet e b                -> TLet <$> tr e <*> tr b
 
-    trAlt :: TAlt -> TCM TAlt
-    trAlt = \case
-      TAGuard g b -> TAGuard <$> tr g <*> tr b
-      TACon q a b -> TACon q a <$> tr b
-      TALit l b   -> TALit l <$> tr b

--- a/test/Common/IO.agda
+++ b/test/Common/IO.agda
@@ -37,7 +37,7 @@ postulate
 {-# COMPILE GHC putStr = Data.Text.IO.putStr #-}
 {-# COMPILE UHC putStr = UHC.Agda.Builtins.primPutStr #-}
 {-# COMPILE JS putStr = function (x) { return function(cb) { process.stdout.write(x); cb(0); }; } #-}
-
+-- Lawrence 2026-08: the cb(0) in this COMPILE JS pragma is unsafe, since 0 is a Float, not a Unit
 
 printChar : Char -> IO Unit
 printChar c = putStr (charToStr c)

--- a/test/Compiler/simple/MatchBool.agda
+++ b/test/Compiler/simple/MatchBool.agda
@@ -1,0 +1,15 @@
+
+-- Tests compilation of catch-all cases
+-- for data types with COMPILE pragmas
+
+open import Agda.Builtin.Bool
+
+open import Common.IO
+open import Common.Unit
+
+_||_ : Bool → Bool → Bool
+false || false = false
+_     || _      = true
+
+main : IO Unit
+main = printBool (true || false)

--- a/test/Compiler/simple/MatchBool.out
+++ b/test/Compiler/simple/MatchBool.out
@@ -1,0 +1,4 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > true


### PR DESCRIPTION
This PR implements tagged arrays as suggested in #8398, but with string tags rather than integers.

## Motivation

I found that Scott encoding makes debugging space leaks harder: when profiling tools say the JS heap contains `512,515,088 B (31.52%) ++ class(Function)/objects`, it's not clear how many of those functions came from Scott-encoded data constructors vs. eta-expanders vs. actual functions in the Agda source.

With tagged arrays, constructors now show up as `Array`s in the heap profile.

The tagged array encoding should also make future experimentation easier, e.g.

* custom class names, for even more readable heap profiles
* Perceus-style reference counting, for timely GC

## Testing status

Every commit in this PR passes `nix build .#test`

I tested this PR on Iepje, where it seems to work, and made memory breakdowns (slightly) more readable.

<details>

I took the following quick & dirty measurements by:

  1. Running the Iepje examples gallery locally (with various compilers & versions)
  2. Opening librewolf's `about:memory` tab
  3. Clicking the 'measure' button (with 'verbose' checked) repeatedly
  4. Copying out the data when I saw it had leaked >1GB

Tagged arrays, delay-passing IO:

    1,625,797,072 B (100.0%) -- explicit
    ├──1,257,727,992 B (77.36%) -- window-objects/top(http://127.0.0.1:8080/, id=89)
    │  ├──1,223,803,712 B (75.27%) -- active/window(http://127.0.0.1:8080/)
    │  │  ├──1,219,061,072 B (74.98%) -- js-realm(http://127.0.0.1:8080/)
    │  │  │  ├──1,215,710,416 B (74.78%) -- classes
    │  │  │  │  ├────512,515,088 B (31.52%) ++ class(Function)/objects
    │  │  │  │  ├────387,946,216 B (23.86%) ── class(Call)/objects/gc-heap
    │  │  │  │  ├────314,988,224 B (19.37%) ++ class(Array)/objects

Tagged arrays, continuation-passing IO:

    838,220,384 B (100.0%) -- explicit
    ├──767,189,336 B (91.53%) -- window-objects/top(http://127.0.0.1:8080/, id=6)
    │  ├──746,018,624 B (89.00%) -- active/window(http://127.0.0.1:8080/)
    │  │  ├──741,169,712 B (88.42%) -- js-realm(http://127.0.0.1:8080/)
    │  │  │  ├──737,929,776 B (88.04%) -- classes
    │  │  │  │  ├──308,072,296 B (36.75%) ++ class(Function)/objects
    │  │  │  │  ├──219,528,904 B (26.19%) ++ class(Array)/objects
    │  │  │  │  ├──209,811,728 B (25.03%) ── class(Call)/objects/gc-heap

Scott encoding, continuation-passing IO:

    1,923,115,072 B (100.0%) -- explicit
    ├──1,445,013,512 B (75.14%) -- window-objects/top(http://127.0.0.1:8080/, id=33)
    │  ├──1,227,940,128 B (63.85%) -- active/window(http://127.0.0.1:8080/)
    │  │  ├──1,223,218,256 B (63.61%) -- js-realm(http://127.0.0.1:8080/)
    │  │  │  ├──1,220,825,888 B (63.48%) -- classes
    │  │  │  │  ├────655,018,120 B (34.06%) ++ class(Function)/objects
    │  │  │  │  ├────559,298,736 B (29.08%) ── class(Call)/objects/gc-heap
    │  │  │  │  ├──────6,230,456 B (00.32%) ++ class(Array)/objects

Scott encoding, delay-passing IO:

    1,345,705,616 B (100.0%) -- explicit
    ├────943,527,056 B (70.11%) -- window-objects/top(http://127.0.0.1:8080/, id=8)
    │    ├──858,701,696 B (63.81%) -- active
    │    │  ├──858,561,408 B (63.80%) -- window(http://127.0.0.1:8080/)
    │    │  │  ├──851,639,408 B (63.29%) -- js-realm(http://127.0.0.1:8080/)
    │    │  │  │  ├──847,517,392 B (62.98%) -- classes
    │    │  │  │  │  ├──449,416,984 B (33.40%) ++ class(Function)/objects
    │    │  │  │  │  ├──393,071,256 B (29.21%) ── class(Call)/objects/gc-heap [2]
    │    │  │  │  │  ├────4,051,576 B (00.30%) ++ class(Array)/objects

</details>

## Potential breakage

This PR changes Agda's default JS-encoding of `data` & `record` types.

I am not sure whether to classify this change as 'breaking' or not:

* Comments in the source code (by @andreasabel, 2020) suggest similar changes were previously considered breaking
* Downstream code *might* be relying on Agda's default JS-encoding of `data` or `record` types
* However, I am not aware of any such code (none of mine was broken by this PR)
* Downstream Agda developments can still choose their own encoding, via `COMPILE JS` pragmas
* `COMPILE JS` pragmas on data types still work after this PR, with no need for migration
* Over-approximating breakage slows down development: long deprecation periods, blocked changes, etc.
* https://xkcd.com/1172/

## Notes for reviwers

This is entirely my own implementation, not based on any previous PR, and made without LLMs.

The last commit makes the breaking change to data encoding,
the others commits are refactors, and placed earlier for easier review & revert.

