### PR TITLE
Fix #8532 by adding a missing `reduceDefCopies` in `getDefType`.

### DIFF
--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -300,6 +300,8 @@ origProjection f = do
 --   @t@ is not a data/record/axiom type.
 --
 --   Precondition: @t@ is reduced.
+--   Copies stemming from module applications are unfolded here in addition,
+--   since reduction may leave them in place (see issue #8532).
 --
 --   See also: 'Agda.TypeChecking.Datatypes.getConType'
 getDefType :: PureTCM m => QName -> Type -> m (Maybe Type)
@@ -326,7 +328,16 @@ getDefType f t = do
                 | otherwise = n - 1
       reportSLn "tc.deftype" 20 $ "projIndex    = " ++ show n
       -- we get the parameters from type @t@
-      instantiate (unEl t) >>= \case
+      -- Andreas, 2026-09-03, issue #8532:
+      -- Even a reduced @t@ can be headed by a copy stemming from a module
+      -- application, e.g. @N.D us@ for @module N = M vs@ with @D@ declared in @M@.
+      -- Such a copy is @eligibleForProjectionLike@, but its arguments @us@ are
+      -- /not/ the parameters of the original @D@ (they include the parameters of
+      -- the module @N@ lives in), so taking them would produce garbage parameters.
+      -- Thus, unfold copy indirections first; this is cheap.
+      -- (Same treatment as in 'Agda.TypeChecking.ProjectionLike.candidateArgs',
+      -- see issue #8686.)
+      instantiate (unEl t) >>= reduceDefCopies >>= \case
         Def d es -> do
           -- Andreas, 2013-10-22
           -- we need to check this @Def@ is fully reduced.

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -877,7 +877,7 @@ reduceDefCopy f es = do
 
 -- | Recursively apply 'reduceDefCopy' so remove all copy-indirections
 -- but otherwise do not reduce the term.
-reduceDefCopies :: Term -> TCM Term
+reduceDefCopies :: PureTCM m => Term -> m Term
 reduceDefCopies v = do
   r <- case v of
     Def f es -> reduceDefCopy f es

--- a/test/Succeed/Issue8532.agda
+++ b/test/Succeed/Issue8532.agda
@@ -1,0 +1,50 @@
+-- Andreas, 2026-09-03, issue #8532, reported by WhatisRT,
+-- minimized by szumixie.
+--
+-- The projection @M.G.β@ was applied to a value whose type was headed by
+-- @H._.G@, a copy of @M.G@ stemming from the module application @open M ℕ@.
+-- Taking the "parameters" of the projection from the arguments of the copy
+-- produced the ill-typed type @F.X x@ (with @x : H ℕ@ a record value),
+-- which crashed the (fast) reduction machinery.
+--
+-- The unsolved metas are not essential to the issue,
+-- they just could not be avoided when minimizing it.
+
+{-# OPTIONS --allow-unsolved-metas #-}
+
+module Issue8532 where
+
+open import Agda.Builtin.Equality
+
+postulate
+  ℕ : Set
+
+record F : Set₁ where
+  field
+    X : Set
+
+postulate
+  fun : (P : Set) → P
+  xx : F
+
+module M (_ : Set) where
+  record G (m : F) : Set where
+    field
+      α : (i : ℕ) → _ → ℕ
+      β : F.X m → ℕ
+
+record H (_ : Set) : Set where
+  open M ℕ
+
+  f : ℕ → ℕ
+  f _ = G.α (fun (G xx)) (G.β (fun (G xx)) _) _
+
+x : H ℕ
+x = record {}
+
+pf : H.f x _ ≡ H.f x _
+pf = refl
+
+-- WAS: internal error in Agda.TypeChecking.Reduce.Fast (fast reduction)
+-- resp. Agda.TypeChecking.Substitute (@conApp@, ordinary reduction).
+-- Should succeed (modulo unsolved metas).

--- a/test/Succeed/Issue8532NoFast.agda
+++ b/test/Succeed/Issue8532NoFast.agda
@@ -1,0 +1,53 @@
+-- Andreas, 2026-09-03, issue #8532, reported by WhatisRT,
+-- minimized by szumixie.
+--
+-- Variant of Issue8532.agda that exercises the ordinary reduction machinery.
+--
+-- The projection @M.G.β@ was applied to a value whose type was headed by
+-- @H._.G@, a copy of @M.G@ stemming from the module application @open M ℕ@.
+-- Taking the "parameters" of the projection from the arguments of the copy
+-- produced the ill-typed type @F.X x@ (with @x : H ℕ@ a record value),
+-- which crashed the (fast) reduction machinery.
+--
+-- The unsolved metas are not essential to the issue,
+-- they just could not be avoided when minimizing it.
+
+{-# OPTIONS --allow-unsolved-metas #-}
+{-# OPTIONS --no-fast-reduce #-}
+
+module Issue8532NoFast where
+
+open import Agda.Builtin.Equality
+
+postulate
+  ℕ : Set
+
+record F : Set₁ where
+  field
+    X : Set
+
+postulate
+  fun : (P : Set) → P
+  xx : F
+
+module M (_ : Set) where
+  record G (m : F) : Set where
+    field
+      α : (i : ℕ) → _ → ℕ
+      β : F.X m → ℕ
+
+record H (_ : Set) : Set where
+  open M ℕ
+
+  f : ℕ → ℕ
+  f _ = G.α (fun (G xx)) (G.β (fun (G xx)) _) _
+
+x : H ℕ
+x = record {}
+
+pf : H.f x _ ≡ H.f x _
+pf = refl
+
+-- WAS: internal error in Agda.TypeChecking.Reduce.Fast (fast reduction)
+-- resp. Agda.TypeChecking.Substitute (@conApp@, ordinary reduction).
+-- Should succeed (modulo unsolved metas).

--- a/test/Succeed/Issue8532Shrunk.agda
+++ b/test/Succeed/Issue8532Shrunk.agda
@@ -1,0 +1,48 @@
+-- Andreas, 2026-09-03, issue #8532.
+-- Further shrunk by Claude, but with essential idea from Szumi Xie.
+--
+-- Essential ingredients:
+--   * a parameterized module M containing a parameterized record G,
+--   * a module application (here: @open M ℕ@) inside a *parameterized*
+--     record H, creating a copy @H._.G@ of @G@ whose leading arguments
+--     are the parameters of H rather than those of G,
+--   * a projection (@β@) whose type mentions G's parameter @m@,
+--   * a record value (@record {}@) instantiating H's record variable.
+--
+-- The unsolved metas are not essential to the issue.
+
+{-# OPTIONS --allow-unsolved-metas #-}
+
+module Issue8532Shrunk where
+
+open import Agda.Builtin.Equality
+
+postulate ℕ : Set
+
+record F : Set₁ where
+  field X : Set
+
+postulate xx : F
+
+module M (_ : Set) where
+  record G (m : F) : Set where
+    field
+      α : (i : ℕ) → _ → ℕ
+      β : F.X m → ℕ
+
+record H (_ : Set) : Set where
+  open M ℕ
+  postulate g : G xx
+
+  f : ℕ → ℕ
+  f _ = G.α g (G.β g _) _
+
+x : H ℕ
+x = record {}
+
+pf : H.f x _ ≡ H.f x _
+pf = refl
+
+-- WAS: internal error in Agda.TypeChecking.Reduce.Fast,
+-- because @G.β g@ was assigned the ill-typed type @F.X x → ℕ@.
+-- Should succeed (modulo unsolved metas).


### PR DESCRIPTION
Claude found the needle in the haystack.

Closes #8532.

<details>
<summary>Claude's analysis and fix description (slightly abbreviated)</summary>

Root cause
----------

`getDefType f t` (`src/full/Agda/TypeChecking/Records.hs:307`) reconstructs a projection's *parameters* from the head of its principal argument's type: for `t = Def d es` it takes `take npars es`, guarding only with `eligibleForProjectionLike d` (data/record/axiom heads).

A **module-application copy** passes that guard but is not the original. In the reproducer, `open M ℕ` inside `record H (_ : Set)` creates the copy `H._.G`, whose leading arguments are `H`'s module parameters, not `M.G`'s. So

```
getDefType M.G.β (H._.G {ℕ} x xx)
```

took `[ℕ, x]` as `(A, m)` instead of `[ℕ, xx]`, giving `β` the ill-typed type `F.X x → ℕ` where `x : H ℕ` is a record value. Reducing `F.X (record {})` then hit `__IMPOSSIBLE__` — in `Reduce/Fast.hs:1041` under fast reduction, in `Substitute.hs:156` (`conApp`, with the `projected by F.X` trace) otherwise.

Fix
---

`src/full/Agda/TypeChecking/Records.hs` — unfold copy indirections before extracting parameters:

```haskell
(reduceDefCopies =<< instantiate (unEl t)) >>= \case
```

This mirrors the existing fix for issue #8686 in `ProjectionLike.candidateArgs`, which unfolds copies for the same reason ("this is the only way heads that are `eligibleForProjectionLike` can reduce").

Tests
-----

`--allow-unsolved-metas`: The metas are genuinely unsolvable, as the reporter notes.

`test/Succeed/Issue8532Shrunk.agda`: shrunk by replacing `fun : (P : Set) → P` and its two applications with a `postulate g : G xx` inside `H`.

I probed further shrinks that all stop reproducing (pre-fix), and documented the essential ingredients in the test header: dropping `M`'s parameter, `H`'s parameter, the `α` field, `α`'s `(i : ℕ) →` argument, or replacing `record F`/`F.X` with a postulated `X : F → Set`, or postulating `x` instead of `x = record {}`.

</details>
