### PR TITLE
Fix #8725 by computing correct parentModule when inducing copying record type

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -488,13 +488,42 @@ applySection new ptel old ts info@ScopeCopyInfo{ renModules = rm, renNames = rd 
             --   mkD` which we did before).
             Map.singleton x . pure . qualify m <$> freshName_ (prettyShow $ qnameName x)
 
+        -- @parentModule x y p@:
+        -- Where to put the copy of the data/record type @p@ of the
+        -- constructor or projection @x@, given that @x@ is copied to @y@?
+        --
+        -- The type @p@ lives in an ancestor module of the module of its
+        -- child @x@, but how many levels up depends on the kind of child:
+        --
+        -- 1. A data type and its constructors live in the same module
+        --    (0 levels up).
+        --
+        -- 2. A record lives one level above its projections, which live in
+        --    the record module (1 level up).
+        --
+        -- 3. A record with a user-written constructor lives in the same module
+        --    as that constructor (0 levels up, issue #4189), but the /generated/
+        --    constructor of a record without a constructor declaration lives in
+        --    the record module (1 level up, see 'ConcreteToAbstract.recordConName').
+        --
+        -- So rather than hardwiring the number of levels, we read it off the
+        -- original names @x@ and @p@ and reproduce it for the copies (#8725).
+        -- Getting this wrong lands the copy of @p@ in a record module, whose
+        -- telescope has one parameter too many (the record value), which then
+        -- crashes the next module application that copies @p@ again.
+        parentModule :: QName -> QName -> QName -> ModuleName
+        parentModule x y p = mnameFromList $ dropEnd (sanitize levels) ys
+          where
+            qual     = mnameToList . qnameModule
+            ys       = qual y
+            levels   = length (qual x) - length (qual p)
+            -- optional: force argument of @(`dropEnd` ys`)@ into range @0..length ys@
+            sanitize = max 0 . min (length ys)
+
         childToParent :: (QName, List1 QName) -> TCM (Maybe (ModuleName, QName))
         childToParent (x, y :| _) = do
           theDef <$> getConstInfo x <&> \case
-            -- the constructors and the data type live in the same
-            -- module, so it suffices to use the same module name that
-            -- the constructor ended up in for the data type
-            Constructor{ conData = d } -> Just (qnameModule y, d)
+            Constructor{ conData = d } -> Just (parentModule x y d, d)
 
             -- If a proper projection is being copied, its record needs to be
             -- copied too (#8037).
@@ -502,16 +531,7 @@ applySection new ptel old ts info@ScopeCopyInfo{ renModules = rm, renNames = rd 
             -- #8242: copying a proper projection M.R.proj → N.R.proj does not
             -- mean we should copy the record type M.R to N.R.R!
             def | Just Projection{ projProper = Just r } <- isProjection_ def ->
-              let
-                -- putting the record in the parent of where the
-                -- projection ended up seems robust. i don't think it's
-                -- possible for a copied proper projection to end up
-                -- nested relative to the correct place to put the
-                -- record.
-                parent = case initLast (mnameToList (qnameModule y)) of
-                  Just (mod, _) -> mnameFromList mod
-                  Nothing       -> __IMPOSSIBLE__
-              in Just (mnameFromList (init (mnameToList (qnameModule y))), r)
+              Just (parentModule x y r, r)
 
             _ -> Nothing
 
@@ -520,9 +540,13 @@ applySection new ptel old ts info@ScopeCopyInfo{ renModules = rm, renNames = rd 
           (theDef <$> getConstInfo x) <&> \case
             Datatype{ dataCons = cs } -> map (qnameModule y,) cs
 
-            -- note about the module here: the record constructor lives
-            -- outside the record module, in the same module as the
-            -- record.
+            -- note about the module here: a user-written record constructor
+            -- lives outside the record module, in the same module as the
+            -- record (#4189), so we put its copy next to the copy of the
+            -- record.  A generated constructor lives in the record module, but
+            -- putting its copy next to the record copy is fine as well: what
+            -- matters is that 'parentModule' above recovers the relative
+            -- position from the copies rather than assuming a fixed one.
             --
             -- in debugging output, if the record being copied has a
             -- generated constructor name, it's going to look like we

--- a/test/Succeed/Issue8725.agda
+++ b/test/Succeed/Issue8725.agda
@@ -1,0 +1,40 @@
+-- Andreas, 2026-09-03, issue #8725, found in the agda-categories library.
+--
+-- When a module application copies a proper projection or a constructor,
+-- the respective record/data type has to be copied as well (see #8037).
+-- The copy of the type has to be placed in the correct module: a record
+-- type lives one level above its projections (which live in the record
+-- module), whereas a data type lives in the same module as its constructors.
+--
+-- The generated constructor of a record without a constructor declaration
+-- lives in the record module, so it must not be used to place the copy of
+-- the record type in the same module: otherwise the copy of the record type
+-- ends up inside a record module, whose telescope has one parameter too many
+-- (the record value).  The next module application copying this record type
+-- then crashed with an internal error in 'piApply'.
+
+module Issue8725 where
+
+postulate A : Set
+
+module M (X : Set) where
+
+  record R : Set where
+    field f : X
+
+-- Export only the record module R, not the record type R.
+-- Thus, the copy of the record type below has to be invented by Agda.
+
+module Core where
+  open M A public using (module R)
+
+module C = Core
+
+postulate r : M.R A
+
+-- This module application crashed.
+
+module r = C.R r
+
+test : A
+test = r.f


### PR DESCRIPTION
PR #8681 reintroduced this internal error (introduced by PR #8210,
fixed by PR #8242) when refactoring the anonymous record constructor
feature.

Issue shrunk and fixed by Claude followed by some manual polishing.

Closes #8725.

<details>
<summary>Claude interaction</summary>

Prompt 1
========

I am getting this internal error.
```
$ agda -l agda-categories -i test/Succeed test/Succeed/Issue8725.agda

Checking Issue8725 (/Users/abela/agda/test/Succeed/Issue8725.agda).
piApply t = Set (lub @6 @5)
  args = [Issue8725._.unit-insert {@7} {@6} {@5} {@4} {@3} @2 {@1} {@0}]
An internal error has occurred. Please report this as a bug.
Location of the error: __IMPOSSIBLE__, called at src/full/Agda/TypeChecking/Substitute.hs:643:81
```
Please shrink `test/Succeed/Issue8725.agda` so it does not rely on external libraries but still produces the same internal error.
You find the source of the `agda-categories` library under `ecosystem/agda-categories`.

Also analyse and fix the bug.

Answer 1
========

Done. Summary:

The bug
-------

`applySection`'s `closeConstructors` (`src/full/Agda/TypeChecking/Monad/Signature.hs`) invents a copy of a data/record type when one of its constructors or projections is copied (#8037). It decided *which module* to put that copy in by hardwiring the relative nesting:

- constructor → same module as the constructor (`qnameModule y`)
- projection → parent of the projection's module (`init …`)

But a record *without* a constructor declaration gets a generated constructor that lives **inside the record module** (`ConcreteToAbstract`, `withCurrentModule m $ freshAbstractQName … "constructor"`), not next to the record like a user-written one (#4189). So for such records the constructor branch put the copy of the record type inside a *record module*, whose section telescope has one parameter too many (the record value itself).

In the agda-categories case this produced `....Core._≅_._≅_` — the record `_≅_` sitting in the record module `....Core._≅_` (9 params) while its type only has 8 `Pi`s. The next module application (`module unit-insert = _≅_ unit-insert`) computed `np = 9` from the section and did `defType d \`piApply\` ts'`, running off the end of the telescope → `__IMPOSSIBLE__` at `Substitute.hs:643`.

The fix
-------

Replaced the hardwired nesting with a `parentModule` helper that reads the relative nesting off the *original* names `x` (child) and `p` (parent) and reproduces it for the copies. This yields 0 levels for data constructors and named record constructors, 1 level for projections and generated record constructors, and stays self-consistent across chains of copies. Also dropped the dead `parent` binding in the projection branch and corrected the now-inaccurate comment in `parentToChild`.

</details>
