### PR TITLE
Fix #8532 by ensuring projectTyped gets a reduced type in antiUnify

### DIFF
--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -929,9 +929,11 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
         (arg:) <$> nameElims
           (if visible info then False else not forced)
           (acc `applyE` [elim]) (cod `lazyAbsApp` tm) as
-    nameElims _ tm ty (I.Proj o n:as) = projectTyped tm ty o n >>= \case
-      Nothing          -> mzero
-      Just (_, tm, ty) -> (I.Proj o n:) <$> nameElims False tm ty as
+    nameElims _ tm ty (I.Proj o n:as) = do
+      ty <- reduce ty
+      projectTyped tm ty o n >>= \case
+        Nothing          -> mzero
+        Just (_, tm, ty) -> (I.Proj o n:) <$> nameElims False tm ty as
 
     -- Andreas, 2016-07-06 Issue #2047
 

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -958,6 +958,10 @@ antiUnifyType pid (El s a) (El _ b) = workOnTypes $ El s <$> antiUnify pid (sort
 antiUnifyElims :: ProblemId -> Type -> Term -> Elims -> Elims -> TCM Term
 antiUnifyElims pid a self [] [] = return self
 antiUnifyElims pid a self (Proj o f : es1) (Proj _ g : es2) | f == g = do
+  -- Andreas, 2026-09-05, issue #8532, projectTyped expects reduced type @a@.
+  -- The reduce was already absent in the original feature commit a45f5ce (Agda 2.5.3).
+  -- The bug was dormant for almost a decade.
+  a <- reduce a
   res <- projectTyped self a o f
   case res of
     Just (_, self, a) -> antiUnifyElims pid a self es1 es2
@@ -1184,6 +1188,8 @@ compareElims !pols0 !fors0 !a !v !els01 !els02 =
     -- case: f == f' are projections
     (Proj o f : els1, Proj _ f' : els2)
       | f /= f'   -> do
+          -- Andreas, 2026-09-05, while working on #8532: projectTyped expects reduced type.
+          a <- reduce a
           -- Andreas, 2025-10-06, issue #8126
           -- If we are dealing with generalizable variables rather than projections,
           -- do not throw a MismatchedProjectionsError, but rather a generic f != f' error.

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -325,8 +325,9 @@ getDefType f t = do
       let npars | n == 0    = __IMPOSSIBLE__
                 | otherwise = n - 1
       reportSLn "tc.deftype" 20 $ "projIndex    = " ++ show n
-      -- we get the parameters from type @t@
-      instantiate (unEl t) >>= \case
+      -- Andreas, 2026-09-05: note that @t@ is reduced by precondition,
+      -- but its violation caused issue #8532.
+      case unEl t of
         Def d es -> do
           -- Andreas, 2013-10-22
           -- we need to check this @Def@ is fully reduced.
@@ -387,7 +388,7 @@ shouldBeProjectible v t o f = do
 projectTyped
   :: PureTCM m
   => Term        -- ^ Head (record value).
-  -> Type        -- ^ Its type.
+  -> Type        -- ^ Its type (reduced!).
   -> ProjOrigin
   -> QName       -- ^ Projection.
   -> m (Maybe (Dom Type, Term, Type))

--- a/test/Succeed/Issue8532.agda
+++ b/test/Succeed/Issue8532.agda
@@ -1,0 +1,54 @@
+-- Andreas, 2026-09-03, issue #8532, reported by WhatisRT,
+-- minimized by szumixie.
+--
+-- Cause: Missing reduce in anti-unification.
+--
+-- Claude's analysis:
+-- The projection @M.G.β@ was applied to a value whose type was headed by
+-- @H._.G@, a copy of @M.G@ stemming from the module application @open M ℕ@.
+-- Taking the "parameters" of the projection from the arguments of the copy
+-- produced the ill-typed type @F.X x@ (with @x : H ℕ@ a record value),
+-- which crashed the (fast) reduction machinery.
+--
+-- The unsolved metas are not essential to the issue,
+-- they just could not be avoided when minimizing it.
+
+{-# OPTIONS --allow-unsolved-metas #-}
+
+module Issue8532 where
+
+data _≡_ {a} {A : Set a} (x : A) : A → Set a where
+  refl : x ≡ x
+
+postulate
+  ℕ : Set
+
+record F : Set₁ where
+  field
+    X : Set
+
+postulate
+  fun : (P : Set) → P
+  xx : F
+
+module M (_ : Set) where
+  record G (m : F) : Set where
+    field
+      α : (i : ℕ) → _ → ℕ
+      β : F.X m → ℕ
+
+record H (_ : Set) : Set where
+  open M ℕ
+
+  f : ℕ → ℕ
+  f _ = G.α (fun (G xx)) (G.β (fun (G xx)) _) _
+
+x : H ℕ
+x = record {}
+
+pf : H.f x _ ≡ H.f x _
+pf = refl
+
+-- WAS: internal error in Agda.TypeChecking.Reduce.Fast (fast reduction)
+-- resp. Agda.TypeChecking.Substitute (@conApp@, ordinary reduction).
+-- Should succeed (modulo unsolved metas).


### PR DESCRIPTION
The issue was caused by a missing `reduce` in `antiUnifyELims` (a45f5ce064b97a590a090a4921d92906ab34a461).

AI disclosure: Claude was helpful to point to the cause, but it did not point to the prime cause.  Bisection was helpful, but the true understanding came by checking whether the precondition of a reduced type was always respected in calls to @getDefType@.

I could remove a call to `instantiate` in `getDefType` that Amy introduced in a8ebbe5 (PR #8315) probably fighting a symptom (wrong error message for #8126) rather than finding the cause (missing `reduce`).
Claude's previous fix (PR #8727) of #8532 was along the same line (more reduction in `getDefType` rather than restoring the invariant).

Closes #8532.
