### PR TITLE
Fix issue 8336 by turning projection-like functions back into Defs

### DIFF
--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -39,6 +39,7 @@ import Agda.Utils.Size
 import Agda.Utils.Impossible
 
 import Agda.Interaction.Options
+import Agda.TypeChecking.Reduce (instantiate)
 
 -- * Bidirectional rechecker
 
@@ -346,6 +347,12 @@ checkSpine action a hd es cmp t = do
     , prettyTCM t'
     , "is a subtype of"
     , prettyTCM t
+    ]
+  reportSDoc "tc.check.internal" 70 $ sep
+    [ "checking if (raw)"
+    , pretty =<< instantiate t'
+    , "is a subtype of (raw)"
+    , pretty =<< instantiate t
     ]
   coerceSize cmp (hd es) t' t
   return $ hd es'

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -324,7 +324,12 @@ inferSpine action t hd es = loop t hd id es
         -- case: projection or projection-like
         Proj o f -> do
           t' <- shouldBeProjectible self t o f
-          loop t' (hd . (e:)) (acc . (e:)) es
+          -- Jesper, issue #8336: turn projection-like functions back into Defs
+          proj <- fromMaybe __IMPOSSIBLE__ <$> isProjection f
+          let hd' = if isProperProjection_ proj
+                    then hd . (e:)
+                    else Def f . (Apply (projFromType proj $> hd []) :)
+          loop t' hd' (acc . (e:)) es
 
 checkSpine ::
      Action

--- a/test/Succeed/Issue8336.agda
+++ b/test/Succeed/Issue8336.agda
@@ -1,0 +1,34 @@
+{-# OPTIONS --double-check #-}     -- on by default in the testsuite
+{-# OPTIONS --projection-like #-}  -- on by default
+
+module Issue8336 where
+
+data _≡_ {A : Set} (x : A) : A → Set where
+  refl : x ≡ x
+
+concat : {A : Set} → {x y z : A} → x ≡ y → y ≡ z → x ≡ z
+concat refl refl = refl
+
+data Σ (A : Set) (B : A → Set) : Set where
+  _,_ : (x : A) → B x → Σ A B
+
+-- proj₁ and proj₂ are projection-_like_ functions on a _data_ type.
+
+proj₁ : {A : Set} → {B : A → Set} → Σ A B → A
+proj₁ (x , y) = x
+
+proj₂ : {A : Set} → {B : A → Set} → (z : Σ A B) → B (proj₁ z)
+proj₂ (x , y) = y
+
+_×_ : Set → Set → Set
+A × B = Σ A (λ _ → B)
+
+S : Set → Set
+S A = Σ (A → A) (λ f → (x : A) → f x ≡ x)
+
+p : {X : Set} → (u : X → X) → ((x : X) → u x ≡ x) → (S X → S X) × (S X → S X)
+p u hu = (λ z → (λ x → u (proj₁ z x)) , (λ x → concat (hu (proj₁ z x)) (proj₂ z x))) , (λ z → z)
+
+goal : {X : Set} → (u : X → X) → (hu : (x : X) → u x ≡ x) → (s : S X) → (x : X)
+  → proj₂ (proj₁ (p u hu) s) x ≡ proj₂ (proj₁ (p u hu) s) x
+goal u hu s x = concat refl refl


### PR DESCRIPTION
This is my alternative to the fix in https://github.com/agda/agda/pull/8717. The `loop` helper function for `inferSpine` returns two arguments: the current head value and the eliminations. Of these, only the eliminations should be subject to the supplied transformation, while the first one is used for type checking so needs to be a valid term. This is already *almost* the case in the current implementation, except that projection-like functions are transformed into `Proj`s which (as the issue demonstrates) are not considered properly by the evaluator. So either we should support projection-like functions in `Proj` form everywhere (see https://github.com/agda/agda/issues/8487), or we should just turn these `Proj`s back into `Def`s once they have been checked. This PR implements the latter approach.

Either way, there is no need to revert back to the old situation where we produce two outputs in every part of `checkInternal` as in #8717.