### PR TITLE
Add Agda Web to the manual

### DIFF
--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -5,7 +5,7 @@ Installation
 ************
 
 .. hint:: If you want a sneak peek of Agda without installing it, try the
-  `Agda Pad <https://agdapad.quasicoherent.io/>`_.
+  `Agda Pad <https://agdapad.quasicoherent.io/>`_ or the `Agda Web <https://agda-web.github.io>`_.
 
 .. hint:: This documentation is for first-time Agda users.
     More advanced "do it yourself" instructions can be found in the Agda repo's


### PR DESCRIPTION
## Summary
Add [Agda Web](https://agda-web.github.io) as an option to try out Agda without installing it. 

## Background

VS Code has been the most popular IDE according to this [survey](https://survey.stackoverflow.co/2025/technology#most-popular-technologies-dev-envs-dev-envs-learn), so it would be nice to have a VS Code environment for beginners to try Agda first. On the other hand, the VS Code extension is not as robust as the Agda mode for Emacs, so beginners could still feel frustrated.

Anyhow, they may choose to use Agda with Emacs locally if they Agda is interesting enough. After weighing the pros and cons above, I think it is worthwhile to mention Agda Web in the manual. 

### Misc

- [Agda Pad](https://agdapad.quasicoherent.io) is currently down. @iblech, is this still maintained?
